### PR TITLE
Fix CVE-2026-4105 lab: activate systemd-machined in the healthcheck

### DIFF
--- a/CVE-2026-4105/docker-compose.yml
+++ b/CVE-2026-4105/docker-compose.yml
@@ -20,7 +20,12 @@ services:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     stop_signal: SIGRTMIN+3
     healthcheck:
-      test: ["CMD", "busctl", "status", "org.freedesktop.machine1"]
+      # busctl status does not D-Bus-activate the unit, so it failed with
+      # "Failed to get credentials" while systemd-machined sat loaded but
+      # inactive (activatable). A Manager method call activates it and
+      # proves machine1 answers: ListMachines returns the .host registration
+      # this CVE concerns.
+      test: ["CMD", "busctl", "call", "org.freedesktop.machine1", "/org/freedesktop/machine1", "org.freedesktop.machine1.Manager", "ListMachines"]
       interval: 5s
       timeout: 10s
       retries: 12
@@ -45,7 +50,12 @@ services:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
     stop_signal: SIGRTMIN+3
     healthcheck:
-      test: ["CMD", "busctl", "status", "org.freedesktop.machine1"]
+      # busctl status does not D-Bus-activate the unit, so it failed with
+      # "Failed to get credentials" while systemd-machined sat loaded but
+      # inactive (activatable). A Manager method call activates it and
+      # proves machine1 answers: ListMachines returns the .host registration
+      # this CVE concerns.
+      test: ["CMD", "busctl", "call", "org.freedesktop.machine1", "/org/freedesktop/machine1", "org.freedesktop.machine1.Manager", "ListMachines"]
       interval: 5s
       timeout: 10s
       retries: 12


### PR DESCRIPTION
**Symptom:** both services stay `unhealthy`; the healthcheck fails with `Failed to get credentials: No such device or address`.

**Root cause:** `busctl status org.freedesktop.machine1` does not D-Bus-activate the unit. `systemd-machined.service` sits loaded but inactive and appears on the bus as `(activatable)`, so `busctl status` has nothing to query.

**Fix:** call a Manager method instead, which activates the service and proves it answers. Verified in-container: `ListMachines` activates machined and returns the `.host` registration this CVE concerns, after which the unit reports active.

Verified by building the lab and bringing it up: it now reports healthy. No PoC logic or vulnerability mechanics were changed.