### PR TITLE
Scope templates/ ignore rule to the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ runtime-ports.md
 .docker-compose.verify.yml
 .runtime-port-map.csv
 pipeline-run-report.md
-templates/
+/templates/
 RUN-DOCKER-SINGLE.md
 
 # Internal tooling — not part of the CVE collection itself


### PR DESCRIPTION
The bare `templates/` rule matched package content — e.g. CVE-2026-54159's vendored `ps_facetedsearch/views/templates/` (46 files: Smarty templates + index.php guards) — and would silently drop them from a staged package on `git add`, publishing a module missing its front-office rendering path. Found by the pipeline's QA review + ignored-files gate.\n\nThe rule's intent is pipeline-internal files at the repo root (`.docker-compose.verify.yml`, `pipeline-run-report.md` neighbors); anchoring to `/templates/` preserves that and unblocks packages.