### PR TITLE
Fix CVE-2026-62242 lab: build from Dockerfile.vulnerable / Dockerfile.patched

### DIFF
--- a/CVE-2026-62242/docker-compose.control.yml
+++ b/CVE-2026-62242/docker-compose.control.yml
@@ -2,7 +2,7 @@ services:
   web:
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.patched
       args:
         SBA_VERSION: "4.1.2"
     image: cve-2026-62242-web:control

--- a/CVE-2026-62242/docker-compose.yml
+++ b/CVE-2026-62242/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   web:
     build:
       context: .
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.vulnerable
       args:
         SBA_VERSION: "4.1.1"
     image: cve-2026-62242-web:local


### PR DESCRIPTION
**Symptom:** build fails with `failed to read dockerfile: open Dockerfile: no such file or directory`. The lab cannot be built at all.

**Root cause:** both compose files declare `dockerfile: Dockerfile`, but the directory ships only `Dockerfile.vulnerable` and `Dockerfile.patched`.

**Fix:** point each compose file at the right Dockerfile. The mapping is unambiguous: the build args match the ARG defaults (`SBA_VERSION` 4.1.1 -> vulnerable, 4.1.2 -> patched).

Verified by building the lab and bringing it up: it now reports healthy. No PoC logic or vulnerability mechanics were changed.