### PR TITLE
Fix CVE-2025-66489 lab: skip the workspace rebuild on yarn add sharp

### DIFF
--- a/CVE-2025-66489/Dockerfile.vulnerable
+++ b/CVE-2025-66489/Dockerfile.vulnerable
@@ -92,8 +92,6 @@ WORKDIR /calcom
 COPY --from=builder-two /calcom ./
 
 # Reinstall sharp for the target platform (builder compiled for BUILDPLATFORM)
-# Surface the inner workspace build log so a postinstall failure is
-# diagnosable rather than hidden inside /tmp/xfs-*/build.log.
 # --mode=skip-build: plain `yarn add` reruns the workspace post-install via
 # turbo, and @calcom/platform-types then fails to compile with TS2307
 # (@nestjs/common absent in the runner stage), so the image could not be

--- a/CVE-2025-66489/Dockerfile.vulnerable
+++ b/CVE-2025-66489/Dockerfile.vulnerable
@@ -92,7 +92,14 @@ WORKDIR /calcom
 COPY --from=builder-two /calcom ./
 
 # Reinstall sharp for the target platform (builder compiled for BUILDPLATFORM)
-RUN yarn add sharp
+# Surface the inner workspace build log so a postinstall failure is
+# diagnosable rather than hidden inside /tmp/xfs-*/build.log.
+# --mode=skip-build: plain `yarn add` reruns the workspace post-install via
+# turbo, and @calcom/platform-types then fails to compile with TS2307
+# (@nestjs/common absent in the runner stage), so the image could not be
+# built at all. sharp ships prebuilt platform binaries, so its own build
+# step is not needed here.
+RUN yarn add sharp --mode=skip-build
 
 # Patch seed-app-store.ts: v5.9.7 calls undefined seedAppData() on line 258.
 # Remove the call so the seed script completes without error.


### PR DESCRIPTION
**Symptom:** build fails after ~2 minutes with `YN0009: calcom-monorepo@workspace:. couldn't be built successfully`.

**Root cause:** `yarn add sharp` re-runs the workspace post-install through turbo. `@calcom/platform-types` then fails to compile with `TS2307: Cannot find module '@nestjs/common'`, because the runner stage does not carry that devDependency. The real error was hidden in a container-internal log; surfacing it identified the failing task.

**Fix:** add `--mode=skip-build`. sharp ships prebuilt platform binaries, so its own build step is not needed here, and the workspace post-install no longer runs in the runner stage.

Verified by building the lab and bringing it up: it now reports healthy. No PoC logic or vulnerability mechanics were changed.