### PR TITLE
Fix CVE-2026-63637 lab: probe dgraph zero's health endpoint

### DIFF
--- a/CVE-2026-63637/docker-compose.control.yml
+++ b/CVE-2026-63637/docker-compose.control.yml
@@ -3,7 +3,7 @@ services:
     image: dgraph/dgraph:v25.3.8
     command: dgraph zero --my=zero:5080
     healthcheck:
-      test: ["CMD-SHELL", "test -f /dgraph/zw/zw.dirlock || exit 1"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:6080/health || exit 1"]
       interval: 5s
       timeout: 3s
       retries: 20

--- a/CVE-2026-63637/docker-compose.yml
+++ b/CVE-2026-63637/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: dgraph/dgraph:v25.3.7
     command: dgraph zero --my=zero:5080
     healthcheck:
-      test: ["CMD-SHELL", "test -f /dgraph/zw/zw.dirlock || exit 1"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:6080/health || exit 1"]
       interval: 5s
       timeout: 3s
       retries: 20


### PR DESCRIPTION
**Symptom:** the `zero` service stays `unhealthy` while its log reports `Server is ready: OK`.

**Root cause:** the healthcheck runs `test -f /dgraph/zw/zw.dirlock`. On dgraph v25.3.7 no such file exists anywhere under `/dgraph` (`find /dgraph -name '*dirlock*'` returns nothing).

**Fix:** probe zero's own HTTP health endpoint instead. `curl` is present at `/usr/bin/curl` in the image and `curl -sf http://localhost:6080/health` returns OK.

Verified by building the lab and bringing it up: it now reports healthy. No PoC logic or vulnerability mechanics were changed.