### PR TITLE
Fix CVE-2025-54466 lab: treat OFBiz 401 as alive

### DIFF
--- a/CVE-2025-54466/docker-compose.yml
+++ b/CVE-2025-54466/docker-compose.yml
@@ -21,7 +21,10 @@ services:
     environment:
       - OFBIZ_SKIP_INIT=true
     healthcheck:
-      test: ["CMD", "curl", "-fks", "https://localhost:8443/accounting/control/main"]
+      # Liveness only. OFBiz answers 401 on this path when unauthenticated,
+      # which is correct behaviour, but curl -f treats 401 as a failure
+      # (exit 22) so the lab never went healthy despite serving normally.
+      test: ["CMD", "curl", "-ks", "-o", "/dev/null", "https://localhost:8443/accounting/control/main"]
       interval: 15s
       timeout: 10s
       retries: 20


### PR DESCRIPTION
**Symptom:** the service stays `unhealthy` while OFBiz is serving normally (the log shows it rendering the login view and handling requests).

**Root cause:** the healthcheck uses `curl -fks` against `/accounting/control/main`. OFBiz correctly answers `401` to an unauthenticated request, and `curl -f` treats any status >= 400 as failure (exit 22), so the check could never pass.

**Fix:** drop `-f` so any HTTP response counts as alive. Verified in-container: the endpoint returns 401 and the server is up.

Verified by building the lab and bringing it up: it now reports healthy. No PoC logic or vulnerability mechanics were changed.