### PR TITLE
Fix CVE-2026-58154 lab: generate the TLS certificate at build time

### DIFF
--- a/CVE-2026-58154/Dockerfile.patched
+++ b/CVE-2026-58154/Dockerfile.patched
@@ -54,7 +54,8 @@ RUN openssl req -x509 -newkey rsa:2048 -nodes -days 3650 -subj "/CN=ats" \
       -keyout /opt/ats/etc/trafficserver/ats.key \
       -out /opt/ats/etc/trafficserver/ats.crt \
     && chmod 0644 /opt/ats/etc/trafficserver/ats.crt \
-                  /opt/ats/etc/trafficserver/ats.key
+    && chmod 0640 /opt/ats/etc/trafficserver/ats.key \
+    && chown nobody:nogroup /opt/ats/etc/trafficserver/ats.key
 
 # ASan: abort on first error so the container exits with SIGABRT evidence;
 # no leak checking (noise on normal exit); symbolize via installed llvm.

--- a/CVE-2026-58154/Dockerfile.patched
+++ b/CVE-2026-58154/Dockerfile.patched
@@ -36,7 +36,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
       libasan6 libssl3 libpcre3 libpcre2-8-0 zlib1g libfmt8 libbrotli1 \
       libcap2 libncurses6 libunwind8 \
-      curl python3 gdb binutils llvm checksec ca-certificates \
+      curl python3 gdb binutils llvm checksec ca-certificates openssl \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /opt/ats /opt/ats
 
@@ -44,6 +44,17 @@ COPY --from=builder /opt/ats /opt/ats
 # privileges (starts as root, setuid nobody per proxy.config.admin.user_id).
 RUN mkdir -p /opt/ats/var/log/trafficserver /opt/ats/var/trafficserver \
     && chmod -R a+rwX /opt/ats/var
+
+# Self-signed cert for the TLS/HTTP-2 listener. Generated at build time so the
+# lab is self-contained: assets/ats.crt and assets/ats.key were never committed,
+# and bind-mounting the missing paths made Docker create directories, which ATS
+# refused to load. Any throwaway cert works here — the PoC disables verification
+# by design (see assets/regen-cert.sh). ssl_multicert.config names these files.
+RUN openssl req -x509 -newkey rsa:2048 -nodes -days 3650 -subj "/CN=ats" \
+      -keyout /opt/ats/etc/trafficserver/ats.key \
+      -out /opt/ats/etc/trafficserver/ats.crt \
+    && chmod 0644 /opt/ats/etc/trafficserver/ats.crt \
+                  /opt/ats/etc/trafficserver/ats.key
 
 # ASan: abort on first error so the container exits with SIGABRT evidence;
 # no leak checking (noise on normal exit); symbolize via installed llvm.

--- a/CVE-2026-58154/Dockerfile.vulnerable
+++ b/CVE-2026-58154/Dockerfile.vulnerable
@@ -54,7 +54,8 @@ RUN openssl req -x509 -newkey rsa:2048 -nodes -days 3650 -subj "/CN=ats" \
       -keyout /opt/ats/etc/trafficserver/ats.key \
       -out /opt/ats/etc/trafficserver/ats.crt \
     && chmod 0644 /opt/ats/etc/trafficserver/ats.crt \
-                  /opt/ats/etc/trafficserver/ats.key
+    && chmod 0640 /opt/ats/etc/trafficserver/ats.key \
+    && chown nobody:nogroup /opt/ats/etc/trafficserver/ats.key
 
 # ASan: abort on first error so the container exits with SIGABRT evidence;
 # no leak checking (noise on normal exit); symbolize via installed llvm.

--- a/CVE-2026-58154/Dockerfile.vulnerable
+++ b/CVE-2026-58154/Dockerfile.vulnerable
@@ -36,7 +36,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
       libasan6 libssl3 libpcre3 libpcre2-8-0 zlib1g libfmt8 libbrotli1 \
       libcap2 libncurses6 libunwind8 \
-      curl python3 gdb binutils llvm checksec ca-certificates \
+      curl python3 gdb binutils llvm checksec ca-certificates openssl \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /opt/ats /opt/ats
 
@@ -44,6 +44,17 @@ COPY --from=builder /opt/ats /opt/ats
 # privileges (starts as root, setuid nobody per proxy.config.admin.user_id).
 RUN mkdir -p /opt/ats/var/log/trafficserver /opt/ats/var/trafficserver \
     && chmod -R a+rwX /opt/ats/var
+
+# Self-signed cert for the TLS/HTTP-2 listener. Generated at build time so the
+# lab is self-contained: assets/ats.crt and assets/ats.key were never committed,
+# and bind-mounting the missing paths made Docker create directories, which ATS
+# refused to load. Any throwaway cert works here — the PoC disables verification
+# by design (see assets/regen-cert.sh). ssl_multicert.config names these files.
+RUN openssl req -x509 -newkey rsa:2048 -nodes -days 3650 -subj "/CN=ats" \
+      -keyout /opt/ats/etc/trafficserver/ats.key \
+      -out /opt/ats/etc/trafficserver/ats.crt \
+    && chmod 0644 /opt/ats/etc/trafficserver/ats.crt \
+                  /opt/ats/etc/trafficserver/ats.key
 
 # ASan: abort on first error so the container exits with SIGABRT evidence;
 # no leak checking (noise on normal exit); symbolize via installed llvm.

--- a/CVE-2026-58154/docker-compose.yml
+++ b/CVE-2026-58154/docker-compose.yml
@@ -1,6 +1,8 @@
 # CVE-2026-58154 publish lab: ATS 10.1.3 (vulnerable) reverse-proxying to an
 # internal origin, with an optional patched control (10.1.4) service.
-# Prereq: ./assets/regen-cert.sh  (creates the self-signed ats.crt/ats.key)
+# The self-signed ats.crt/ats.key are generated during the image build,
+# so no prerequisite step is needed. Use assets/regen-cert.sh only if you
+# want to replace the cert on the host for local experimentation.
 # Ports: vulnerable 18080 (H1) / 18443 (TLS H2); control 18081 / 18444.
 services:
   web:
@@ -16,8 +18,6 @@ services:
       - ./assets/remap.config:/opt/ats/etc/trafficserver/remap.config:ro
       - ./assets/storage.config:/opt/ats/etc/trafficserver/storage.config:ro
       - ./assets/ssl_multicert.config:/opt/ats/etc/trafficserver/ssl_multicert.config:ro
-      - ./assets/ats.crt:/opt/ats/etc/trafficserver/ats.crt:ro
-      - ./assets/ats.key:/opt/ats/etc/trafficserver/ats.key:ro
     depends_on:
       origin:
         condition: service_healthy
@@ -41,8 +41,6 @@ services:
       - ./assets/remap.config:/opt/ats/etc/trafficserver/remap.config:ro
       - ./assets/storage.config:/opt/ats/etc/trafficserver/storage.config:ro
       - ./assets/ssl_multicert.config:/opt/ats/etc/trafficserver/ssl_multicert.config:ro
-      - ./assets/ats.crt:/opt/ats/etc/trafficserver/ats.crt:ro
-      - ./assets/ats.key:/opt/ats/etc/trafficserver/ats.key:ro
     depends_on:
       origin:
         condition: service_healthy


### PR DESCRIPTION
**Symptom:** `docker compose up` fails; Apache Traffic Server aborts with `Emergency: failed to load SSL certificate file, /opt/ats/etc/trafficserver/ssl_multicert.config`.

**Root cause:** `assets/ats.crt` and `assets/ats.key` were never committed (`git ls-files` lists every other asset but not those two). The compose file bind-mounts them, and Docker creates a missing bind-mount source as an empty *directory*, so ATS tried to load a directory as a certificate. The compose header documented `./assets/regen-cert.sh` as a prerequisite, but nothing ran it, so the lab could not start for anyone who cloned the repo.

**Fix:** generate the throwaway self-signed cert during the image build and drop the two bind mounts. No private key is committed. `regen-cert.sh` itself notes that any throwaway cert works because the PoC disables verification by design, so the TLS/H2 path under test is unaffected.

Verified by building the lab and bringing it up: it now reports healthy. No PoC logic or vulnerability mechanics were changed.