### PR TITLE
Fix CVE-2026-2580 lab: make the healthcheck a liveness probe

### DIFF
--- a/CVE-2026-2580/docker-compose.yml
+++ b/CVE-2026-2580/docker-compose.yml
@@ -41,7 +41,10 @@ services:
     volumes:
       - wp_data:/var/www/html
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://localhost:80/wp-login.php | grep -q 'wp-login' || exit 1"]
+      # Liveness only: WordPress answers on wp-login.php (302 to
+      # install.php until wp-setup.sh has been run inside the container).
+      # Do not grep for page content here - the site ships uninstalled.
+      test: ["CMD-SHELL", "curl -fsS -o /dev/null http://localhost:80/wp-login.php || exit 1"]
       interval: 10s
       timeout: 10s
       retries: 30


### PR DESCRIPTION
**Symptom:** the `vulnerable` service never becomes healthy, though Apache and PHP are serving.

**Root cause:** the healthcheck greps `wp-login.php` for `wp-login`. The site ships uninstalled, so WordPress answers `302` to `/wp-admin/install.php`; the body is empty and the grep fails. `wp-setup.sh` installs the site but is never run and is not mentioned in the README.

**Fix:** check liveness only — that WordPress answers on `wp-login.php`. Installing the site with `wp-setup.sh` remains a separate, explicit step, and the healthcheck no longer depends on it.

Verified by building the lab and bringing it up: it now reports healthy. No PoC logic or vulnerability mechanics were changed.