### PR TITLE
Fix CVE-2024-56325 lab: drop the leaked cveforgev2_default network

### DIFF
--- a/CVE-2024-56325/README.md
+++ b/CVE-2024-56325/README.md
@@ -95,9 +95,9 @@ Container IPs are dynamically assigned. Retrieve them before running PoC scripts
 
 ```bash
 CONTROLLER_IP=$(docker inspect cve-2024-56325-controller \
-  | jq -r '.[0].NetworkSettings.Networks["cveforgev2_default"].IPAddress')
+  | jq -r '.[0].NetworkSettings.Networks["cve-2024-56325_lab-net"].IPAddress')
 BROKER_IP=$(docker inspect cve-2024-56325-broker \
-  | jq -r '.[0].NetworkSettings.Networks["cveforgev2_default"].IPAddress')
+  | jq -r '.[0].NetworkSettings.Networks["cve-2024-56325_lab-net"].IPAddress')
 echo "Controller: ${CONTROLLER_IP}:9000"
 echo "Broker:     ${BROKER_IP}:8099"
 ```

--- a/CVE-2024-56325/docker-compose.yml
+++ b/CVE-2024-56325/docker-compose.yml
@@ -32,7 +32,6 @@ services:
       start_period: 30s
     networks:
       - lab-net
-      - cveforgev2_default
 
   pinot-broker:
     build:
@@ -52,10 +51,7 @@ services:
       start_period: 30s
     networks:
       - lab-net
-      - cveforgev2_default
 
 networks:
   lab-net:
     driver: bridge
-  cveforgev2_default:
-    external: true


### PR DESCRIPTION
**Symptom:** `docker compose up` fails with `network cveforgev2_default declared as external, but could not be found`.

**Root cause:** `cveforgev2_default` is the build environment's own compose network, declared `external: true`. It exists on no user's machine. Other labs' `scrub_report.md` files mention the same string, so stripping these references was intended and this one was missed.

**Fix:** detach both services from it and remove the declaration. Every service already joins `lab-net`, so reachability between lab services is unchanged. The README's container-IP lookups referenced the same leaked name and now point at `lab-net`.

Verified by building the lab and bringing it up: it now reports healthy. No PoC logic or vulnerability mechanics were changed.