### PR TITLE
Make every lab buildable from source

### DIFF
--- a/CVE-2016-15057/docker-compose.yml
+++ b/CVE-2016-15057/docker-compose.yml
@@ -8,6 +8,9 @@
 
 services:
   vulnerable:
+    build:
+      context: .
+      dockerfile: Dockerfile.vulnerable
     image: ghcr.io/exploitintel/cve-2016-15057-vulnerable:latest
     container_name: cve-2016-15057-vulnerable
     ports:

--- a/CVE-2016-15057/docker-compose.yml
+++ b/CVE-2016-15057/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.vulnerable
-    image: ghcr.io/exploitintel/cve-2016-15057-vulnerable:latest
+    image: cve-2016-15057-vulnerable:local
     container_name: cve-2016-15057-vulnerable
     ports:
       - "18080:8080"

--- a/CVE-2024-31866/docker-compose.yml
+++ b/CVE-2024-31866/docker-compose.yml
@@ -8,7 +8,7 @@
 
 services:
   vulnerable:
-    image: ghcr.io/exploitintel/cve-2024-31866-vulnerable:latest
+    image: cve-2024-31866-vulnerable:local
     build:
       context: .
       dockerfile: Dockerfile.vulnerable

--- a/CVE-2024-43115/docker-compose.yml
+++ b/CVE-2024-43115/docker-compose.yml
@@ -60,7 +60,7 @@ services:
       - lab-net
 
   vulnerable:
-    image: ghcr.io/exploitintel/cve-2024-43115-vulnerable:latest
+    image: cve-2024-43115-vulnerable:local
     build:
       context: .
       dockerfile: Dockerfile.vulnerable

--- a/CVE-2024-56143/docker-compose.yml
+++ b/CVE-2024-56143/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.vulnerable
-    image: ghcr.io/exploitintel/cve-2024-56143-vulnerable:latest
+    image: cve-2024-56143-vulnerable:local
     container_name: cve-2024-56143-vulnerable
     environment:
       - NODE_ENV=development

--- a/CVE-2024-56143/docker-compose.yml
+++ b/CVE-2024-56143/docker-compose.yml
@@ -8,6 +8,9 @@
 
 services:
   vulnerable:
+    build:
+      context: .
+      dockerfile: Dockerfile.vulnerable
     image: ghcr.io/exploitintel/cve-2024-56143-vulnerable:latest
     container_name: cve-2024-56143-vulnerable
     environment:

--- a/CVE-2025-10622/docker-compose.yml
+++ b/CVE-2025-10622/docker-compose.yml
@@ -50,6 +50,9 @@ services:
       - lab-net
 
   vulnerable:
+    build:
+      context: .
+      dockerfile: Dockerfile.vulnerable
     image: ghcr.io/exploitintel/cve-2025-10622-vulnerable:latest
     container_name: cve-2025-10622-app
     environment:

--- a/CVE-2025-10622/docker-compose.yml
+++ b/CVE-2025-10622/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.vulnerable
-    image: ghcr.io/exploitintel/cve-2025-10622-vulnerable:latest
+    image: cve-2025-10622-vulnerable:local
     container_name: cve-2025-10622-app
     environment:
       - DATABASE_URL=postgres://foreman:foreman@db/foreman?pool=5

--- a/CVE-2025-11539/docker-compose.yml
+++ b/CVE-2025-11539/docker-compose.yml
@@ -28,6 +28,9 @@ services:
       - lab-net
 
   vulnerable:
+    build:
+      context: .
+      dockerfile: Dockerfile.vulnerable
     image: ghcr.io/exploitintel/cve-2025-11539-vulnerable:latest
     container_name: cve-2025-11539-renderer
     depends_on:

--- a/CVE-2025-11539/docker-compose.yml
+++ b/CVE-2025-11539/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.vulnerable
-    image: ghcr.io/exploitintel/cve-2025-11539-vulnerable:latest
+    image: cve-2025-11539-vulnerable:local
     container_name: cve-2025-11539-renderer
     depends_on:
       grafana:

--- a/CVE-2025-24490/docker-compose.yml
+++ b/CVE-2025-24490/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - lab-net
 
   vulnerable:
-    image: ghcr.io/exploitintel/cve-2025-24490-vulnerable:latest
+    image: cve-2025-24490-vulnerable:local
     build:
       context: .
       dockerfile: Dockerfile.vulnerable

--- a/CVE-2025-4981/docker-compose.yml
+++ b/CVE-2025-4981/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - lab-net
 
   vulnerable:
-    image: ghcr.io/exploitintel/cve-2025-4981-vulnerable:latest
+    image: cve-2025-4981-vulnerable:local
     build:
       context: .
       dockerfile: Dockerfile.vulnerable

--- a/CVE-2025-53606/docker-compose.yml
+++ b/CVE-2025-53606/docker-compose.yml
@@ -2,7 +2,7 @@
 # Vulnerable (2.4.0) + Patched (2.5.0) lab environment
 services:
   vulnerable:
-    image: ghcr.io/exploitintel/cve-2025-53606-vulnerable:latest
+    image: cve-2025-53606-vulnerable:local
     build:
       context: .
       dockerfile: Dockerfile.vulnerable

--- a/CVE-2025-53833/docker-compose.yml
+++ b/CVE-2025-53833/docker-compose.yml
@@ -10,6 +10,9 @@
 
 services:
   vulnerable:
+    build:
+      context: .
+      dockerfile: Dockerfile.vulnerable
     image: ghcr.io/exploitintel/cve-2025-53833-vulnerable:latest
     container_name: cve-2025-53833-vulnerable
     ports:
@@ -19,6 +22,9 @@ services:
     restart: unless-stopped
 
   patched:
+    build:
+      context: .
+      dockerfile: Dockerfile.patched
     image: ghcr.io/exploitintel/cve-2025-53833-patched:latest
     container_name: cve-2025-53833-patched
     ports:

--- a/CVE-2025-53833/docker-compose.yml
+++ b/CVE-2025-53833/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.vulnerable
-    image: ghcr.io/exploitintel/cve-2025-53833-vulnerable:latest
+    image: cve-2025-53833-vulnerable:local
     container_name: cve-2025-53833-vulnerable
     ports:
       - "8081:8000"
@@ -25,7 +25,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.patched
-    image: ghcr.io/exploitintel/cve-2025-53833-patched:latest
+    image: cve-2025-53833-patched:local
     container_name: cve-2025-53833-patched
     ports:
       - "8082:8000"

--- a/CVE-2025-53833/setup.sh
+++ b/CVE-2025-53833/setup.sh
@@ -8,6 +8,13 @@ set -e
 
 LARECIPE_VERSION="${LARECIPE_VERSION:-2.8.0}"
 
+# Composer refuses to resolve versions carrying security advisories, and this
+# lab deliberately needs them. The override must be global and set before the
+# first Composer command: create-project resolves laravel/framework itself, so
+# a per-project setting applied afterwards comes too late.
+echo "[*] Allowing advisory-affected packages (lab environment)..."
+composer config --global audit.block-insecure false
+
 echo "[*] Creating Laravel 10.x project..."
 composer create-project laravel/laravel:^10.0 /app/larecipe-lab \
     --prefer-dist --no-interaction --no-dev

--- a/CVE-2025-58046/docker-compose.yml
+++ b/CVE-2025-58046/docker-compose.yml
@@ -10,6 +10,9 @@
 services:
 
   mysql-de:
+    build:
+      context: .
+      dockerfile: Dockerfile.mysql
     image: ghcr.io/exploitintel/cve-2025-58046-mysql:latest
     container_name: cve-2025-58046-mysql
     environment:
@@ -25,6 +28,9 @@ services:
       - cve-2025-58046-net
 
   vulnerable:
+    build:
+      context: .
+      dockerfile: Dockerfile.vulnerable
     image: ghcr.io/exploitintel/cve-2025-58046-vulnerable:latest
     container_name: cve-2025-58046-dataease
     stop_signal: SIGTERM
@@ -59,6 +65,9 @@ services:
       - cve-2025-58046-net
 
   dataease-patched:
+    build:
+      context: .
+      dockerfile: Dockerfile.patched
     image: ghcr.io/exploitintel/cve-2025-58046-patched:latest
     container_name: cve-2025-58046-patched
     stop_signal: SIGTERM

--- a/CVE-2025-58046/docker-compose.yml
+++ b/CVE-2025-58046/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.mysql
-    image: ghcr.io/exploitintel/cve-2025-58046-mysql:latest
+    image: cve-2025-58046-mysql:local
     container_name: cve-2025-58046-mysql
     environment:
       - MYSQL_ROOT_PASSWORD=Password123@mysql
@@ -31,7 +31,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.vulnerable
-    image: ghcr.io/exploitintel/cve-2025-58046-vulnerable:latest
+    image: cve-2025-58046-vulnerable:local
     container_name: cve-2025-58046-dataease
     stop_signal: SIGTERM
     stop_grace_period: 15s
@@ -68,7 +68,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.patched
-    image: ghcr.io/exploitintel/cve-2025-58046-patched:latest
+    image: cve-2025-58046-patched:local
     container_name: cve-2025-58046-patched
     stop_signal: SIGTERM
     stop_grace_period: 15s

--- a/CVE-2025-58159/docker-compose.yml
+++ b/CVE-2025-58159/docker-compose.yml
@@ -19,6 +19,9 @@ services:
       start_period: 10s
 
   db-init:
+    build:
+      context: .
+      dockerfile: Dockerfile.vulnerable
     image: ghcr.io/exploitintel/cve-2025-58159-vulnerable:latest
     container_name: cve-2025-58159-db-init
     depends_on:
@@ -29,6 +32,9 @@ services:
       - lab-net
 
   vulnerable:
+    build:
+      context: .
+      dockerfile: Dockerfile.vulnerable
     image: ghcr.io/exploitintel/cve-2025-58159-vulnerable:latest
     container_name: cve-2025-58159-vulnerable
     ports:
@@ -48,6 +54,9 @@ services:
       start_period: 15s
 
   patched:
+    build:
+      context: .
+      dockerfile: Dockerfile.patched
     image: ghcr.io/exploitintel/cve-2025-58159-patched:latest
     container_name: cve-2025-58159-patched
     ports:

--- a/CVE-2025-58159/docker-compose.yml
+++ b/CVE-2025-58159/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.vulnerable
-    image: ghcr.io/exploitintel/cve-2025-58159-vulnerable:latest
+    image: cve-2025-58159-vulnerable:local
     container_name: cve-2025-58159-db-init
     depends_on:
       db:
@@ -35,7 +35,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.vulnerable
-    image: ghcr.io/exploitintel/cve-2025-58159-vulnerable:latest
+    image: cve-2025-58159-vulnerable:local
     container_name: cve-2025-58159-vulnerable
     ports:
       - "8083:80"
@@ -57,7 +57,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.patched
-    image: ghcr.io/exploitintel/cve-2025-58159-patched:latest
+    image: cve-2025-58159-patched:local
     container_name: cve-2025-58159-patched
     ports:
       - "8084:80"

--- a/CVE-2025-60355/docker-compose.patched.yml
+++ b/CVE-2025-60355/docker-compose.patched.yml
@@ -18,7 +18,7 @@ services:
 
   # MariaDB 10.11 (MySQL-compatible) with schema + seed data
   cve-60355-patched-mysql:
-    image: ghcr.io/exploitintel/cve-2025-60355-mysql:latest
+    image: cve-2025-60355-mysql:local
     container_name: cve-60355-patched-mysql
     hostname: cve-60355-mysql
     environment:
@@ -36,7 +36,7 @@ services:
 
   # blog-admin v2.3.9 (patched)
   cve-60355-patched-admin:
-    image: ghcr.io/exploitintel/cve-2025-60355-admin-patched:latest
+    image: cve-2025-60355-admin-patched:local
     container_name: cve-60355-patched-admin
     hostname: cve-60355-admin
     environment:
@@ -65,7 +65,7 @@ services:
 
   # blog-web v2.3.9 (patched)
   cve-60355-patched-web:
-    image: ghcr.io/exploitintel/cve-2025-60355-web-patched:latest
+    image: cve-2025-60355-web-patched:local
     container_name: cve-60355-patched-web
     hostname: cve-60355-web
     environment:

--- a/CVE-2025-60355/docker-compose.yml
+++ b/CVE-2025-60355/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.mysql
-    image: ghcr.io/exploitintel/cve-2025-60355-mysql:latest
+    image: cve-2025-60355-mysql:local
     container_name: cve-60355-mysql
     hostname: cve-60355-mysql
     environment:
@@ -42,7 +42,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.admin
-    image: ghcr.io/exploitintel/cve-2025-60355-admin:latest
+    image: cve-2025-60355-admin:local
     container_name: cve-60355-admin
     hostname: cve-60355-admin
     env_file:
@@ -62,7 +62,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.web
-    image: ghcr.io/exploitintel/cve-2025-60355-web:latest
+    image: cve-2025-60355-web:local
     container_name: cve-60355-web
     hostname: cve-60355-web
     env_file:

--- a/CVE-2025-60355/docker-compose.yml
+++ b/CVE-2025-60355/docker-compose.yml
@@ -18,6 +18,9 @@ services:
 
   # MariaDB 10.11 (MySQL-compatible) with schema + seed data
   cve-60355-mysql:
+    build:
+      context: .
+      dockerfile: Dockerfile.mysql
     image: ghcr.io/exploitintel/cve-2025-60355-mysql:latest
     container_name: cve-60355-mysql
     hostname: cve-60355-mysql
@@ -36,6 +39,9 @@ services:
 
   # blog-admin: Admin backend (template edit endpoint)
   vulnerable:
+    build:
+      context: .
+      dockerfile: Dockerfile.admin
     image: ghcr.io/exploitintel/cve-2025-60355-admin:latest
     container_name: cve-60355-admin
     hostname: cve-60355-admin
@@ -53,6 +59,9 @@ services:
 
   # blog-web: Public frontend (robots.txt trigger endpoint)
   cve-60355-web:
+    build:
+      context: .
+      dockerfile: Dockerfile.web
     image: ghcr.io/exploitintel/cve-2025-60355-web:latest
     container_name: cve-60355-web
     hostname: cve-60355-web

--- a/CVE-2025-66489/docker-compose.yml
+++ b/CVE-2025-66489/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.vulnerable
-    image: ghcr.io/exploitintel/cve-2025-66489-vulnerable:latest
+    image: cve-2025-66489-vulnerable:local
     container_name: cve-2025-66489-vulnerable
     environment:
       DATABASE_URL: postgresql://unicorn_user:magical_password@cve-2025-66489-db:5432/calendso

--- a/CVE-2025-69985/docker-compose.yml
+++ b/CVE-2025-69985/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.vulnerable
-    image: ghcr.io/exploitintel/cve-2025-69985-vulnerable:latest
+    image: cve-2025-69985-vulnerable:local
     container_name: cve-2025-69985-vulnerable
     hostname: cve-2025-69985-vulnerable
     restart: unless-stopped

--- a/CVE-2025-69985/docker-compose.yml
+++ b/CVE-2025-69985/docker-compose.yml
@@ -8,6 +8,9 @@
 
 services:
   vulnerable:
+    build:
+      context: .
+      dockerfile: Dockerfile.vulnerable
     image: ghcr.io/exploitintel/cve-2025-69985-vulnerable:latest
     container_name: cve-2025-69985-vulnerable
     hostname: cve-2025-69985-vulnerable

--- a/CVE-2025-7734/docker-compose.yml
+++ b/CVE-2025-7734/docker-compose.yml
@@ -8,7 +8,7 @@
 
 services:
   vulnerable:
-    image: ghcr.io/exploitintel/cve-2025-7734-vulnerable:latest
+    image: cve-2025-7734-vulnerable:local
     build:
       context: .
       dockerfile: Dockerfile.vulnerable

--- a/CVE-2026-0765/docker-compose.yml
+++ b/CVE-2026-0765/docker-compose.yml
@@ -8,7 +8,7 @@
 
 services:
   vulnerable:
-    image: ghcr.io/exploitintel/cve-2026-0765-vulnerable:latest
+    image: cve-2026-0765-vulnerable:local
     build:
       context: .
       dockerfile: Dockerfile.vulnerable

--- a/CVE-2026-0766/docker-compose.yml
+++ b/CVE-2026-0766/docker-compose.yml
@@ -7,7 +7,7 @@
 
 services:
   vulnerable:
-    image: ghcr.io/exploitintel/cve-2026-0766-vulnerable:latest
+    image: cve-2026-0766-vulnerable:local
     build:
       context: .
       dockerfile: Dockerfile.vulnerable

--- a/CVE-2026-0768/docker-compose.yml
+++ b/CVE-2026-0768/docker-compose.yml
@@ -7,7 +7,7 @@
 
 services:
   vulnerable:
-    image: ghcr.io/exploitintel/cve-2026-0768-vulnerable:latest
+    image: cve-2026-0768-vulnerable:local
     build:
       context: .
       dockerfile: Dockerfile.vulnerable

--- a/CVE-2026-0769/docker-compose.yml
+++ b/CVE-2026-0769/docker-compose.yml
@@ -8,7 +8,7 @@
 
 services:
   vulnerable:
-    image: ghcr.io/exploitintel/cve-2026-0769-vulnerable:latest
+    image: cve-2026-0769-vulnerable:local
     build:
       context: .
       dockerfile: Dockerfile.vulnerable

--- a/CVE-2026-23906/docker-compose.yml
+++ b/CVE-2026-23906/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.openldap
-    image: ghcr.io/exploitintel/cve-2026-23906-openldap:latest
+    image: cve-2026-23906-openldap:local
     container_name: cve-2026-23906-openldap
     environment:
       LDAP_ORGANISATION: "Example Inc."

--- a/CVE-2026-23906/docker-compose.yml
+++ b/CVE-2026-23906/docker-compose.yml
@@ -19,6 +19,9 @@ volumes:
 services:
   # ---- OpenLDAP: LDAP directory with test users ----
   openldap:
+    build:
+      context: .
+      dockerfile: Dockerfile.openldap
     image: ghcr.io/exploitintel/cve-2026-23906-openldap:latest
     container_name: cve-2026-23906-openldap
     environment:

--- a/CVE-2026-2635/docker-compose.yml
+++ b/CVE-2026-2635/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.vulnerable
-    image: ghcr.io/exploitintel/cve-2026-2635-vulnerable:latest
+    image: cve-2026-2635-vulnerable:local
     container_name: cve-2026-2635-vulnerable
     ports:
       - "15000:5000"
@@ -30,7 +30,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.patched
-    image: ghcr.io/exploitintel/cve-2026-2635-patched:latest
+    image: cve-2026-2635-patched:local
     container_name: cve-2026-2635-patched
     ports:
       - "15001:5000"
@@ -49,7 +49,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.v3.10
-    image: ghcr.io/exploitintel/cve-2026-2635-v3.10:latest
+    image: cve-2026-2635-v3.10:local
     container_name: cve-2026-2635-v310
     ports:
       - "15002:5000"

--- a/CVE-2026-2635/docker-compose.yml
+++ b/CVE-2026-2635/docker-compose.yml
@@ -8,6 +8,9 @@
 
 services:
   vulnerable:
+    build:
+      context: .
+      dockerfile: Dockerfile.vulnerable
     image: ghcr.io/exploitintel/cve-2026-2635-vulnerable:latest
     container_name: cve-2026-2635-vulnerable
     ports:
@@ -24,6 +27,9 @@ services:
       - lab-net
 
   patched:
+    build:
+      context: .
+      dockerfile: Dockerfile.patched
     image: ghcr.io/exploitintel/cve-2026-2635-patched:latest
     container_name: cve-2026-2635-patched
     ports:
@@ -40,6 +46,9 @@ services:
       - lab-net
 
   v310:
+    build:
+      context: .
+      dockerfile: Dockerfile.v3.10
     image: ghcr.io/exploitintel/cve-2026-2635-v3.10:latest
     container_name: cve-2026-2635-v310
     ports:

--- a/CVE-2026-26988/docker-compose-patched.yml
+++ b/CVE-2026-26988/docker-compose-patched.yml
@@ -49,7 +49,7 @@ services:
     restart: unless-stopped
 
   librenms-patched:
-    image: ghcr.io/exploitintel/cve-2026-26988-patched:latest
+    image: cve-2026-26988-patched:local
     container_name: cve-2026-26988-patched
     hostname: librenms-patched
     cap_add:

--- a/CVE-2026-2749/docker-compose.yml
+++ b/CVE-2026-2749/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.vulnerable
-    image: ghcr.io/exploitintel/cve-2026-2749-vulnerable:latest
+    image: cve-2026-2749-vulnerable:local
     container_name: cve-2026-2749-vulnerable
     ports:
       - "8080:80"

--- a/CVE-2026-2749/docker-compose.yml
+++ b/CVE-2026-2749/docker-compose.yml
@@ -8,6 +8,9 @@
 
 services:
   vulnerable:
+    build:
+      context: .
+      dockerfile: Dockerfile.vulnerable
     image: ghcr.io/exploitintel/cve-2026-2749-vulnerable:latest
     container_name: cve-2026-2749-vulnerable
     ports:

--- a/CVE-2026-28215/docker-compose.yml
+++ b/CVE-2026-28215/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.vulnerable
-    image: ghcr.io/exploitintel/cve-2026-28215-vulnerable:latest
+    image: cve-2026-28215-vulnerable:local
     container_name: cve-2026-28215-vulnerable
     restart: unless-stopped
     ports:

--- a/CVE-2026-28215/docker-compose.yml
+++ b/CVE-2026-28215/docker-compose.yml
@@ -25,6 +25,9 @@ services:
       - lab-net
 
   vulnerable:
+    build:
+      context: .
+      dockerfile: Dockerfile.vulnerable
     image: ghcr.io/exploitintel/cve-2026-28215-vulnerable:latest
     container_name: cve-2026-28215-vulnerable
     restart: unless-stopped

--- a/CVE-2026-28296/docker-compose.yml
+++ b/CVE-2026-28296/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.ftpserver
-    image: ghcr.io/exploitintel/cve-2026-28296-ftpserver:latest
+    image: cve-2026-28296-ftpserver:local
     container_name: cve-2026-28296-ftpserver
     hostname: vulnerable
     ports:
@@ -22,7 +22,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.malicious-ftpserver
-    image: ghcr.io/exploitintel/cve-2026-28296-malicious-ftpserver:latest
+    image: cve-2026-28296-malicious-ftpserver:local
     container_name: cve-2026-28296-malicious-ftpserver
     hostname: malicious-ftpserver
     environment:
@@ -39,7 +39,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.gvfs-client
-    image: ghcr.io/exploitintel/cve-2026-28296-gvfs-client:latest
+    image: cve-2026-28296-gvfs-client:local
     container_name: cve-2026-28296-gvfs-client
     hostname: gvfs-client
     depends_on:
@@ -57,7 +57,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.gvfs-patched
-    image: ghcr.io/exploitintel/cve-2026-28296-gvfs-patched:latest
+    image: cve-2026-28296-gvfs-patched:local
     container_name: cve-2026-28296-gvfs-patched
     hostname: gvfs-patched
     depends_on:

--- a/CVE-2026-28296/docker-compose.yml
+++ b/CVE-2026-28296/docker-compose.yml
@@ -4,6 +4,9 @@
 services:
   # Vulnerable FTP server target (vsftpd - for original PoC)
   vulnerable:
+    build:
+      context: .
+      dockerfile: Dockerfile.ftpserver
     image: ghcr.io/exploitintel/cve-2026-28296-ftpserver:latest
     container_name: cve-2026-28296-ftpserver
     hostname: vulnerable
@@ -16,6 +19,9 @@ services:
 
   # Malicious FTP server (crafted LIST with tainted symlink targets)
   malicious-ftpserver:
+    build:
+      context: .
+      dockerfile: Dockerfile.malicious-ftpserver
     image: ghcr.io/exploitintel/cve-2026-28296-malicious-ftpserver:latest
     container_name: cve-2026-28296-malicious-ftpserver
     hostname: malicious-ftpserver
@@ -30,6 +36,9 @@ services:
 
   # Vulnerable GVFS client (pre-fix version, 1.54.2 on bookworm)
   gvfs-client:
+    build:
+      context: .
+      dockerfile: Dockerfile.gvfs-client
     image: ghcr.io/exploitintel/cve-2026-28296-gvfs-client:latest
     container_name: cve-2026-28296-gvfs-client
     hostname: gvfs-client
@@ -45,6 +54,9 @@ services:
 
   # Patched GVFS client (HEAD/1.59.2 on trixie - has incomplete CRLF fix)
   gvfs-patched:
+    build:
+      context: .
+      dockerfile: Dockerfile.gvfs-patched
     image: ghcr.io/exploitintel/cve-2026-28296-gvfs-patched:latest
     container_name: cve-2026-28296-gvfs-patched
     hostname: gvfs-patched

--- a/CVE-2026-28370/docker-compose.yml
+++ b/CVE-2026-28370/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.vulnerable
-    image: ghcr.io/exploitintel/cve-2026-28370-vulnerable:latest
+    image: cve-2026-28370-vulnerable:local
     container_name: cve-2026-28370-vulnerable
     ports:
       - "8370:8370"
@@ -26,7 +26,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.patched
-    image: ghcr.io/exploitintel/cve-2026-28370-patched:latest
+    image: cve-2026-28370-patched:local
     container_name: cve-2026-28370-patched
     command: ["sleep", "infinity"]
     volumes:

--- a/CVE-2026-28370/docker-compose.yml
+++ b/CVE-2026-28370/docker-compose.yml
@@ -9,6 +9,9 @@
 
 services:
   vulnerable:
+    build:
+      context: .
+      dockerfile: Dockerfile.vulnerable
     image: ghcr.io/exploitintel/cve-2026-28370-vulnerable:latest
     container_name: cve-2026-28370-vulnerable
     ports:
@@ -20,6 +23,9 @@ services:
       - lab-net
 
   patched:
+    build:
+      context: .
+      dockerfile: Dockerfile.patched
     image: ghcr.io/exploitintel/cve-2026-28370-patched:latest
     container_name: cve-2026-28370-patched
     command: ["sleep", "infinity"]

--- a/CVE-2026-28372/docker-compose.yml
+++ b/CVE-2026-28372/docker-compose.yml
@@ -9,6 +9,9 @@
 
 services:
   vulnerable:
+    build:
+      context: .
+      dockerfile: Dockerfile.vulnerable
     image: ghcr.io/exploitintel/cve-2026-28372-vulnerable:latest
     container_name: cve-2026-28372-vulnerable
     hostname: telnetd-lab

--- a/CVE-2026-28372/docker-compose.yml
+++ b/CVE-2026-28372/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.vulnerable
-    image: ghcr.io/exploitintel/cve-2026-28372-vulnerable:latest
+    image: cve-2026-28372-vulnerable:local
     container_name: cve-2026-28372-vulnerable
     hostname: telnetd-lab
     ports:

--- a/CVE-2026-28417/docker-compose.yml
+++ b/CVE-2026-28417/docker-compose.yml
@@ -8,6 +8,9 @@
 
 services:
   vulnerable:
+    build:
+      context: .
+      dockerfile: Dockerfile.vulnerable
     image: ghcr.io/exploitintel/cve-2026-28417-vulnerable:latest
     container_name: cve-2026-28417-vulnerable
     ports:

--- a/CVE-2026-28417/docker-compose.yml
+++ b/CVE-2026-28417/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.vulnerable
-    image: ghcr.io/exploitintel/cve-2026-28417-vulnerable:latest
+    image: cve-2026-28417-vulnerable:local
     container_name: cve-2026-28417-vulnerable
     ports:
       - "8417:8417"

--- a/CVE-2026-30860/docker-compose.yml
+++ b/CVE-2026-30860/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     restart: unless-stopped
 
   vulnerable:
-    image: ghcr.io/exploitintel/cve-2026-30860-vulnerable:latest
+    image: cve-2026-30860-vulnerable:local
     build:
       context: .
       dockerfile: Dockerfile.vulnerable

--- a/CVE-2026-30861/docker-compose.yml
+++ b/CVE-2026-30861/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     restart: unless-stopped
 
   vulnerable:
-    image: ghcr.io/exploitintel/cve-2026-30861-vulnerable:latest
+    image: cve-2026-30861-vulnerable:local
     build:
       context: .
       dockerfile: Dockerfile.vulnerable


### PR DESCRIPTION
Every lab in this repository can now be built from its own source, and no lab
depends on a prebuilt image.

**17 labs could not be built at all**

Their compose files pinned `image: ghcr.io/exploitintel/...` with no `build:`
stanza, so the only way to run them was to pull. Their Dockerfiles were present
the whole time — only the compose wiring was missing. Each affected service now
has a `build:` stanza.

The mapping was derived, not guessed: the retired publish workflow named images
`<dir>-<role>` from each `Dockerfile.<role>`, so it reverses deterministically,
and every target file was confirmed to exist before the stanza was added.

**30 labs were tagged from a registry that will stop being published**

Any service carrying both a `build:` stanza and a `ghcr.io/...` tag is inert for
the people most likely to run it: compose finds the pulled image locally and
never builds, so the restored build path does nothing for them. Once publishing
stops, that cached image is frozen with no signal that it is stale.

All 30 (the 17 above plus 13 that already had a build stanza) are retagged
`<lab>-<role>:local`, the convention the other 96 labs already use. No
`ghcr.io/exploitintel` reference remains in any compose file. Three markdown
files still mention GHCR images for labs outside this set and are untouched.

**One lab also needed a fix to build**

`CVE-2025-53833` failed with:

    Root composer.json requires laravel/framework ^10.10, found
    laravel/framework[v10.10.0, ..., v10.50.3] but these were not loaded,
    because they are affected by security advisories

Composer now refuses to resolve advisory-affected versions, and this lab
deliberately requires them. `setup.sh` already intended to allow this, but ran
`composer config audit.block-insecure false` *after* `composer create-project`,
which is the command that resolves `laravel/framework`. The override is now set
globally before the first Composer command. The per-project setting is kept so
the value persists in the generated `composer.json`.

**Verification**

All 17 previously unbuildable labs were built from source and started with no
prebuilt image involved: 17/17 build, 17/17 come up healthy. No PoC logic or
vulnerability mechanics were changed.