### PR TITLE
Fix CVE-2026-0773 lab: pin opentelemetry-api below 1.37

### DIFF
--- a/CVE-2026-0773/Dockerfile.vulnerable
+++ b/CVE-2026-0773/Dockerfile.vulnerable
@@ -23,6 +23,12 @@ RUN git clone --depth 1 --branch v0.55.6 https://github.com/Upsonic/Upsonic.git 
 RUN pip install --no-cache-dir -e . 2>&1 || \
     pip install --no-cache-dir -e . --no-build-isolation 2>&1
 
+# Upsonic v0.55.6 leaves its dependencies unpinned. pydantic-ai imports
+# `opentelemetry._events`, an experimental module removed in
+# opentelemetry-api 1.37, so a fresh resolve (1.44+) breaks `import upsonic`.
+# Constrain just the telemetry API; the cloudpickle path under test is unaffected.
+RUN pip install --no-cache-dir "opentelemetry-api<1.37"
+
 # Install curl for healthcheck (already done above, but ensure it's there)
 # Verify the vulnerable code is present
 RUN python3 -c "import upsonic; print('Upsonic version:', upsonic.__version__ if hasattr(upsonic, '__version__') else 'installed')"


### PR DESCRIPTION
**Symptom:** build fails at the `import upsonic` verification step with `ModuleNotFoundError: No module named 'opentelemetry._events'`.

**Root cause:** Upsonic's source is pinned to tag v0.55.6 but its Python dependencies are not, so a fresh resolve installs opentelemetry-api 1.44. `pydantic-ai` does `from opentelemetry._events import Event`, and that experimental module was removed in opentelemetry-api 1.37.

**Fix:** constrain the telemetry API after the editable install. Verified in a clean `python:3.12-slim` container: with 1.44 the import fails; with `opentelemetry-api<1.37` (resolves 1.36.0) `_events` is present and `pydantic_ai.messages` imports. The `cloudpickle.loads()` path this lab demonstrates is untouched.

Verified by building the lab and bringing it up: it now reports healthy. No PoC logic or vulnerability mechanics were changed.