### PR TITLE
Fix CVE-2026-66713 lab: build from Dockerfile.vulnerable / Dockerfile.patched

### DIFF
--- a/CVE-2026-66713/docker-compose.control.yml
+++ b/CVE-2026-66713/docker-compose.control.yml
@@ -1,6 +1,8 @@
 services:
   web:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile.patched
     image: cve-2026-66713-control-web:local
     ports:
       - "${WEB_PORT}:8080"

--- a/CVE-2026-66713/docker-compose.yml
+++ b/CVE-2026-66713/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   web:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile.vulnerable
     image: cve-2026-66713-web:local
     ports:
       - "${WEB_PORT}:8080"


### PR DESCRIPTION
**Symptom:** build fails with `failed to read dockerfile: open Dockerfile: no such file or directory`. The lab cannot be built at all.

**Root cause:** the `web` service uses `build: .`, which defaults to a file named `Dockerfile`. The directory ships `Dockerfile.vulnerable`, `Dockerfile.patched` and `callback.Dockerfile` — no plain `Dockerfile`.

**Fix:** give both compose files an explicit context and dockerfile.

Verified by building the lab and bringing it up: it now reports healthy. No PoC logic or vulnerability mechanics were changed.