### PR TITLE
Fix CVE-2026-47194 lab: make the healthcheck a liveness probe

### DIFF
--- a/CVE-2026-47194/docker-compose.control.yml
+++ b/CVE-2026-47194/docker-compose.control.yml
@@ -41,7 +41,10 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8080/api/method/ping || exit 1"]
+      # Liveness only. Frappe answers 404 on every path until seed.sh has
+      # created site1.local, so -f (fail on >=400) kept the lab unhealthy
+      # while werkzeug was serving normally. Any HTTP response proves it is up.
+      test: ["CMD-SHELL", "curl -s -o /dev/null http://localhost:8080/api/method/ping || exit 1"]
       interval: 5s
       timeout: 3s
       retries: 12

--- a/CVE-2026-47194/docker-compose.yml
+++ b/CVE-2026-47194/docker-compose.yml
@@ -41,7 +41,10 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:8080/api/method/ping || exit 1"]
+      # Liveness only. Frappe answers 404 on every path until seed.sh has
+      # created site1.local, so -f (fail on >=400) kept the lab unhealthy
+      # while werkzeug was serving normally. Any HTTP response proves it is up.
+      test: ["CMD-SHELL", "curl -s -o /dev/null http://localhost:8080/api/method/ping || exit 1"]
       interval: 5s
       timeout: 3s
       retries: 12


### PR DESCRIPTION
**Symptom:** the `web` service stays `unhealthy` while werkzeug is serving.

**Root cause:** the healthcheck uses `curl -sf /api/method/ping`. The image never creates the site — `seed.sh` runs `new-site site1.local` plus migrations and must be invoked by hand after `up` — so Frappe answers `404` on every path until then (confirmed for both `Host: localhost` and `Host: site1.local`), and `-f` turns that into a failure.

**Fix:** accept any HTTP response as proof the server is up. Seeding with `seed.sh` remains an explicit step.

Verified by building the lab and bringing it up: it now reports healthy. No PoC logic or vulnerability mechanics were changed.