### PR TITLE
Add a scheduled lab-health workflow

### DIFF
--- a/.github/audit/README.md
+++ b/.github/audit/README.md
@@ -1,0 +1,51 @@
+# Lab health audit
+
+Builds every CVE lab in this repository from source, starts it, and checks that
+it reports healthy. Used by `.github/workflows/lab-health.yml`, and runnable by
+hand.
+
+It publishes nothing and never modifies a lab.
+
+## Run it
+
+```bash
+python3 .github/audit/audit.py --repo . --runs-dir /tmp/runs --run-id local
+```
+
+Useful flags:
+
+| Flag | Purpose |
+|---|---|
+| `--only CVE-2026-58154` | Audit one lab (repeatable) |
+| `--shards N --shard I` | Split the labs across parallel runners |
+| `--skip-privileged` | Exclude labs needing privileged containers |
+| `--build-workers N` | Parallel builds. Several labs run `make -j$(nproc)`, so a high value starves them into false timeouts |
+| `--disk-floor-gb N` | Abort below this much free space |
+| `--allow-dirty` | Audit uncommitted changes; the recorded SHA gains a `-dirty` suffix |
+
+## What counts as healthy
+
+Each lab is judged by the strongest signal it offers, and the record says which
+was used:
+
+- **T1** — every service declaring a healthcheck reaches `healthy`
+- **T2** — no healthcheck, so every published port must accept a connection
+- **T3** — no healthcheck and no ports, so containers must simply stay up
+
+The timeout comes from each lab's own healthcheck declaration
+(`start_period + interval × retries`) rather than a fixed value, because labs
+legitimately differ: one asks for 900s.
+
+## Outcomes that are not lab defects
+
+- `FAIL_PREREQ` — the lab needs something the runner does not provide, such as
+  the kind cluster `CVE-2026-44182` documents as a requirement
+- `CRASH_EXPECTED` — the target aborts under a sanitizer on purpose, which is
+  the demonstration; recorded only when the lab declares that intent *and* its
+  output carries a sanitizer signature
+- `INFRA_ERROR` — a registry or network problem, not the lab
+
+## Scope
+
+It answers "does the lab stand up", not "does the exploit still work". A lab can
+come up perfectly with a dead PoC, and this will call it healthy.

--- a/.github/audit/audit.py
+++ b/.github/audit/audit.py
@@ -1,0 +1,689 @@
+"""CVE Docker lab audit runner.
+
+Phase 1 builds every lab in parallel (no host ports are bound during build).
+Phase 2 brings each lab up one at a time, probes it, captures evidence, and
+tears it down. Records are immutable and keyed by (repo_sha, cve).
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import datetime
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import time
+
+import inventory
+import probes
+import safety
+
+REPO_DEFAULT = "."
+HARNESS_HOME = pathlib.Path(__file__).resolve().parent
+RUNS_DIR = HARNESS_HOME / "runs"
+
+BUILD_TIMEOUT = 1200
+UP_TIMEOUT = 300
+PROBE_TIMEOUT = 180
+STABLE_SECONDS = 30
+BUILD_WORKERS = 6
+DISK_FLOOR_GB = safety.DISK_FLOOR_BYTES // 1024 ** 3
+DISK_HEADROOM_GB = 200
+
+INFRA_PATTERNS = (
+    "toomanyrequests",
+    "you have reached your pull rate limit",
+    "429 too many requests",
+    "temporary failure in name resolution",
+    "tls handshake timeout",
+    "i/o timeout",
+    "connection reset by peer",
+    "no space left on device",
+    # Transient upstream HTTP errors while fetching release assets. CVE-2024-21626
+    # failed on a GitHub 503 pulling a runc binary — the lab is fine, the CDN was not.
+    "503 service unavailable",
+    "502 bad gateway",
+    "500 internal server error",
+    "connection timed out",
+    # containerd content-store race seen under heavy parallel builds
+    # (CVE-2026-0766): "failed commit on ref ... commit failed: rename".
+    "failed commit on ref",
+    "commit failed: rename",
+)
+UPSTREAM_PATTERNS = (
+    "manifest unknown",
+    "pull access denied",
+    "repository does not exist",
+)
+PACKAGE_PATTERNS = (
+    "unable to locate package",
+    "has no installation candidate",
+    "no package matching",
+)
+DEPENDENCY_PATTERNS = (
+    "no matching distribution found",
+    "could not find a version that satisfies",
+    "npm err! 404",
+)
+# CVE-2026-66713 declares `build: .` for a service, which defaults to
+# `Dockerfile` — a file that directory does not contain. The lab cannot build
+# at all, which is a repo defect distinct from upstream rot.
+MISSING_DOCKERFILE_PATTERNS = (
+    "failed to read dockerfile",
+    "cannot locate specified dockerfile",
+)
+
+
+class DirtyRepoError(Exception):
+    """The repo under audit has uncommitted changes."""
+
+
+def _now():
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+def classify_build_failure(log: str) -> str:
+    """Bucket a failed build log into an actionable root cause."""
+    text = (log or "").lower()
+    for patterns, label in (
+        (INFRA_PATTERNS, "infra"),
+        (MISSING_DOCKERFILE_PATTERNS, "missing_dockerfile"),
+        (UPSTREAM_PATTERNS, "upstream_gone"),
+        (PACKAGE_PATTERNS, "package_gone"),
+        (DEPENDENCY_PATTERNS, "dependency_gone"),
+    ):
+        if any(p in text for p in patterns):
+            return label
+    return "build_error"
+
+
+def is_infra_failure(log: str) -> bool:
+    return classify_build_failure(log) == "infra"
+
+
+def repo_sha(repo_root, allow_dirty: bool = False) -> str:
+    """Short SHA of the repo under audit. Refuses to run against a dirty tree.
+
+    `allow_dirty` exists only to verify uncommitted lab repairs before they are
+    committed. Such a result describes the working tree, not the commit, so the
+    SHA is suffixed `-dirty` and must never be presented as an audit of that
+    commit.
+    """
+    dirty = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=str(repo_root), capture_output=True, text=True, timeout=60,
+    )
+    is_dirty = bool(dirty.stdout.strip())
+    if is_dirty and not allow_dirty:
+        raise DirtyRepoError(
+            f"{repo_root} has uncommitted changes; results could not be "
+            "attributed to a commit (use --allow-dirty to verify local repairs)"
+        )
+    sha = subprocess.run(
+        ["git", "rev-parse", "--short", "HEAD"],
+        cwd=str(repo_root), capture_output=True, text=True, timeout=60,
+    )
+    return sha.stdout.strip() + ("-dirty" if is_dirty else "")
+
+
+class ConcurrentRunError(Exception):
+    """Another audit process is already live in this run directory."""
+
+
+class RunDir:
+    """One audit run's on-disk home. Results are append-only."""
+
+    def __init__(self, path):
+        self.path = pathlib.Path(path)
+        (self.path / "logs").mkdir(parents=True, exist_ok=True)
+
+    @property
+    def lock_file(self):
+        return self.path / "run.pid"
+
+    def acquire(self) -> None:
+        """Refuse to start when another live process owns this run directory.
+
+        Two runs sharing a run-id probe the same labs at once: they collide on
+        pinned container names and compose networks, and both append to
+        results.jsonl, so every verdict is an artifact of the race rather than
+        of the lab. A stale PID from a crashed or rebooted run is reclaimed.
+        """
+        if self.lock_file.exists():
+            try:
+                pid = int(self.lock_file.read_text().strip())
+            except (ValueError, OSError):
+                pid = None
+            if pid and pid != os.getpid():
+                try:
+                    os.kill(pid, 0)
+                except ProcessLookupError:
+                    pass  # stale lock, previous run died
+                except PermissionError:
+                    raise ConcurrentRunError(
+                        f"pid {pid} still owns {self.path}"
+                    )
+                else:
+                    raise ConcurrentRunError(
+                        f"pid {pid} is already running in {self.path}"
+                    )
+        self.lock_file.write_text(str(os.getpid()), encoding="utf-8")
+
+    def release(self) -> None:
+        try:
+            self.lock_file.unlink()
+        except OSError:
+            pass
+
+    @property
+    def results_file(self):
+        return self.path / "results.jsonl"
+
+    def append_result(self, record: dict) -> None:
+        with self.results_file.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, sort_keys=True) + "\n")
+
+    def write_manifest(self, data: dict) -> None:
+        (self.path / "manifest.json").write_text(
+            json.dumps(data, indent=2, sort_keys=True), encoding="utf-8"
+        )
+
+    def log_path(self, cve: str, name: str):
+        directory = self.path / "logs" / cve
+        directory.mkdir(parents=True, exist_ok=True)
+        return directory / name
+
+    def completed_cves(self) -> set:
+        if not self.results_file.exists():
+            return set()
+        done = set()
+        for line in self.results_file.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if line:
+                done.add(json.loads(line)["cve"])
+        return done
+
+
+def compose_cmd(lab: dict, *args) -> list:
+    """Full compose argv for a lab, carrying the profile and env-file flags."""
+    return inventory.compose_args(lab.get("env_file")) + list(args)
+
+
+def _compose(lab, *args, timeout):
+    """Run docker compose in the lab directory, as a user would."""
+    return subprocess.run(
+        compose_cmd(lab, *args),
+        cwd=lab["path"], capture_output=True, text=True, timeout=timeout,
+    )
+
+
+def build_lab(lab: dict, run_dir: RunDir, timeout: int = BUILD_TIMEOUT) -> dict:
+    """Build one lab. Retries once on an infrastructure failure."""
+    started = time.monotonic()
+    attempts, result, log_text = 0, None, ""
+
+    while attempts < 2:
+        attempts += 1
+        try:
+            # --progress is a global compose flag; placing it after `build`
+            # works but compose warns. Keep it global to stay quiet and correct.
+            result = _compose(
+                lab, "--progress", "plain", "build", timeout=timeout
+            )
+            log_text = (result.stdout or "") + (result.stderr or "")
+        except subprocess.TimeoutExpired as exc:
+            # Keep whatever the build managed to emit — without it a timeout is
+            # undiagnosable, and we cannot tell a hung build from a slow one.
+            partial = ""
+            for stream in (exc.stdout, exc.stderr):
+                if stream:
+                    partial += stream if isinstance(stream, str) else stream.decode(
+                        "utf-8", "replace"
+                    )
+            run_dir.log_path(lab["cve"], "build.log").write_text(
+                f"TIMEOUT after {timeout}s\n\n{partial}", encoding="utf-8"
+            )
+            return {
+                "build_state": "TIMEOUT",
+                "build_seconds": round(time.monotonic() - started, 1),
+                "build_cause": "timeout",
+                "build_attempts": attempts,
+                "build_timeout_used": timeout,
+            }
+        if result.returncode == 0 or not is_infra_failure(log_text):
+            break
+        time.sleep(20)
+
+    run_dir.log_path(lab["cve"], "build.log").write_text(log_text, encoding="utf-8")
+    seconds = round(time.monotonic() - started, 1)
+
+    if result.returncode == 0:
+        return {
+            "build_state": "OK",
+            "build_seconds": seconds,
+            "build_cause": None,
+            "build_attempts": attempts,
+        }
+
+    cause = classify_build_failure(log_text)
+    return {
+        "build_state": "INFRA_ERROR" if cause == "infra" else "FAIL_BUILD",
+        "build_seconds": seconds,
+        "build_cause": cause,
+        "build_attempts": attempts,
+    }
+
+
+def effective_tier(static: str, containers) -> str:
+    """Static analysis cannot see ports that only exist at runtime."""
+    if static == "T3" and probes.runtime_ports(containers):
+        return "T2"
+    return static
+
+
+def _ps(lab):
+    try:
+        result = _compose(lab, "ps", "-a", "--format", "json", timeout=60)
+    except subprocess.TimeoutExpired:
+        return []
+    return probes.parse_ps(result.stdout)
+
+
+def _teardown(lab, volumes_before=None, timeout=UP_TIMEOUT):
+    """Tear a lab down without `-v`.
+
+    `down -v` removes every named volume the compose file declares, including
+    volumes that pre-date the run — it destroyed a user's existing
+    `cve-2025-24490_pg_data`. Instead tear down without `-v` and delete only
+    volumes that appeared while this lab was up, so state still does not leak
+    between labs.
+    """
+    try:
+        _compose(lab, "down", "--remove-orphans", timeout=timeout)
+    except subprocess.TimeoutExpired:
+        pass
+    # A lab pinning `container_name` (e.g. CVE-2025-11539) cannot start while a
+    # container of that exact name survives from an earlier interrupted run, and
+    # `compose down` misses it when the leftover carries different project
+    # labels. Only names this lab's own compose declares are touched.
+    for name in lab.get("container_names") or []:
+        subprocess.run(["docker", "rm", "-f", name],
+                       capture_output=True, text=True, timeout=60)
+    if volumes_before is not None:
+        return safety.remove_new_volumes(volumes_before)
+    return []
+
+
+def probe_budget(lab: dict, floor: int = PROBE_TIMEOUT) -> int:
+    """Seconds to allow a lab to become healthy.
+
+    Honour the lab's own healthcheck declaration when it asks for longer than
+    the floor — a slow-booting service like GitLab is not a broken one.
+    """
+    return int(max(floor, lab.get("health_budget_seconds") or 0))
+
+
+def probe_lab(lab: dict, run_dir: RunDir, up_timeout: int = UP_TIMEOUT,
+              probe_floor: int = PROBE_TIMEOUT) -> dict:
+    """Bring one lab up, probe it to a verdict, capture evidence, tear it down."""
+    started = time.monotonic()
+    budget = probe_budget(lab, probe_floor)
+    volumes_before = safety.snapshot()["volumes"]
+    _teardown(lab, volumes_before)
+
+    try:
+        up = _compose(lab, "up", "-d", timeout=up_timeout)
+    except subprocess.TimeoutExpired as exc:
+        # Preserve partial output: without it an `up` timeout is undiagnosable,
+        # and a slow image pull looks identical to a hung container.
+        partial = ""
+        for stream in (exc.stdout, exc.stderr):
+            if stream:
+                partial += stream if isinstance(stream, str) else stream.decode(
+                    "utf-8", "replace"
+                )
+        run_dir.log_path(lab["cve"], "up.log").write_text(
+            f"TIMEOUT after {up_timeout}s\n\n{partial}", encoding="utf-8"
+        )
+        _teardown(lab, volumes_before)
+        return {
+            "state": "TIMEOUT", "reason": f"up exceeded {up_timeout}s",
+            "probe_tier_effective": lab["probe_tier_static"],
+            "probe_seconds": round(time.monotonic() - started, 1),
+            "probe_budget_used": budget,
+            "runtime_ports": [],
+        }
+
+    up_log = (up.stdout or "") + (up.stderr or "")
+    run_dir.log_path(lab["cve"], "up.log").write_text(up_log, encoding="utf-8")
+
+    if up.returncode != 0:
+        containers = _ps(lab)
+        _teardown(lab, volumes_before)
+        state = "FAIL_UP"
+        if "declared as external, but could not be found" in up_log:
+            # An unmet documented prerequisite (e.g. a kind cluster), not rot.
+            state = "FAIL_PREREQ"
+        elif lab["required_env"] and not lab["env_file"]:
+            state = "FAIL_ENV_MISSING"
+        elif is_infra_failure(up_log):
+            state = "INFRA_ERROR"
+        tail = up_log.strip().splitlines()
+        return {
+            "state": state,
+            "reason": tail[-1] if tail else "up failed",
+            "probe_tier_effective": lab["probe_tier_static"],
+            "probe_seconds": round(time.monotonic() - started, 1),
+            "runtime_ports": probes.runtime_ports(containers),
+        }
+
+    deadline = time.monotonic() + budget
+    first_seen = time.monotonic()
+    verdict, reason = probes.PENDING, "not started"
+    containers, tier, port_results = [], lab["probe_tier_static"], {}
+
+    while time.monotonic() < deadline:
+        containers = _ps(lab)
+        tier = effective_tier(lab["probe_tier_static"], containers)
+        if tier == "T1":
+            verdict, reason = probes.verdict_t1(
+                containers, lab["healthcheck_services"]
+            )
+        elif tier == "T2":
+            ports = probes.runtime_ports(containers)
+            port_results = {p: probes.tcp_probe("127.0.0.1", p) for p in ports}
+            verdict, reason = probes.verdict_t2(containers, port_results)
+        else:
+            stable = int(time.monotonic() - first_seen)
+            verdict, reason = probes.verdict_t3(containers, stable, STABLE_SECONDS)
+
+        if verdict in (probes.PASS, probes.FAIL_UP):
+            break
+        time.sleep(3)
+
+    container_log = ""
+    try:
+        logs = _compose(lab, "logs", "--tail", "200", timeout=60)
+        container_log = (logs.stdout or "") + (logs.stderr or "")
+        run_dir.log_path(lab["cve"], "container.log").write_text(
+            container_log, encoding="utf-8"
+        )
+    except subprocess.TimeoutExpired:
+        pass
+
+    run_dir.log_path(lab["cve"], "ps.json").write_text(
+        json.dumps([c.__dict__ for c in containers], indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    if port_results:
+        run_dir.log_path(lab["cve"], "probe.json").write_text(
+            json.dumps({str(k): v for k, v in port_results.items()}, indent=2),
+            encoding="utf-8",
+        )
+
+    _teardown(lab, volumes_before)
+
+    state = {
+        probes.PASS: "PASS",
+        probes.FAIL_UP: "FAIL_UP",
+        probes.PENDING: "FAIL_UNHEALTHY",
+    }[verdict]
+
+    # A memory-corruption lab whose target aborts on purpose has not "failed to
+    # come up" — the abort is the demonstration. Requires BOTH the lab's own
+    # declaration and a sanitizer signature in its output, so an ordinary crash
+    # can never be laundered into a non-failure.
+    if (
+        state == "FAIL_UP"
+        and lab.get("crash_expected")
+        and probes.looks_like_sanitizer_abort(container_log)
+    ):
+        state = "CRASH_EXPECTED"
+        reason = f"sanitizer abort, declared by the lab: {reason}"
+    elif state in ("FAIL_UP", "FAIL_UNHEALTHY") and lab["required_env"] and not lab["env_file"]:
+        state = "FAIL_ENV_MISSING"
+
+    return {
+        "state": state,
+        "reason": reason,
+        "probe_tier_effective": tier,
+        "probe_seconds": round(time.monotonic() - started, 1),
+        "probe_budget_used": budget,
+        "runtime_ports": probes.runtime_ports(containers),
+    }
+
+
+def _select(labs, args):
+    chosen = [l for l in labs if l["cohort"] == inventory.COHORT_DOCKER]
+    if args.only:
+        wanted = set(args.only)
+        chosen = [l for l in chosen if l["cve"] in wanted]
+    if getattr(args, "skip_privileged", False):
+        chosen = [l for l in chosen if not l["privileged"]]
+    # Privileged labs run last: they receive real host-level capability.
+    chosen.sort(key=lambda l: (l["privileged"], l["cve"]))
+    shards = getattr(args, "shards", 1) or 1
+    if shards > 1:
+        # Deal round-robin off the sorted list so each shard gets a comparable
+        # mix of fast and slow labs rather than one shard inheriting a run of
+        # heavy builds.
+        chosen = [l for i, l in enumerate(chosen) if i % shards == args.shard]
+    if args.limit:
+        chosen = chosen[: args.limit]
+    return chosen
+
+
+def run(args) -> int:
+    repo = pathlib.Path(args.repo)
+    sha = repo_sha(repo, allow_dirty=args.allow_dirty)
+
+    disk_floor = int(args.disk_floor_gb) * 1024 ** 3
+    disk_headroom = int(args.disk_headroom_gb) * 1024 ** 3
+    if not safety.disk_ok(floor=disk_floor):
+        print(
+            f"ABORT: free space {safety.free_bytes() // 1024**3} GB is below the "
+            f"{args.disk_floor_gb} GB floor",
+            file=sys.stderr,
+        )
+        return 2
+
+    runs_dir = pathlib.Path(args.runs_dir) if args.runs_dir else RUNS_DIR
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    run_id = args.run_id or (
+        f"{sha}-{datetime.datetime.now().strftime('%Y%m%d-%H%M%S')}"
+    )
+    run_dir = RunDir(runs_dir / run_id)
+
+    try:
+        run_dir.acquire()
+    except ConcurrentRunError as exc:
+        print(f"ABORT: {exc}", file=sys.stderr)
+        return 4
+
+    print(f"[*] repo {repo} @ {sha}")
+    print(f"[*] run dir {run_dir.path}")
+
+    before = safety.snapshot()
+    all_labs = inventory.collect(repo)
+    targets = _select(all_labs, args)
+
+    done = run_dir.completed_cves() if args.resume else set()
+    if done:
+        print(f"[*] resuming, {len(done)} lab(s) already recorded")
+        targets = [l for l in targets if l["cve"] not in done]
+
+    base_manifest = {
+        "repo": str(repo),
+        "repo_sha": sha,
+        "started_at": _now(),
+        "host": subprocess.run(
+            ["hostname"], capture_output=True, text=True
+        ).stdout.strip(),
+        "docker": subprocess.run(
+            ["docker", "version", "--format", "{{.Server.Version}}"],
+            capture_output=True, text=True,
+        ).stdout.strip(),
+        "build_workers": args.build_workers,
+        "total_dirs": len(all_labs),
+        "targets": [l["cve"] for l in targets],
+        "preflight": {k: len(v) for k, v in before.items()},
+    }
+    run_dir.write_manifest(base_manifest)
+
+    # Non-docker cohorts are recorded once so totals reconcile to all dirs.
+    if not args.only and not args.limit:
+        for lab in all_labs:
+            if lab["cohort"] == inventory.COHORT_DOCKER or lab["cve"] in done:
+                continue
+            run_dir.append_result({
+                "cve": lab["cve"], "repo_sha": sha, "cohort": lab["cohort"],
+                "state": {
+                    inventory.COHORT_NONE: "NO_LAB",
+                    inventory.COHORT_VM: "NOT_DOCKER",
+                }.get(lab["cohort"], "SKIPPED"),
+                "reason": "not a docker lab", "recorded_at": _now(),
+            })
+
+    if args.dry_run:
+        for lab in targets:
+            print(f"    {lab['cve']:<20} tier={lab['probe_tier_static']} "
+                  f"privileged={lab['privileged']} env={lab['required_env']}")
+        print(f"[*] dry run: {len(targets)} lab(s) would be audited")
+        return 0
+
+    builds = {}
+    if args.phase in ("build", "all"):
+        print(f"[*] phase 1: building {len(targets)} lab(s), "
+              f"{args.build_workers} workers")
+        with concurrent.futures.ThreadPoolExecutor(args.build_workers) as pool:
+            futures = {
+                pool.submit(build_lab, l, run_dir, args.build_timeout): l
+                for l in targets
+            }
+            for i, future in enumerate(
+                concurrent.futures.as_completed(futures), 1
+            ):
+                lab = futures[future]
+                builds[lab["cve"]] = future.result()
+                print(f"    [{i}/{len(targets)}] {lab['cve']:<20} "
+                      f"build={builds[lab['cve']]['build_state']} "
+                      f"({builds[lab['cve']]['build_seconds']}s)", flush=True)
+
+    if args.phase in ("probe", "all"):
+        print(f"[*] phase 2: probing {len(targets)} lab(s), serial")
+        for i, lab in enumerate(targets, 1):
+            build = builds.get(lab["cve"], {"build_state": "SKIPPED"})
+            record = {
+                "cve": lab["cve"], "repo_sha": sha, "cohort": lab["cohort"],
+                "probe_tier_static": lab["probe_tier_static"],
+                "privileged": lab["privileged"],
+                "required_env": lab["required_env"],
+                "env_file_used": bool(lab["env_file"]),
+                "dockerfiles": lab["dockerfiles"],
+                "profiles": lab.get("profiles") or [],
+                "recorded_at": _now(),
+                **build,
+            }
+            if build["build_state"] in ("FAIL_BUILD", "TIMEOUT", "INFRA_ERROR"):
+                record["state"] = build["build_state"]
+                if build["build_state"] == "TIMEOUT":
+                    record["reason"] = (
+                        f"build exceeded "
+                        f"{build.get('build_timeout_used', args.build_timeout)}s "
+                        f"at {args.build_workers} concurrent worker(s)"
+                    )
+                else:
+                    record["reason"] = f"build failed: {build.get('build_cause')}"
+                record["probe_tier_effective"] = lab["probe_tier_static"]
+                record["runtime_ports"] = []
+            else:
+                record.update(
+                    probe_lab(lab, run_dir, args.up_timeout,
+                              args.probe_timeout)
+                )
+
+            run_dir.append_result(record)
+            print(f"    [{i}/{len(targets)}] {lab['cve']:<20} "
+                  f"{record['state']:<18} {record.get('reason', '')[:60]}",
+                  flush=True)
+
+            if not safety.disk_ok(floor=disk_headroom):
+                removed = safety.remove_new_images(before, safety.snapshot())
+                print(f"    [*] disk headroom low, removed "
+                      f"{len(removed)} new image(s)", flush=True)
+
+    after = safety.snapshot()
+    try:
+        safety.assert_preserved(before, after)
+        preserved, note = True, "all pre-existing artifacts intact"
+    except safety.HostMutationError as exc:
+        preserved, note = False, str(exc)
+        print(f"[!] HOST MUTATION: {note}", file=sys.stderr)
+
+    base_manifest.update({
+        "finished_at": _now(),
+        "postflight": {k: len(v) for k, v in after.items()},
+        "host_preserved": preserved,
+        "host_note": note,
+    })
+    run_dir.write_manifest(base_manifest)
+    run_dir.release()
+    print(f"[*] done -> {run_dir.path}")
+    return 0 if preserved else 3
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Audit CVE Docker labs")
+    parser.add_argument("--repo", default=REPO_DEFAULT)
+    parser.add_argument("--phase", choices=("build", "probe", "all"), default="all")
+    parser.add_argument("--only", action="append", default=[])
+    parser.add_argument("--limit", type=int, default=0)
+    parser.add_argument("--build-workers", type=int, default=BUILD_WORKERS)
+    parser.add_argument(
+        "--build-timeout", type=int, default=BUILD_TIMEOUT,
+        help="Per-lab build timeout in seconds. Raise it when retrying "
+             "source-compiling labs serially, which the default suits poorly.",
+    )
+    parser.add_argument(
+        "--up-timeout", type=int, default=UP_TIMEOUT,
+        help="Seconds for `compose up -d`. Labs with no build stanza pull "
+             "their images here, which the default suits poorly.",
+    )
+    parser.add_argument(
+        "--probe-timeout", type=int, default=PROBE_TIMEOUT,
+        help="Floor for the health probe. A lab declaring a longer "
+             "healthcheck budget gets its own, larger value.",
+    )
+    parser.add_argument("--runs-dir", default="")
+    parser.add_argument(
+        "--disk-floor-gb", type=int, default=DISK_FLOOR_GB,
+        help="Abort if free space is below this. CI runners have far less "
+             "disk than a lab host, so this must be lowered there.",
+    )
+    parser.add_argument(
+        "--disk-headroom-gb", type=int, default=DISK_HEADROOM_GB,
+        help="Below this, remove images this run created before continuing.",
+    )
+    parser.add_argument("--shards", type=int, default=1,
+                        help="Split the lab list into this many shards.")
+    parser.add_argument("--shard", type=int, default=0,
+                        help="Which shard to run (0-based).")
+    parser.add_argument("--skip-privileged", action="store_true",
+                        help="Exclude labs that need privileged containers.")
+    parser.add_argument("--run-id", default="")
+    parser.add_argument("--resume", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--allow-dirty", action="store_true",
+        help="Audit a dirty working tree to verify uncommitted lab repairs. "
+             "The recorded SHA gains a -dirty suffix; such a run is not an "
+             "audit of any commit.",
+    )
+    return run(parser.parse_args())
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/audit/audit.py
+++ b/.github/audit/audit.py
@@ -15,6 +15,7 @@ import os
 import pathlib
 import subprocess
 import sys
+import tempfile
 import time
 
 import inventory
@@ -22,7 +23,9 @@ import probes
 import safety
 
 REPO_DEFAULT = "."
-HARNESS_HOME = pathlib.Path(__file__).resolve().parent
+HARNESS_HOME = pathlib.Path(tempfile.gettempdir()) / "cve-lab-audit"
+# Never default inside the repository: run output would dirty the working
+# tree, and the dirty-tree guard would then refuse every subsequent run.
 RUNS_DIR = HARNESS_HOME / "runs"
 
 BUILD_TIMEOUT = 1200
@@ -31,7 +34,10 @@ PROBE_TIMEOUT = 180
 STABLE_SECONDS = 30
 BUILD_WORKERS = 6
 DISK_FLOOR_GB = safety.DISK_FLOOR_BYTES // 1024 ** 3
-DISK_HEADROOM_GB = 200
+# Prune images this run created once free space drops below this. Keep it
+# low: a large value fires after every lab on an ordinary disk and destroys
+# the layer cache, turning a warm re-run into a cold rebuild.
+DISK_HEADROOM_GB = 20
 
 INFRA_PATTERNS = (
     "toomanyrequests",
@@ -545,6 +551,22 @@ def run(args) -> int:
                     inventory.COHORT_VM: "NOT_DOCKER",
                 }.get(lab["cohort"], "SKIPPED"),
                 "reason": "not a docker lab", "recorded_at": _now(),
+            })
+
+    # Privileged labs excluded by policy are recorded, not silently dropped:
+    # a report that omits them reads as "everything passed" when 5 labs were
+    # never exercised.
+    if args.skip_privileged:
+        for lab in all_labs:
+            if lab["cohort"] != inventory.COHORT_DOCKER or not lab["privileged"]:
+                continue
+            if lab["cve"] in done:
+                continue
+            run_dir.append_result({
+                "cve": lab["cve"], "repo_sha": sha, "cohort": lab["cohort"],
+                "state": "SKIPPED", "privileged": True,
+                "reason": "privileged lab excluded by --skip-privileged",
+                "recorded_at": _now(),
             })
 
     if args.dry_run:

--- a/.github/audit/ci_summary.py
+++ b/.github/audit/ci_summary.py
@@ -1,0 +1,86 @@
+"""Summarise a lab-health run for the CI job summary, and set the exit status.
+
+Reads the combined results.jsonl from every shard, prints Markdown, and exits
+non-zero only when a lab is genuinely broken. States that describe the
+environment rather than the lab -- an unmet documented prerequisite, a
+registry hiccup, a target that aborts by design -- are reported but do not
+fail the run, so the signal stays trustworthy.
+"""
+
+import collections
+import json
+import pathlib
+import sys
+
+# A lab defect: the lab itself is broken and someone should fix it.
+FAILING = (
+    "FAIL_BUILD", "FAIL_UP", "FAIL_UNHEALTHY", "FAIL_ENV_MISSING", "TIMEOUT",
+)
+# Real outcomes that are not lab defects.
+INFORMATIONAL = (
+    "FAIL_PREREQ",     # needs something this runner does not provide (e.g. a kind cluster)
+    "CRASH_EXPECTED",  # sanitizer abort is the demonstration
+    "INFRA_ERROR",     # registry/network hiccup
+    "SKIPPED",         # excluded by policy, e.g. privileged labs in CI
+    "NO_LAB",          # not a Docker lab
+    "NOT_DOCKER",
+)
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: ci_summary.py <results.jsonl>", file=sys.stderr)
+        return 2
+
+    path = pathlib.Path(sys.argv[1])
+    if not path.exists() or not path.stat().st_size:
+        print("## Lab health\n\nNo results were produced — every shard failed "
+              "before writing output.")
+        return 1
+
+    # Later records win, so a lab retried within a run is counted once.
+    latest = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            record = json.loads(line)
+            latest[record["cve"]] = record
+    records = sorted(latest.values(), key=lambda r: r["cve"])
+
+    counts = collections.Counter(r["state"] for r in records)
+    broken = [r for r in records if r["state"] in FAILING]
+    passed = [r for r in records if r["state"] == "PASS"]
+
+    print("## Lab health\n")
+    print(f"**{len(passed)} of {len(records)} labs healthy.**\n")
+
+    print("| State | Count |")
+    print("|---|---|")
+    for state, count in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])):
+        print(f"| `{state}` | {count} |")
+
+    if broken:
+        print(f"\n### Broken labs ({len(broken)})\n")
+        print("| Lab | State | Detail |")
+        print("|---|---|---|")
+        for r in broken:
+            detail = (r.get("reason") or "").replace("|", "\\|")[:90]
+            print(f"| `{r['cve']}` | {r['state']} | {detail} |")
+
+    noted = [r for r in records if r["state"] in INFORMATIONAL
+             and r["state"] not in ("NO_LAB", "NOT_DOCKER")]
+    if noted:
+        print("\n### Not counted as failures\n")
+        for r in noted:
+            detail = (r.get("reason") or "")[:90]
+            print(f"- `{r['cve']}` — {r['state']}: {detail}")
+
+    if broken:
+        print(f"\nFailing because {len(broken)} lab(s) are broken.")
+        return 1
+
+    print("\nAll labs that this runner can exercise are healthy.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/audit/ci_summary.py
+++ b/.github/audit/ci_summary.py
@@ -1,44 +1,55 @@
-"""Summarise a lab-health run for the CI job summary, and set the exit status.
+"""Summarise a lab-health run for the CI job summary and set the exit status.
 
 Reads the combined results.jsonl from every shard, prints Markdown, and exits
-non-zero only when a lab is genuinely broken. States that describe the
-environment rather than the lab -- an unmet documented prerequisite, a
-registry hiccup, a target that aborts by design -- are reported but do not
-fail the run, so the signal stays trustworthy.
+non-zero when a lab is broken *or* when a lab was never reported at all.
+
+That second check matters as much as the first. Coverage is assembled from
+independent shards, so a shard that dies before writing its artifact removes
+labs from the run silently. Without an expected-set comparison the summary
+would happily report "96 of 96 healthy" while 14 labs went untested — the same
+green-but-meaningless signal this workflow exists to replace.
+
+The state taxonomy lives in report.py so the CI verdict and the generated
+report can never disagree about what counts as a failure.
 """
 
+import argparse
 import collections
 import json
 import pathlib
 import sys
 
-# A lab defect: the lab itself is broken and someone should fix it.
-FAILING = (
-    "FAIL_BUILD", "FAIL_UP", "FAIL_UNHEALTHY", "FAIL_ENV_MISSING", "TIMEOUT",
-)
-# Real outcomes that are not lab defects.
-INFORMATIONAL = (
-    "FAIL_PREREQ",     # needs something this runner does not provide (e.g. a kind cluster)
-    "CRASH_EXPECTED",  # sanitizer abort is the demonstration
-    "INFRA_ERROR",     # registry/network hiccup
-    "SKIPPED",         # excluded by policy, e.g. privileged labs in CI
-    "NO_LAB",          # not a Docker lab
-    "NOT_DOCKER",
-)
+import report
+
+# Real outcomes that describe the environment rather than a lab defect.
+NOT_A_DEFECT = tuple(s for s in report.EXCLUDED_STATES if s not in ("NO_LAB", "NOT_DOCKER"))
+
+
+def expected_labs(repo: pathlib.Path) -> set:
+    """Every directory that is a Docker lab, straight from the filesystem.
+
+    Deliberately not using inventory.collect(): this runs in a job with no
+    images built and no need for a Docker daemon, and the question here is only
+    "which labs should have been reported".
+    """
+    return {
+        d.name for d in repo.glob("CVE-*")
+        if d.is_dir() and (d / "docker-compose.yml").is_file()
+    }
 
 
 def main() -> int:
-    if len(sys.argv) < 2:
-        print("usage: ci_summary.py <results.jsonl>", file=sys.stderr)
-        return 2
+    parser = argparse.ArgumentParser()
+    parser.add_argument("results")
+    parser.add_argument("--repo", default=".")
+    args = parser.parse_args()
 
-    path = pathlib.Path(sys.argv[1])
+    path = pathlib.Path(args.results)
     if not path.exists() or not path.stat().st_size:
         print("## Lab health\n\nNo results were produced — every shard failed "
               "before writing output.")
         return 1
 
-    # Later records win, so a lab retried within a run is counted once.
     latest = {}
     for line in path.read_text(encoding="utf-8").splitlines():
         if line.strip():
@@ -46,12 +57,16 @@ def main() -> int:
             latest[record["cve"]] = record
     records = sorted(latest.values(), key=lambda r: r["cve"])
 
+    expected = expected_labs(pathlib.Path(args.repo))
+    missing = sorted(expected - set(latest))
+
     counts = collections.Counter(r["state"] for r in records)
-    broken = [r for r in records if r["state"] in FAILING]
-    passed = [r for r in records if r["state"] == "PASS"]
+    broken = [r for r in records if r["state"] in report.FAIL_STATES]
+    passed = [r for r in records if r["state"] in report.PASS_STATES]
 
     print("## Lab health\n")
-    print(f"**{len(passed)} of {len(records)} labs healthy.**\n")
+    print(f"**{len(passed)} passed, {len(broken)} broken, "
+          f"{len(expected)} labs expected.**\n")
 
     print("| State | Count |")
     print("|---|---|")
@@ -66,19 +81,31 @@ def main() -> int:
             detail = (r.get("reason") or "").replace("|", "\\|")[:90]
             print(f"| `{r['cve']}` | {r['state']} | {detail} |")
 
-    noted = [r for r in records if r["state"] in INFORMATIONAL
-             and r["state"] not in ("NO_LAB", "NOT_DOCKER")]
+    if missing:
+        print(f"\n### Never reported ({len(missing)})\n")
+        print("These labs produced no result at all — a shard most likely died "
+              "before writing its artifact. They were **not** tested.\n")
+        for cve in missing:
+            print(f"- `{cve}`")
+
+    noted = [r for r in records if r["state"] in NOT_A_DEFECT]
     if noted:
         print("\n### Not counted as failures\n")
         for r in noted:
             detail = (r.get("reason") or "")[:90]
             print(f"- `{r['cve']}` — {r['state']}: {detail}")
 
-    if broken:
-        print(f"\nFailing because {len(broken)} lab(s) are broken.")
+    if broken or missing:
+        reasons = []
+        if broken:
+            reasons.append(f"{len(broken)} lab(s) broken")
+        if missing:
+            reasons.append(f"{len(missing)} lab(s) never reported")
+        print(f"\nFailing: {', '.join(reasons)}.")
         return 1
 
-    print("\nAll labs that this runner can exercise are healthy.")
+    print("\nEvery expected lab reported, and all that this runner can "
+          "exercise are healthy.")
     return 0
 
 

--- a/.github/audit/inventory.py
+++ b/.github/audit/inventory.py
@@ -1,0 +1,229 @@
+"""Derive the audit universe from the repo. No hardcoded CVE lists."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import subprocess
+
+COHORT_DOCKER = "docker_lab"
+COHORT_VM = "not_docker"
+COHORT_NONE = "no_lab"
+COHORT_UNKNOWN = "unknown"
+
+COMPOSE_FILE = "docker-compose.yml"
+UNSET_VAR_RE = re.compile(r'The \\?"([A-Z_][A-Z0-9_]*)\\?" variable is not set')
+
+# A lab may declare that its target is *meant* to die: memory-corruption labs
+# set a sanitizer to abort so the container exit code is the demonstration.
+# CVE-2026-64608's compose says so in a comment: abort_on_error=1 makes a memory
+# error surface as SIGABRT (exit 134) "so the container exit code is unambiguous
+# signal evidence". Such a lab must not be scored as if it failed to come up.
+CRASH_ENV_MARKERS = ("abort_on_error=1", "asan_options", "ubsan_options", "msan_options")
+
+
+class ComposeConfigError(Exception):
+    """`docker compose config` exited non-zero."""
+
+
+def classify(lab_dir: pathlib.Path) -> str:
+    """Cohort for one CVE directory. Rules are ordered; first match wins.
+
+    The VM lab check must precede the no-lab check: CVE-2026-50540 has neither
+    a compose file nor a Dockerfile, so it would otherwise be miscounted.
+    """
+    if (lab_dir / COMPOSE_FILE).is_file():
+        return COHORT_DOCKER
+    if (lab_dir / "run.sh").is_file() and (lab_dir / "vm-assets").is_dir():
+        return COHORT_VM
+    if not list(lab_dir.glob("Dockerfile.*")):
+        return COHORT_NONE
+    return COHORT_UNKNOWN
+
+
+def parse_required_env(stderr: str) -> list:
+    """Variable names compose warned were unset, sorted and deduped."""
+    return sorted({m.group(1) for m in UNSET_VAR_RE.finditer(stderr or "")})
+
+
+def compose_args(env_file=None) -> list:
+    """Base `docker compose` arguments shared by inventory and the runner.
+
+    `--profile "*"` activates every declared profile. Without it, a lab whose
+    services are all profile-gated resolves to zero services and `up` silently
+    starts nothing — which would look like a crash rather than a config gate.
+    CVE-2026-20348 is the case in point. Verified harmless on labs that declare
+    no profiles.
+    """
+    args = ["docker", "compose", "--profile", "*"]
+    if env_file:
+        args += ["--env-file", str(env_file)]
+    return args
+
+
+def compose_config(lab_dir: pathlib.Path, env_file=None):
+    """Resolved compose config plus stderr. Raises ComposeConfigError on failure."""
+    cmd = compose_args(env_file) + ["config", "--format", "json"]
+    result = subprocess.run(
+        cmd, cwd=str(lab_dir), capture_output=True, text=True, timeout=180
+    )
+    if result.returncode != 0:
+        raise ComposeConfigError(result.stderr.strip())
+    return json.loads(result.stdout), result.stderr
+
+
+def services_info(config: dict) -> dict:
+    """Per-service facts needed to run and judge the lab.
+
+    A port entry without a `published` key means the mapping used an unset
+    variable; Docker will assign a random host port at runtime.
+    """
+    info = {}
+    for name, svc in (config.get("services") or {}).items():
+        svc = svc or {}
+        health = svc.get("healthcheck") or {}
+        env = svc.get("environment") or {}
+        if isinstance(env, list):
+            env = dict(
+                (item.split("=", 1) + [""])[:2] for item in env if isinstance(item, str)
+            )
+        env_text = " ".join(f"{k}={v}" for k, v in env.items()).lower()
+        static_ports, dynamic = [], False
+        for port in svc.get("ports") or []:
+            published = (port or {}).get("published")
+            if published in (None, "", 0, "0"):
+                dynamic = True
+            else:
+                static_ports.append(int(published))
+        info[name] = {
+            "healthcheck": bool(health) and not health.get("disable", False),
+            "static_ports": sorted(set(static_ports)),
+            "dynamic_ports": dynamic,
+            "privileged": bool(svc.get("privileged")),
+            "profiles": list(svc.get("profiles") or []),
+            "crash_expected": any(m in env_text for m in CRASH_ENV_MARKERS),
+            "healthcheck_spec": health,
+            "container_name": svc.get("container_name") or "",
+        }
+    return info
+
+
+DURATION_RE = re.compile(r"([0-9]*\.?[0-9]+)(ms|us|ns|h|m|s)")
+DURATION_UNITS = {
+    "ns": 1e-9, "us": 1e-6, "ms": 1e-3, "s": 1.0, "m": 60.0, "h": 3600.0
+}
+
+
+def parse_duration(value) -> float:
+    """Parse a Go-style compose duration ('10s', '5m0s', '1h30m') to seconds."""
+    if value is None or value == "":
+        return 0.0
+    if isinstance(value, (int, float)):
+        # Compose may emit raw nanoseconds for durations set programmatically.
+        return float(value) / 1e9 if value > 1e6 else float(value)
+    total, matched = 0.0, False
+    for amount, unit in DURATION_RE.findall(str(value)):
+        total += float(amount) * DURATION_UNITS[unit]
+        matched = True
+    return total if matched else 0.0
+
+
+def health_budget(services: dict) -> float:
+    """How long the labs themselves say they may need to become healthy.
+
+    A fixed probe timeout is wrong: CVE-2022-0735 is GitLab CE declaring
+    start_period 5m with 60 retries at 10s, i.e. up to 900s. Deriving the
+    budget from the lab's own healthcheck avoids failing a slow-but-working
+    lab, without giving every lab the same generous allowance.
+    """
+    budgets = [0.0]
+    for svc in services.values():
+        health = svc.get("healthcheck_spec") or {}
+        if not health:
+            continue
+        start = parse_duration(health.get("start_period"))
+        interval = parse_duration(health.get("interval")) or 30.0
+        retries = int(health.get("retries") or 3)
+        budgets.append(start + interval * retries)
+    return max(budgets)
+
+
+def static_tier(services: dict) -> str:
+    """Provisional tier. Upgraded to T2 at runtime if dynamic ports appear."""
+    if any(s["healthcheck"] for s in services.values()):
+        return "T1"
+    if any(s["static_ports"] for s in services.values()):
+        return "T2"
+    return "T3"
+
+
+def build_lab(lab_dir: pathlib.Path) -> dict:
+    """Full inventory record for one CVE directory."""
+    cohort = classify(lab_dir)
+    record = {
+        "cve": lab_dir.name,
+        "path": str(lab_dir),
+        "cohort": cohort,
+        "compose_file": COMPOSE_FILE if cohort == COHORT_DOCKER else None,
+        "services": [],
+        "dockerfiles": sorted(p.name for p in lab_dir.glob("Dockerfile.*")),
+        "static_host_ports": [],
+        "dynamic_ports": False,
+        "required_env": [],
+        "env_file": None,
+        "healthcheck_services": [],
+        "privileged": False,
+        "profiles": [],
+        "crash_expected": False,
+        "container_names": [],
+        "external_networks": [],
+        "health_budget_seconds": 0.0,
+        "probe_tier_static": None,
+        "config_error": None,
+    }
+    if cohort != COHORT_DOCKER:
+        return record
+
+    example = lab_dir / ".env.example"
+    if example.is_file():
+        record["env_file"] = str(example)
+
+    try:
+        config, stderr = compose_config(lab_dir, env_file=record["env_file"])
+    except ComposeConfigError as exc:
+        record["config_error"] = str(exc)
+        return record
+
+    services = services_info(config)
+    record["services"] = sorted(services)
+    record["required_env"] = parse_required_env(stderr)
+    record["static_host_ports"] = sorted(
+        {p for s in services.values() for p in s["static_ports"]}
+    )
+    record["dynamic_ports"] = any(s["dynamic_ports"] for s in services.values())
+    record["healthcheck_services"] = sorted(
+        n for n, s in services.items() if s["healthcheck"]
+    )
+    record["privileged"] = any(s["privileged"] for s in services.values())
+    record["profiles"] = sorted({p for s in services.values() for p in s["profiles"]})
+    record["crash_expected"] = any(s["crash_expected"] for s in services.values())
+    # Networks the lab expects to already exist. CVE-2026-44182 requires a kind
+    # cluster (its README lists kind + kubectl as requirements), so a missing
+    # external network is an unmet prerequisite, not lab rot.
+    record["external_networks"] = sorted(
+        name for name, net in (config.get("networks") or {}).items()
+        if (net or {}).get("external")
+    )
+    record["container_names"] = sorted(
+        s["container_name"] for s in services.values() if s["container_name"]
+    )
+    record["health_budget_seconds"] = round(health_budget(services), 1)
+    record["probe_tier_static"] = static_tier(services)
+    return record
+
+
+def collect(repo_root) -> list:
+    """Inventory every CVE-* directory, sorted by name."""
+    root = pathlib.Path(repo_root)
+    return [build_lab(d) for d in sorted(root.glob("CVE-*")) if d.is_dir()]

--- a/.github/audit/probes.py
+++ b/.github/audit/probes.py
@@ -1,0 +1,145 @@
+"""Verdict logic — pure functions over normalized container records.
+
+The caller performs all Docker I/O and passes results in. `PENDING` means the
+lab has not failed but has not yet satisfied its tier; the caller keeps polling
+until the probe timeout, then records FAIL_UNHEALTHY.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+from dataclasses import dataclass, field
+
+PASS = "PASS"
+PENDING = "PENDING"
+FAIL_UP = "FAIL_UP"
+
+# Runtime evidence that a container died inside a sanitizer rather than from
+# ordinary breakage. Required *in addition to* the lab declaring crash-abort
+# semantics before a non-zero exit is treated as intended behaviour.
+SANITIZER_MARKERS = (
+    "addresssanitizer",
+    "undefinedbehaviorsanitizer",
+    "memorysanitizer",
+    "leaksanitizer",
+    "runtime error:",
+    "==aborting",
+)
+
+
+def looks_like_sanitizer_abort(log: str) -> bool:
+    """True when container output carries a sanitizer crash signature."""
+    text = (log or "").lower()
+    return any(marker in text for marker in SANITIZER_MARKERS)
+
+
+@dataclass
+class Container:
+    service: str
+    name: str
+    state: str
+    health: str
+    exit_code: int
+    published: list = field(default_factory=list)
+
+
+def parse_ps(raw: str) -> list:
+    """Parse `docker compose ps -a --format json`.
+
+    Compose 5.4.0 on the runner emits NDJSON (verified). A JSON array is also
+    accepted so the harness survives a compose upgrade.
+    """
+    raw = (raw or "").strip()
+    if not raw:
+        return []
+    if raw.startswith("["):
+        objects = json.loads(raw)
+    else:
+        objects = [json.loads(line) for line in raw.splitlines() if line.strip()]
+
+    containers = []
+    for obj in objects:
+        ports = {
+            int(p["PublishedPort"])
+            for p in (obj.get("Publishers") or [])
+            if p.get("PublishedPort")
+        }
+        containers.append(
+            Container(
+                service=obj.get("Service", ""),
+                name=obj.get("Name") or obj.get("Names", ""),
+                state=(obj.get("State") or "").lower(),
+                health=(obj.get("Health") or "").lower(),
+                exit_code=int(obj.get("ExitCode") or 0),
+                published=sorted(ports),
+            )
+        )
+    return containers
+
+
+def container_ok(c: Container):
+    """Running is fine. Exited-0 is a completed one-shot, also fine."""
+    if c.state == "running":
+        return True, None
+    if c.state == "exited" and c.exit_code == 0:
+        return True, None
+    return False, f"{c.service}: state={c.state} exit={c.exit_code}"
+
+
+def _crashed(containers):
+    return [why for c in containers for ok, why in [container_ok(c)] if not ok]
+
+
+def runtime_ports(containers) -> list:
+    return sorted({p for c in containers for p in c.published})
+
+
+def verdict_t1(containers, healthcheck_services):
+    if not containers:
+        return FAIL_UP, "no containers created"
+    crashed = _crashed(containers)
+    if crashed:
+        return FAIL_UP, "; ".join(crashed)
+    wanted = set(healthcheck_services or [])
+    pending = [
+        f"{c.service}: health={c.health or 'none'}"
+        for c in containers
+        if c.service in wanted and c.state == "running" and c.health != "healthy"
+    ]
+    if pending:
+        return PENDING, "; ".join(pending)
+    return PASS, f"{len(containers)} container(s) up, healthchecks satisfied"
+
+
+def verdict_t2(containers, probe_results):
+    if not containers:
+        return FAIL_UP, "no containers created"
+    crashed = _crashed(containers)
+    if crashed:
+        return FAIL_UP, "; ".join(crashed)
+    if not probe_results:
+        return PENDING, "no published ports observed yet"
+    dead = sorted(port for port, ok in probe_results.items() if not ok)
+    if dead:
+        return PENDING, f"ports not answering: {dead}"
+    return PASS, f"all {len(probe_results)} published port(s) answering"
+
+
+def verdict_t3(containers, stable_seconds, required_stable=30):
+    if not containers:
+        return FAIL_UP, "no containers created"
+    crashed = _crashed(containers)
+    if crashed:
+        return FAIL_UP, "; ".join(crashed)
+    if stable_seconds < required_stable:
+        return PENDING, f"stable {stable_seconds}s of {required_stable}s"
+    return PASS, f"{len(containers)} container(s) stable for {required_stable}s"
+
+
+def tcp_probe(host: str, port: int, timeout: float = 3.0) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False

--- a/.github/audit/report.py
+++ b/.github/audit/report.py
@@ -1,0 +1,165 @@
+"""Render an audit run's results.jsonl into AUDIT-REPORT.md."""
+
+from __future__ import annotations
+
+import collections
+import json
+import pathlib
+import sys
+
+PASS_STATES = ("PASS",)
+FAIL_STATES = (
+    "FAIL_BUILD", "FAIL_UP", "FAIL_UNHEALTHY", "FAIL_ENV_MISSING", "TIMEOUT"
+)
+# CRASH_EXPECTED is neither: the lab did what it was built to do, but we did not
+# verify a healthy service. It gets its own section for human confirmation.
+# FAIL_PREREQ is not a lab defect: the lab needs an external dependency its
+# README documents (a kind cluster, say) that this host does not provide.
+EXCLUDED_STATES = (
+    "NO_LAB", "NOT_DOCKER", "SKIPPED", "INFRA_ERROR", "CRASH_EXPECTED",
+    "FAIL_PREREQ",
+)
+
+
+def load(results_path) -> list:
+    path = pathlib.Path(results_path)
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def merge(record_sets) -> list:
+    """Combine runs, later ones winning per CVE.
+
+    A retry re-tests a subset under corrected settings; its verdict supersedes
+    the original. Within one set the last record for a CVE also wins, so a
+    resumed run does not double-count.
+    """
+    latest = {}
+    for records in record_sets:
+        for record in records:
+            latest[record["cve"]] = record
+    return sorted(latest.values(), key=lambda r: r["cve"])
+
+
+def summarise(records) -> dict:
+    return dict(collections.Counter(r["state"] for r in records))
+
+
+def advisories(records) -> list:
+    """Real defects that are not 'lab down'."""
+    out = []
+    for r in sorted(records, key=lambda x: x["cve"]):
+        if r.get("state") != "PASS":
+            continue
+        if r.get("required_env") and not r.get("env_file_used"):
+            out.append(
+                f"`{r['cve']}` — came up, but requires env vars with no default "
+                f"and no `.env.example`: {', '.join(r['required_env'])}. "
+                "Host port is assigned randomly."
+            )
+    return out
+
+
+def render(records, manifest) -> str:
+    counts = summarise(records)
+    tested = [r for r in records if r["state"] not in EXCLUDED_STATES]
+    passed = [r for r in records if r["state"] in PASS_STATES]
+    failed = [r for r in records if r["state"] in FAIL_STATES]
+
+    lines = [
+        "# CVE Docker Lab Audit — Report",
+        "",
+        f"**Repo SHA:** `{manifest.get('repo_sha', 'unknown')}`  ",
+        f"**Host:** {manifest.get('host', 'unknown')}  ",
+        f"**Finished:** {manifest.get('finished_at', 'unknown')}  ",
+        f"**Host artifacts preserved:** {manifest.get('host_preserved', 'unknown')}",
+        "",
+        "Pass bar: the lab builds and comes up healthy. This audit does **not**",
+        "test whether the PoC still proves the vulnerability.",
+        "",
+        "## Summary",
+        "",
+        f"- Directories recorded: **{len(records)}**",
+        f"- Labs tested: **{len(tested)}**",
+        f"- Passed: **{len(passed)}**",
+        f"- Failed: **{len(failed)}**",
+        "",
+        "| State | Count |",
+        "|---|---|",
+    ]
+    for state, count in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0])):
+        lines.append(f"| `{state}` | {count} |")
+
+    if failed:
+        lines += ["", "## Failures grouped by root cause", ""]
+        by_cause = collections.defaultdict(list)
+        for r in failed:
+            by_cause[r.get("build_cause") or r["state"]].append(r)
+        for cause, group in sorted(by_cause.items()):
+            lines += [f"### {cause} ({len(group)})", ""]
+            for r in sorted(group, key=lambda x: x["cve"]):
+                lines.append(f"- `{r['cve']}` — {r.get('reason', '')}")
+            lines.append("")
+
+    crashers = [r for r in records if r["state"] == "CRASH_EXPECTED"]
+    if crashers:
+        lines += [
+            "", "## Crash-by-design targets", "",
+            "These labs declare sanitizer abort semantics and their containers "
+            "died with a sanitizer signature. The abort *is* the demonstration, "
+            "so they are not counted as failures — but neither was a healthy "
+            "service verified. Confirm by hand.", "",
+        ]
+        for r in sorted(crashers, key=lambda x: x["cve"]):
+            lines.append(f"- `{r['cve']}` — {r.get('reason', '')}")
+        lines.append("")
+
+    notes = advisories(records)
+    if notes:
+        lines += ["## Advisory findings", "",
+                  "Labs that came up but carry a real defect:", ""]
+        lines += [f"- {n}" for n in notes]
+        lines.append("")
+
+    lines += ["## Per-lab results", "",
+              "| CVE | State | Tier | Ports | Build (s) | Detail |",
+              "|---|---|---|---|---|---|"]
+    for r in sorted(records, key=lambda x: x["cve"]):
+        ports = ", ".join(str(p) for p in r.get("runtime_ports") or []) or "—"
+        lines.append(
+            f"| `{r['cve']}` | {r['state']} | "
+            f"{r.get('probe_tier_effective') or '—'} | {ports} | "
+            f"{r.get('build_seconds', '—')} | {(r.get('reason') or '')[:80]} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(
+            "usage: python3 report.py runs/<run-id> [runs/<retry-id> ...]\n"
+            "Later runs supersede earlier ones per CVE.",
+            file=sys.stderr,
+        )
+        return 1
+    run_paths = [pathlib.Path(p) for p in sys.argv[1:]]
+    records = merge(load(p / "results.jsonl") for p in run_paths)
+
+    manifest = {}
+    for path in run_paths:
+        manifest_path = path / "manifest.json"
+        if manifest_path.exists():
+            manifest.update(json.loads(manifest_path.read_text()))
+    manifest["runs_merged"] = [p.name for p in run_paths]
+
+    out = run_paths[0] / "AUDIT-REPORT.md"
+    out.write_text(render(records, manifest), encoding="utf-8")
+    print(f"wrote {out} ({len(records)} records from {len(run_paths)} run(s))")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/audit/safety.py
+++ b/.github/audit/safety.py
@@ -1,0 +1,125 @@
+"""Host-protection primitives for the CVE lab audit.
+
+This is the ONLY module permitted to delete Docker artifacts. Every removal is
+gated on a preflight snapshot: an artifact that existed before the run started
+can never be removed, no matter what.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+DISK_FLOOR_BYTES = 100 * 1024 ** 3
+KINDS = ("images", "image_tags", "volumes", "networks")
+
+# What the preservation assertion actually guards. Raw image IDs are NOT in this
+# set: rebuilding a lab moves its tag to a fresh ID and leaves the old ID
+# unreferenced, which is normal Docker behaviour and destroys nothing the user
+# depends on. Tags, volumes and networks are the things whose loss is real.
+PROTECTED_KINDS = ("image_tags", "volumes", "networks")
+
+
+class HostMutationError(Exception):
+    """Raised when the harness detects it removed something pre-existing."""
+
+
+def _docker(*args, timeout=120):
+    return subprocess.run(
+        ["docker", *args], capture_output=True, text=True, timeout=timeout
+    )
+
+
+def _ids(kind: str) -> set:
+    args = {
+        "images": ["image", "ls", "-aq"],
+        "image_tags": ["image", "ls", "--format", "{{.Repository}}:{{.Tag}}"],
+        "volumes": ["volume", "ls", "-q"],
+        "networks": ["network", "ls", "-q"],
+    }[kind]
+    result = _docker(*args)
+    if result.returncode != 0:
+        raise RuntimeError(f"docker {' '.join(args)} failed: {result.stderr.strip()}")
+    values = {line.strip() for line in result.stdout.splitlines() if line.strip()}
+    if kind == "image_tags":
+        # Untagged images are unreferenced by definition; they carry no identity
+        # a user can depend on, so they are not protected.
+        values = {v for v in values if "<none>" not in v}
+    return values
+
+
+def snapshot() -> dict:
+    """Capture every Docker artifact ID currently on the host."""
+    return {kind: _ids(kind) for kind in KINDS}
+
+
+def new_artifacts(before: dict, after: dict) -> dict:
+    """Artifacts present in `after` but not `before` — created by this run."""
+    return {kind: after[kind] - before[kind] for kind in before}
+
+
+def missing_artifacts(before: dict, after: dict) -> dict:
+    """Artifacts present in `before` but gone in `after` — must always be empty."""
+    return {kind: before[kind] - after[kind] for kind in before}
+
+
+def assert_preserved(before: dict, after: dict) -> None:
+    """Raise if the run destroyed anything the user depends on.
+
+    Only PROTECTED_KINDS are enforced. A pre-existing image ID disappearing is
+    expected when a lab is rebuilt: the tag moves to a new ID and the old one is
+    left unreferenced. The tag itself surviving is what proves nothing was lost.
+    """
+    missing = {
+        kind: values
+        for kind, values in missing_artifacts(before, after).items()
+        if values and kind in PROTECTED_KINDS
+    }
+    if missing:
+        raise HostMutationError(
+            "harness removed pre-existing Docker artifacts: "
+            + "; ".join(f"{k}={sorted(v)}" for k, v in sorted(missing.items()))
+        )
+    return None
+
+
+def free_bytes(path: str = "/") -> int:
+    return shutil.disk_usage(path).free
+
+
+def disk_ok(path: str = "/", floor: int = DISK_FLOOR_BYTES) -> bool:
+    return free_bytes(path) >= floor
+
+
+def remove_new_volumes(before_volumes: set) -> list:
+    """Remove only volumes created since `before_volumes`. Returns IDs removed.
+
+    `docker compose down -v` cannot be used for teardown: it deletes every named
+    volume the compose file declares, including one that already existed before
+    the run. That destroyed a user's pre-existing `cve-2025-24490_pg_data`.
+    Tearing down without `-v` and removing only the diff keeps lab state from
+    leaking between labs without touching anything that was already there.
+    """
+    removed = []
+    for volume in sorted(_ids("volumes") - set(before_volumes)):
+        if volume in before_volumes:
+            continue
+        if _docker("volume", "rm", "-f", volume, timeout=60).returncode == 0:
+            removed.append(volume)
+    return removed
+
+
+def remove_new_images(before: dict, after: dict) -> list:
+    """Remove only images created since `before`. Returns the IDs removed.
+
+    Pre-existing images are never candidates. Removal failures are ignored:
+    an image still referenced by another lab simply stays.
+    """
+    candidates = sorted(new_artifacts(before, after).get("images", set()))
+    removed = []
+    for image_id in candidates:
+        if image_id in before["images"]:
+            continue
+        if _docker("rmi", "-f", image_id, timeout=180).returncode == 0:
+            removed.append(image_id)
+    return removed

--- a/.github/audit/tests/test_audit.py
+++ b/.github/audit/tests/test_audit.py
@@ -1,0 +1,317 @@
+import json
+import os
+import pathlib
+import subprocess
+import tempfile
+import unittest
+
+import audit
+import probes
+
+
+class TestBuildFailureClassification(unittest.TestCase):
+    def test_rate_limit_is_infra(self):
+        log = "toomanyrequests: You have reached your pull rate limit"
+        self.assertEqual(audit.classify_build_failure(log), "infra")
+        self.assertTrue(audit.is_infra_failure(log))
+
+    def test_dns_failure_is_infra(self):
+        log = "Temporary failure in name resolution"
+        self.assertEqual(audit.classify_build_failure(log), "infra")
+
+    def test_disk_full_is_infra(self):
+        self.assertEqual(
+            audit.classify_build_failure("no space left on device"), "infra"
+        )
+
+    def test_missing_manifest_is_upstream_gone(self):
+        log = "manifest for someimage:1.2.3 not found: manifest unknown"
+        self.assertEqual(audit.classify_build_failure(log), "upstream_gone")
+        self.assertFalse(audit.is_infra_failure(log))
+
+    def test_apt_package_missing_is_package_gone(self):
+        log = "E: Unable to locate package libfoo-dev"
+        self.assertEqual(audit.classify_build_failure(log), "package_gone")
+
+    def test_pip_resolution_is_dependency_gone(self):
+        log = "ERROR: No matching distribution found for flask==0.1"
+        self.assertEqual(audit.classify_build_failure(log), "dependency_gone")
+
+    def test_upstream_503_is_infra_not_lab_defect(self):
+        """CVE-2024-21626: GitHub returned 503 for a runc release asset."""
+        log = "wget: server returned error: HTTP/1.1 503 Service Unavailable"
+        self.assertEqual(audit.classify_build_failure(log), "infra")
+
+    def test_containerd_commit_race_is_infra(self):
+        """CVE-2026-0766 under a load spike of 29 on 12 cores."""
+        log = ('failed to solve: failed commit on ref "layer-sha256:82ba": '
+               "commit failed: rename /var/lib/containerd/... "
+               "no such file or directory")
+        self.assertEqual(audit.classify_build_failure(log), "infra")
+
+    def test_missing_dockerfile_still_wins_over_generic_no_such_file(self):
+        """Both messages contain 'no such file or directory'; don't confuse them."""
+        log = ("target web: failed to solve: failed to read dockerfile: "
+               "open Dockerfile: no such file or directory")
+        self.assertEqual(audit.classify_build_failure(log), "missing_dockerfile")
+
+    def test_missing_dockerfile_is_its_own_cause(self):
+        """Real failure text from CVE-2026-66713 during the pilot."""
+        log = ("target web: failed to solve: failed to read dockerfile: "
+               "open Dockerfile: no such file or directory")
+        self.assertEqual(audit.classify_build_failure(log), "missing_dockerfile")
+
+    def test_unrecognised_is_generic_build_error(self):
+        self.assertEqual(audit.classify_build_failure("syntax error"), "build_error")
+
+
+class TestRunDir(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.run = audit.RunDir(pathlib.Path(self.tmp.name) / "run-1")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_creates_directory_structure(self):
+        self.assertTrue(self.run.path.is_dir())
+        self.assertTrue((self.run.path / "logs").is_dir())
+
+    def test_append_result_writes_one_json_object_per_line(self):
+        self.run.append_result({"cve": "CVE-1", "state": "PASS"})
+        self.run.append_result({"cve": "CVE-2", "state": "FAIL_BUILD"})
+        lines = (self.run.path / "results.jsonl").read_text().strip().splitlines()
+        self.assertEqual(len(lines), 2)
+        self.assertEqual(json.loads(lines[1])["cve"], "CVE-2")
+
+    def test_completed_cves_supports_resume(self):
+        self.run.append_result({"cve": "CVE-1", "state": "PASS"})
+        self.assertEqual(self.run.completed_cves(), {"CVE-1"})
+
+    def test_completed_cves_empty_before_any_results(self):
+        self.assertEqual(self.run.completed_cves(), set())
+
+    def test_log_path_is_namespaced_per_cve(self):
+        p = self.run.log_path("CVE-2025-1", "build.log")
+        self.assertTrue(p.parent.is_dir())
+        self.assertTrue(str(p).endswith("logs/CVE-2025-1/build.log"))
+
+
+class TestRepoShaDirtyHandling(unittest.TestCase):
+    """A verification run of uncommitted repairs must never look like an audit
+    of the commit it happens to sit on."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo = pathlib.Path(self.tmp.name)
+        for cmd in (
+            ["git", "init", "-q"],
+            ["git", "config", "user.email", "dev@exploit-intel.com"],
+            ["git", "config", "user.name", "Exploit Intelligence Platform"],
+        ):
+            subprocess.run(cmd, cwd=self.repo, capture_output=True)
+        (self.repo / "a.txt").write_text("one")
+        subprocess.run(["git", "add", "-A"], cwd=self.repo, capture_output=True)
+        subprocess.run(["git", "commit", "-qm", "init"], cwd=self.repo,
+                       capture_output=True)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_clean_tree_returns_plain_sha(self):
+        sha = audit.repo_sha(self.repo)
+        self.assertTrue(sha)
+        self.assertNotIn("-dirty", sha)
+
+    def test_dirty_tree_raises_by_default(self):
+        (self.repo / "a.txt").write_text("two")
+        with self.assertRaises(audit.DirtyRepoError):
+            audit.repo_sha(self.repo)
+
+    def test_dirty_tree_allowed_explicitly_is_marked(self):
+        (self.repo / "a.txt").write_text("two")
+        self.assertTrue(audit.repo_sha(self.repo, allow_dirty=True).endswith("-dirty"))
+
+
+class TestRunLock(unittest.TestCase):
+    """Two runs sharing a run-id corrupt each other's results.
+
+    It happened for real: a duplicate retry produced two records per CVE
+    seconds apart, with container-name and network collisions between them.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.path = pathlib.Path(self.tmp.name) / "run-1"
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_second_live_process_is_refused(self):
+        first = audit.RunDir(self.path)
+        first.acquire()
+        # Simulate a different, living process owning the lock.
+        first.lock_file.write_text("1")  # pid 1 always exists
+        second = audit.RunDir(self.path)
+        with self.assertRaises(audit.ConcurrentRunError):
+            second.acquire()
+
+    def test_stale_lock_from_dead_process_is_reclaimed(self):
+        run = audit.RunDir(self.path)
+        run.lock_file.write_text("999999")  # not a live pid
+        run.acquire()
+        self.assertEqual(run.lock_file.read_text().strip(), str(os.getpid()))
+
+    def test_release_removes_the_lock(self):
+        run = audit.RunDir(self.path)
+        run.acquire()
+        run.release()
+        self.assertFalse(run.lock_file.exists())
+
+    def test_reacquiring_own_lock_is_allowed(self):
+        run = audit.RunDir(self.path)
+        run.acquire()
+        run.acquire()
+        self.assertTrue(run.lock_file.exists())
+
+
+class TestEffectiveTier(unittest.TestCase):
+    def _c(self, published):
+        return probes.Container(
+            service="web", name="n", state="running", health="",
+            exit_code=0, published=published,
+        )
+
+    def test_t3_with_runtime_ports_upgrades_to_t2(self):
+        """CVE-2026-66713: ports only exist once the lab is running."""
+        self.assertEqual(audit.effective_tier("T3", [self._c([32768])]), "T2")
+
+    def test_t3_without_ports_stays_t3(self):
+        self.assertEqual(audit.effective_tier("T3", [self._c([])]), "T3")
+
+    def test_t1_never_downgraded(self):
+        self.assertEqual(audit.effective_tier("T1", [self._c([8080])]), "T1")
+
+    def test_t2_unchanged(self):
+        self.assertEqual(audit.effective_tier("T2", [self._c([8080])]), "T2")
+
+
+class TestComposeInvocationUsesProfiles(unittest.TestCase):
+    """The profile flag must reach every runtime compose call, not just config."""
+
+    def test_compose_cmd_starts_with_profile_wildcard(self):
+        lab = {"path": "/x", "env_file": None}
+        self.assertEqual(
+            audit.compose_cmd(lab, "up", "-d"),
+            ["docker", "compose", "--profile", "*", "up", "-d"],
+        )
+
+    def test_compose_cmd_includes_env_file_when_present(self):
+        lab = {"path": "/x", "env_file": "/x/.env.example"}
+        self.assertEqual(
+            audit.compose_cmd(lab, "ps"),
+            ["docker", "compose", "--profile", "*",
+             "--env-file", "/x/.env.example", "ps"],
+        )
+
+
+class TestSelect(unittest.TestCase):
+    def _lab(self, cve, privileged=False):
+        return {"cve": cve, "cohort": "docker_lab", "privileged": privileged}
+
+    def _args(self, **kw):
+        defaults = {"only": [], "limit": 0}
+        defaults.update(kw)
+        return type("Args", (), defaults)()
+
+    def test_privileged_labs_are_ordered_last(self):
+        labs = [
+            self._lab("CVE-A", privileged=True),
+            self._lab("CVE-B"),
+            self._lab("CVE-C"),
+        ]
+        chosen = [l["cve"] for l in audit._select(labs, self._args())]
+        self.assertEqual(chosen, ["CVE-B", "CVE-C", "CVE-A"])
+
+    def test_non_docker_cohorts_excluded(self):
+        labs = [self._lab("CVE-A"), {"cve": "CVE-Z", "cohort": "no_lab",
+                                     "privileged": False}]
+        chosen = [l["cve"] for l in audit._select(labs, self._args())]
+        self.assertEqual(chosen, ["CVE-A"])
+
+    def test_only_filter_restricts_selection(self):
+        labs = [self._lab("CVE-A"), self._lab("CVE-B")]
+        chosen = [l["cve"] for l in audit._select(labs, self._args(only=["CVE-B"]))]
+        self.assertEqual(chosen, ["CVE-B"])
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestSharding(unittest.TestCase):
+    """CI splits the labs across runners; every lab must land in exactly one
+    shard, and shards should interleave so one does not inherit all the slow
+    builds."""
+
+    def _labs(self, n):
+        return [{"cve": f"CVE-{i:04d}", "cohort": "docker_lab", "privileged": False}
+                for i in range(n)]
+
+    def _args(self, **kw):
+        defaults = {"only": [], "limit": 0, "shards": 1, "shard": 0,
+                    "skip_privileged": False}
+        defaults.update(kw)
+        return type("Args", (), defaults)()
+
+    def test_shards_partition_every_lab_exactly_once(self):
+        labs = self._labs(23)
+        seen = []
+        for i in range(4):
+            seen += [l["cve"] for l in audit._select(labs, self._args(shards=4, shard=i))]
+        self.assertEqual(sorted(seen), sorted(l["cve"] for l in labs))
+        self.assertEqual(len(seen), len(set(seen)))
+
+    def test_shards_interleave_rather_than_block(self):
+        labs = self._labs(8)
+        first = [l["cve"] for l in audit._select(labs, self._args(shards=2, shard=0))]
+        self.assertEqual(first, ["CVE-0000", "CVE-0002", "CVE-0004", "CVE-0006"])
+
+    def test_single_shard_returns_everything(self):
+        labs = self._labs(5)
+        self.assertEqual(len(audit._select(labs, self._args())), 5)
+
+    def test_skip_privileged_excludes_them(self):
+        labs = self._labs(3)
+        labs.append({"cve": "CVE-PRIV", "cohort": "docker_lab", "privileged": True})
+        chosen = [l["cve"] for l in audit._select(labs, self._args(skip_privileged=True))]
+        self.assertNotIn("CVE-PRIV", chosen)
+        self.assertEqual(len(chosen), 3)
+
+
+class TestDiskDefaults(unittest.TestCase):
+    """A large headroom default fires on every ordinary disk, pruning the
+    images just built and turning warm re-runs into cold rebuilds."""
+
+    def test_headroom_default_is_modest(self):
+        self.assertLessEqual(audit.DISK_HEADROOM_GB, 50)
+
+    def test_headroom_is_below_the_abort_floor(self):
+        # Pruning must engage before the run aborts, never after.
+        self.assertLess(audit.DISK_HEADROOM_GB, audit.DISK_FLOOR_GB)
+
+
+class TestRunsDirDefaultIsOutsideRepo(unittest.TestCase):
+    """Writing run output into the audited repo dirties the tree, and the
+    dirty-tree guard then refuses every subsequent run."""
+
+    def test_runs_dir_is_not_inside_the_audited_repo(self):
+        import pathlib as _p
+        repo = _p.Path(audit.REPO_DEFAULT).resolve()
+        runs = _p.Path(audit.RUNS_DIR).resolve()
+        self.assertFalse(
+            runs.is_relative_to(repo),
+            f"RUNS_DIR {runs} must not live inside the audited repo {repo}: "
+            "run output would dirty the tree and the dirty-tree guard would "
+            "then refuse every subsequent run",
+        )

--- a/.github/audit/tests/test_ci_summary.py
+++ b/.github/audit/tests/test_ci_summary.py
@@ -1,0 +1,103 @@
+"""Verdict logic for ci_summary, especially the coverage guard.
+
+Written as real TestCases rather than a script: anything living in a directory
+that `unittest discover` scans gets imported, so module-level work and a
+module-level sys.exit() would hijack the whole suite.
+"""
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HERE = pathlib.Path(__file__).resolve().parent
+# The script sits beside this test in the scratch copy and one level up once
+# vendored into .github/audit/tests/.
+SCRIPT = next(
+    c for c in (HERE / "ci_summary.py", HERE.parent / "ci_summary.py") if c.exists()
+)
+
+
+def run_summary(labs, records):
+    """Run ci_summary over a synthetic repo and return (returncode, stdout)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        repo = pathlib.Path(tmp) / "repo"
+        repo.mkdir()
+        for lab in labs:
+            (repo / lab).mkdir()
+            (repo / lab / "docker-compose.yml").write_text("services: {}\n")
+        results = pathlib.Path(tmp) / "results.jsonl"
+        results.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+        proc = subprocess.run(
+            [sys.executable, str(SCRIPT), str(results), "--repo", str(repo)],
+            capture_output=True, text=True,
+        )
+        return proc.returncode, proc.stdout
+
+
+class TestVerdict(unittest.TestCase):
+    def test_all_healthy_passes(self):
+        rc, _ = run_summary(
+            ["CVE-1", "CVE-2"],
+            [{"cve": "CVE-1", "state": "PASS"}, {"cve": "CVE-2", "state": "PASS"}],
+        )
+        self.assertEqual(rc, 0)
+
+    def test_a_broken_lab_fails_the_run(self):
+        rc, out = run_summary(
+            ["CVE-1", "CVE-2"],
+            [{"cve": "CVE-1", "state": "PASS"},
+             {"cve": "CVE-2", "state": "FAIL_BUILD", "reason": "missing_dockerfile"}],
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("CVE-2", out)
+
+    def test_a_lab_that_never_reported_fails_the_run(self):
+        """A shard dying before it writes an artifact must not pass silently."""
+        rc, out = run_summary(
+            ["CVE-1", "CVE-2", "CVE-3"],
+            [{"cve": "CVE-1", "state": "PASS"}, {"cve": "CVE-2", "state": "PASS"}],
+        )
+        self.assertEqual(rc, 1)
+        self.assertIn("Never reported", out)
+        self.assertIn("CVE-3", out)
+
+    def test_prerequisite_and_crash_by_design_do_not_fail(self):
+        rc, _ = run_summary(
+            ["CVE-1", "CVE-2", "CVE-3"],
+            [{"cve": "CVE-1", "state": "PASS"},
+             {"cve": "CVE-2", "state": "FAIL_PREREQ", "reason": "needs kind"},
+             {"cve": "CVE-3", "state": "CRASH_EXPECTED", "reason": "sanitizer abort"}],
+        )
+        self.assertEqual(rc, 0)
+
+    def test_skipped_privileged_labs_are_reported_and_do_not_fail(self):
+        rc, out = run_summary(
+            ["CVE-1", "CVE-2"],
+            [{"cve": "CVE-1", "state": "PASS"},
+             {"cve": "CVE-2", "state": "SKIPPED", "reason": "privileged"}],
+        )
+        self.assertEqual(rc, 0)
+        self.assertIn("CVE-2", out)
+
+    def test_duplicate_records_across_shards_collapse(self):
+        rc, _ = run_summary(
+            ["CVE-1"],
+            [{"cve": "CVE-1", "state": "FAIL_UP"}, {"cve": "CVE-1", "state": "PASS"}],
+        )
+        self.assertEqual(rc, 0)
+
+    def test_empty_results_fail(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            empty = pathlib.Path(tmp) / "results.jsonl"
+            empty.write_text("")
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT), str(empty), "--repo", tmp],
+                capture_output=True, text=True,
+            )
+            self.assertEqual(proc.returncode, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/audit/tests/test_inventory.py
+++ b/.github/audit/tests/test_inventory.py
@@ -1,0 +1,253 @@
+import pathlib
+import tempfile
+import unittest
+
+import inventory
+
+
+class TestClassify(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = pathlib.Path(self.tmp.name)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def _mk(self, name):
+        d = self.root / name
+        d.mkdir()
+        return d
+
+    def test_compose_present_is_docker_lab(self):
+        d = self._mk("CVE-2025-1")
+        (d / "docker-compose.yml").write_text("services: {}\n")
+        self.assertEqual(inventory.classify(d), inventory.COHORT_DOCKER)
+
+    def test_vm_lab_wins_over_no_lab(self):
+        """CVE-2026-50540 has run.sh + vm-assets and no Dockerfile.
+
+        Rule order matters: it must not fall through to no_lab.
+        """
+        d = self._mk("CVE-2026-50540")
+        (d / "run.sh").write_text("#!/bin/sh\n")
+        (d / "vm-assets").mkdir()
+        self.assertEqual(inventory.classify(d), inventory.COHORT_VM)
+
+    def test_no_compose_no_dockerfile_is_no_lab(self):
+        d = self._mk("CVE-2026-24289")
+        (d / "README.md").write_text("x")
+        self.assertEqual(inventory.classify(d), inventory.COHORT_NONE)
+
+    def test_dockerfile_without_compose_is_unknown(self):
+        d = self._mk("CVE-2099-1")
+        (d / "Dockerfile.vulnerable").write_text("FROM alpine\n")
+        self.assertEqual(inventory.classify(d), inventory.COHORT_UNKNOWN)
+
+
+class TestParseRequiredEnv(unittest.TestCase):
+    def test_extracts_unset_variable_names(self):
+        stderr = (
+            'time="x" level=warning msg="The \\"WEB_PORT\\" variable is not set. '
+            'Defaulting to a blank string."\n'
+            'time="x" level=warning msg="The \\"DB_USER\\" variable is not set. '
+            'Defaulting to a blank string."\n'
+        )
+        self.assertEqual(inventory.parse_required_env(stderr), ["DB_USER", "WEB_PORT"])
+
+    def test_returns_empty_when_no_warnings(self):
+        self.assertEqual(inventory.parse_required_env("name: x\n"), [])
+
+
+class TestServicesInfo(unittest.TestCase):
+    def test_reads_healthcheck_ports_and_privileged(self):
+        config = {
+            "services": {
+                "web": {
+                    "healthcheck": {"test": ["CMD", "true"]},
+                    "ports": [{"target": 80, "published": "3100", "protocol": "tcp"}],
+                },
+                "dind": {"privileged": True},
+            }
+        }
+        info = inventory.services_info(config)
+        self.assertTrue(info["web"]["healthcheck"])
+        self.assertEqual(info["web"]["static_ports"], [3100])
+        self.assertFalse(info["web"]["dynamic_ports"])
+        self.assertTrue(info["dind"]["privileged"])
+        self.assertEqual(info["dind"]["static_ports"], [])
+
+    def test_unset_interpolation_marks_dynamic_not_static(self):
+        """`"${WEB_PORT}:80"` unset -> compose drops `published` entirely."""
+        config = {"services": {"web": {"ports": [{"target": 80, "protocol": "tcp"}]}}}
+        info = inventory.services_info(config)
+        self.assertEqual(info["web"]["static_ports"], [])
+        self.assertTrue(info["web"]["dynamic_ports"])
+
+    def test_disabled_healthcheck_does_not_count(self):
+        config = {"services": {"web": {"healthcheck": {"disable": True}}}}
+        self.assertFalse(inventory.services_info(config)["web"]["healthcheck"])
+
+    def test_records_service_profiles(self):
+        config = {"services": {"target": {"profiles": ["vulnerable"]}}}
+        self.assertEqual(
+            inventory.services_info(config)["target"]["profiles"], ["vulnerable"]
+        )
+
+
+class TestContainerNames(unittest.TestCase):
+    """CVE-2025-11539 pins container_name, so a leftover blocks `up`.
+
+    The runner needs these names to clear stale containers that `compose down`
+    misses, which otherwise shows up as a false FAIL_UP.
+    """
+
+    def test_collects_declared_container_names(self):
+        config = {
+            "services": {
+                "grafana": {"container_name": "cve-2025-11539-grafana"},
+                "renderer": {"container_name": "cve-2025-11539-renderer"},
+            }
+        }
+        info = inventory.services_info(config)
+        self.assertEqual(info["grafana"]["container_name"], "cve-2025-11539-grafana")
+
+    def test_absent_container_name_is_empty(self):
+        config = {"services": {"web": {}}}
+        self.assertEqual(inventory.services_info(config)["web"]["container_name"], "")
+
+
+class TestParseDuration(unittest.TestCase):
+    def test_seconds(self):
+        self.assertEqual(inventory.parse_duration("10s"), 10.0)
+
+    def test_compound_go_duration(self):
+        """Compose emits start_period: 5m as '5m0s'."""
+        self.assertEqual(inventory.parse_duration("5m0s"), 300.0)
+
+    def test_hours_and_minutes(self):
+        self.assertEqual(inventory.parse_duration("1h30m"), 5400.0)
+
+    def test_milliseconds(self):
+        self.assertAlmostEqual(inventory.parse_duration("500ms"), 0.5)
+
+    def test_empty_and_none_are_zero(self):
+        self.assertEqual(inventory.parse_duration(""), 0.0)
+        self.assertEqual(inventory.parse_duration(None), 0.0)
+
+
+class TestHealthBudget(unittest.TestCase):
+    """CVE-2022-0735 is GitLab CE: start_period 5m, 60 retries at 10s = 900s.
+
+    A fixed 180s probe timeout failed it while it was still legitimately
+    starting, so the budget must come from the lab's own declaration.
+    """
+
+    def test_gitlab_style_budget(self):
+        services = {
+            "gitlab": {
+                "healthcheck_spec": {
+                    "start_period": "5m0s", "interval": "10s", "retries": 60
+                }
+            }
+        }
+        self.assertEqual(inventory.health_budget(services), 900.0)
+
+    def test_takes_the_slowest_service(self):
+        services = {
+            "fast": {"healthcheck_spec": {"interval": "5s", "retries": 3}},
+            "slow": {"healthcheck_spec": {"interval": "10s", "retries": 60}},
+        }
+        self.assertEqual(inventory.health_budget(services), 600.0)
+
+    def test_no_healthcheck_is_zero(self):
+        self.assertEqual(inventory.health_budget({"a": {}}), 0.0)
+
+    def test_missing_interval_defaults_to_compose_default(self):
+        services = {"a": {"healthcheck_spec": {"retries": 3}}}
+        self.assertEqual(inventory.health_budget(services), 90.0)
+
+
+class TestCrashExpected(unittest.TestCase):
+    """CVE-2026-64608 sets ASAN to abort so exit 134 is the demonstration."""
+
+    def test_detects_asan_abort_from_dict_environment(self):
+        config = {
+            "services": {
+                "target": {"environment": {"ASAN_OPTIONS": "abort_on_error=1"}}
+            }
+        }
+        self.assertTrue(inventory.services_info(config)["target"]["crash_expected"])
+
+    def test_detects_asan_abort_from_list_environment(self):
+        config = {
+            "services": {"target": {"environment": ["ASAN_OPTIONS=abort_on_error=1"]}}
+        }
+        self.assertTrue(inventory.services_info(config)["target"]["crash_expected"])
+
+    def test_ordinary_service_is_not_crash_expected(self):
+        config = {"services": {"web": {"environment": {"DEBUG": "1"}}}}
+        self.assertFalse(inventory.services_info(config)["web"]["crash_expected"])
+
+    def test_missing_environment_is_not_crash_expected(self):
+        config = {"services": {"web": {}}}
+        self.assertFalse(inventory.services_info(config)["web"]["crash_expected"])
+
+
+class TestComposeArgs(unittest.TestCase):
+    """Regression guard for CVE-2026-20348.
+
+    Every service in that lab is profile-gated. Without `--profile "*"`,
+    compose resolves zero services and `up` starts nothing, which the probe
+    would misreport as a crash instead of a config gate.
+    """
+
+    def test_always_activates_all_profiles(self):
+        self.assertEqual(
+            inventory.compose_args(), ["docker", "compose", "--profile", "*"]
+        )
+
+    def test_env_file_is_appended_after_profile(self):
+        self.assertEqual(
+            inventory.compose_args("/x/.env.example"),
+            ["docker", "compose", "--profile", "*", "--env-file", "/x/.env.example"],
+        )
+
+
+class TestStaticTier(unittest.TestCase):
+    def test_healthcheck_wins(self):
+        services = {
+            "a": {"healthcheck": True, "static_ports": [1], "dynamic_ports": False},
+            "b": {"healthcheck": False, "static_ports": [], "dynamic_ports": False},
+        }
+        self.assertEqual(inventory.static_tier(services), "T1")
+
+    def test_ports_without_healthcheck_is_t2(self):
+        services = {
+            "a": {"healthcheck": False, "static_ports": [8080], "dynamic_ports": False}
+        }
+        self.assertEqual(inventory.static_tier(services), "T2")
+
+    def test_neither_is_t3(self):
+        services = {
+            "a": {"healthcheck": False, "static_ports": [], "dynamic_ports": True}
+        }
+        self.assertEqual(inventory.static_tier(services), "T3")
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestExternalNetworks(unittest.TestCase):
+    """CVE-2026-44182 requires a kind cluster (its README lists kind + kubectl),
+    so a missing external network is an unmet prerequisite, not lab rot."""
+
+    def test_collects_external_networks(self):
+        config = {"networks": {"kind": {"external": True},
+                               "lab-net": {"driver": "bridge"}}}
+        record = inventory.services_info(config)  # ensure no crash on no services
+        self.assertEqual(record, {})
+        externals = sorted(
+            n for n, net in config["networks"].items() if (net or {}).get("external")
+        )
+        self.assertEqual(externals, ["kind"])

--- a/.github/audit/tests/test_probes.py
+++ b/.github/audit/tests/test_probes.py
@@ -1,0 +1,163 @@
+import unittest
+
+import probes
+
+# Captured verbatim from `docker compose ps -a --format json` on eip.local,
+# Compose 5.4.0. Note: NDJSON, and Publishers lists each port twice (v4 + v6).
+REAL_NDJSON = (
+    '{"Command":"\\"sh -c \'exit 0\'\\"","ExitCode":0,"Health":"",'
+    '"ID":"e1750364bfe9","Name":"schema-check-oneshot-1","Publishers":[],'
+    '"Service":"oneshot","State":"exited","Status":"Exited (0) 12 seconds ago"}\n'
+    '{"Command":"\\"sh -c \'while true;\\"","ExitCode":0,"Health":"healthy",'
+    '"ID":"60503fe0f02d","Name":"schema-check-web-1","Publishers":['
+    '{"URL":"0.0.0.0","TargetPort":8099,"PublishedPort":18099,"Protocol":"tcp"},'
+    '{"URL":"::","TargetPort":8099,"PublishedPort":18099,"Protocol":"tcp"}],'
+    '"Service":"web","State":"running","Status":"Up 12 seconds (healthy)"}\n'
+)
+
+
+def make(service, state="running", health="", exit_code=0, published=None):
+    return probes.Container(
+        service=service,
+        name=f"proj-{service}-1",
+        state=state,
+        health=health,
+        exit_code=exit_code,
+        published=published or [],
+    )
+
+
+class TestParsePs(unittest.TestCase):
+    def test_parses_real_ndjson_output(self):
+        containers = probes.parse_ps(REAL_NDJSON)
+        self.assertEqual(len(containers), 2)
+        by_service = {c.service: c for c in containers}
+        self.assertEqual(by_service["web"].state, "running")
+        self.assertEqual(by_service["web"].health, "healthy")
+        self.assertEqual(by_service["oneshot"].state, "exited")
+        self.assertEqual(by_service["oneshot"].exit_code, 0)
+
+    def test_dedupes_ipv4_and_ipv6_publishers(self):
+        containers = probes.parse_ps(REAL_NDJSON)
+        web = next(c for c in containers if c.service == "web")
+        self.assertEqual(web.published, [18099])
+
+    def test_accepts_json_array_form(self):
+        containers = probes.parse_ps(
+            '[{"Service":"a","State":"running","Health":"","ExitCode":0,'
+            '"Name":"x","Publishers":[]}]'
+        )
+        self.assertEqual(len(containers), 1)
+
+    def test_empty_output_is_empty_list(self):
+        self.assertEqual(probes.parse_ps("  \n"), [])
+
+    def test_ignores_published_port_zero(self):
+        containers = probes.parse_ps(
+            '{"Service":"a","State":"running","Health":"","ExitCode":0,"Name":"x",'
+            '"Publishers":[{"PublishedPort":0,"TargetPort":80,"Protocol":"tcp"}]}'
+        )
+        self.assertEqual(containers[0].published, [])
+
+
+class TestContainerOk(unittest.TestCase):
+    def test_running_is_ok(self):
+        self.assertEqual(probes.container_ok(make("a")), (True, None))
+
+    def test_exited_zero_is_completed_oneshot(self):
+        ok, _ = probes.container_ok(make("a", state="exited", exit_code=0))
+        self.assertTrue(ok)
+
+    def test_exited_nonzero_fails(self):
+        ok, why = probes.container_ok(make("a", state="exited", exit_code=1))
+        self.assertFalse(ok)
+        self.assertIn("exit=1", why)
+
+    def test_restarting_fails(self):
+        ok, why = probes.container_ok(make("a", state="restarting"))
+        self.assertFalse(ok)
+        self.assertIn("restarting", why)
+
+
+class TestVerdictT1(unittest.TestCase):
+    def test_all_healthy_passes(self):
+        containers = [make("web", health="healthy")]
+        self.assertEqual(probes.verdict_t1(containers, ["web"])[0], "PASS")
+
+    def test_starting_is_pending_not_failure(self):
+        containers = [make("web", health="starting")]
+        self.assertEqual(probes.verdict_t1(containers, ["web"])[0], "PENDING")
+
+    def test_unhealthy_is_pending_until_caller_times_out(self):
+        containers = [make("web", health="unhealthy")]
+        self.assertEqual(probes.verdict_t1(containers, ["web"])[0], "PENDING")
+
+    def test_crashed_container_fails_immediately(self):
+        containers = [make("web", state="exited", exit_code=137, health="")]
+        self.assertEqual(probes.verdict_t1(containers, ["web"])[0], "FAIL_UP")
+
+    def test_oneshot_sidecar_does_not_block_pass(self):
+        containers = [
+            make("web", health="healthy"),
+            make("setup", state="exited", exit_code=0),
+        ]
+        self.assertEqual(probes.verdict_t1(containers, ["web"])[0], "PASS")
+
+    def test_no_containers_fails(self):
+        self.assertEqual(probes.verdict_t1([], ["web"])[0], "FAIL_UP")
+
+
+class TestVerdictT2(unittest.TestCase):
+    def test_all_ports_answering_passes(self):
+        containers = [make("web", published=[8080])]
+        self.assertEqual(probes.verdict_t2(containers, {8080: True})[0], "PASS")
+
+    def test_dead_port_is_pending(self):
+        containers = [make("web", published=[8080])]
+        self.assertEqual(probes.verdict_t2(containers, {8080: False})[0], "PENDING")
+
+    def test_no_ports_observed_is_pending(self):
+        self.assertEqual(probes.verdict_t2([make("web")], {})[0], "PENDING")
+
+
+class TestVerdictT3(unittest.TestCase):
+    def test_stable_long_enough_passes(self):
+        self.assertEqual(probes.verdict_t3([make("a")], 30)[0], "PASS")
+
+    def test_not_yet_stable_is_pending(self):
+        self.assertEqual(probes.verdict_t3([make("a")], 5)[0], "PENDING")
+
+    def test_crash_fails(self):
+        containers = [make("a", state="exited", exit_code=2)]
+        self.assertEqual(probes.verdict_t3(containers, 60)[0], "FAIL_UP")
+
+
+class TestSanitizerDetection(unittest.TestCase):
+    """Captured from CVE-2026-64608's real container output during the pilot."""
+
+    REAL_ASAN = (
+        "target-1  | AddressSanitizer:DEADLYSIGNAL\n"
+        "target-1  | ==7==ERROR: AddressSanitizer: SEGV on unknown address\n"
+        "target-1  | ==7==ABORTING\n"
+    )
+
+    def test_detects_real_addresssanitizer_output(self):
+        self.assertTrue(probes.looks_like_sanitizer_abort(self.REAL_ASAN))
+
+    def test_ordinary_crash_is_not_a_sanitizer_abort(self):
+        self.assertFalse(
+            probes.looks_like_sanitizer_abort("nginx: bind() to 0.0.0.0:80 failed")
+        )
+
+    def test_empty_log_is_not_a_sanitizer_abort(self):
+        self.assertFalse(probes.looks_like_sanitizer_abort(""))
+
+
+class TestRuntimePorts(unittest.TestCase):
+    def test_collects_and_sorts_across_containers(self):
+        containers = [make("a", published=[8081]), make("b", published=[8080, 8081])]
+        self.assertEqual(probes.runtime_ports(containers), [8080, 8081])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/audit/tests/test_report.py
+++ b/.github/audit/tests/test_report.py
@@ -1,0 +1,111 @@
+import json
+import pathlib
+import tempfile
+import unittest
+
+import report
+
+RECORDS = [
+    {"cve": "CVE-1", "state": "PASS", "cohort": "docker_lab",
+     "probe_tier_effective": "T1", "reason": "ok", "required_env": [],
+     "runtime_ports": [8080], "build_seconds": 12.0},
+    {"cve": "CVE-2", "state": "FAIL_BUILD", "cohort": "docker_lab",
+     "build_cause": "upstream_gone", "reason": "build failed: upstream_gone",
+     "required_env": [], "probe_tier_effective": "T1", "build_seconds": 4.0},
+    {"cve": "CVE-3", "state": "NO_LAB", "cohort": "no_lab",
+     "reason": "not a docker lab"},
+    {"cve": "CVE-4", "state": "PASS", "cohort": "docker_lab",
+     "probe_tier_effective": "T2", "reason": "ok", "required_env": ["WEB_PORT"],
+     "env_file_used": False, "runtime_ports": [32768], "build_seconds": 30.0},
+]
+
+
+class TestSummarise(unittest.TestCase):
+    def test_counts_by_state(self):
+        self.assertEqual(
+            report.summarise(RECORDS),
+            {"PASS": 2, "FAIL_BUILD": 1, "NO_LAB": 1},
+        )
+
+
+class TestAdvisories(unittest.TestCase):
+    def test_flags_lab_that_passed_but_needs_undocumented_env(self):
+        found = report.advisories(RECORDS)
+        self.assertTrue(any("CVE-4" in a and "WEB_PORT" in a for a in found))
+
+    def test_no_advisory_for_clean_lab(self):
+        self.assertFalse(any("CVE-1" in a for a in report.advisories(RECORDS)))
+
+
+class TestRender(unittest.TestCase):
+    def test_report_contains_totals_and_each_cve(self):
+        text = report.render(RECORDS, {"repo_sha": "abc1234"})
+        self.assertIn("abc1234", text)
+        for record in RECORDS:
+            self.assertIn(record["cve"], text)
+
+    def test_failures_grouped_by_cause(self):
+        text = report.render(RECORDS, {"repo_sha": "abc1234"})
+        self.assertIn("upstream_gone", text)
+
+    def test_counts_exclude_non_lab_cohorts_from_tested(self):
+        text = report.render(RECORDS, {"repo_sha": "abc1234"})
+        self.assertIn("Labs tested: **3**", text)
+        self.assertIn("Directories recorded: **4**", text)
+
+
+class TestMerge(unittest.TestCase):
+    """A retry supersedes the original verdict for the CVEs it re-tested."""
+
+    def test_later_run_wins_per_cve(self):
+        original = [{"cve": "CVE-1", "state": "TIMEOUT"},
+                    {"cve": "CVE-2", "state": "PASS"}]
+        retry = [{"cve": "CVE-1", "state": "PASS"}]
+        merged = report.merge([original, retry])
+        by_cve = {r["cve"]: r["state"] for r in merged}
+        self.assertEqual(by_cve, {"CVE-1": "PASS", "CVE-2": "PASS"})
+
+    def test_no_double_counting(self):
+        merged = report.merge([
+            [{"cve": "CVE-1", "state": "FAIL_UP"}],
+            [{"cve": "CVE-1", "state": "PASS"}],
+        ])
+        self.assertEqual(len(merged), 1)
+
+    def test_duplicate_records_within_one_run_collapse(self):
+        """A concurrent-run bug once wrote two records per CVE."""
+        merged = report.merge([[
+            {"cve": "CVE-1", "state": "FAIL_UP"},
+            {"cve": "CVE-1", "state": "PASS"},
+        ]])
+        self.assertEqual(len(merged), 1)
+        self.assertEqual(merged[0]["state"], "PASS")
+
+    def test_output_is_sorted_by_cve(self):
+        merged = report.merge([[{"cve": "CVE-9", "state": "PASS"},
+                                {"cve": "CVE-1", "state": "PASS"}]])
+        self.assertEqual([r["cve"] for r in merged], ["CVE-1", "CVE-9"])
+
+
+class TestLoad(unittest.TestCase):
+    def test_reads_jsonl(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / "results.jsonl"
+            path.write_text("\n".join(json.dumps(r) for r in RECORDS) + "\n")
+            self.assertEqual(len(report.load(path)), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class TestPrereqNotCountedAsFailure(unittest.TestCase):
+    def test_fail_prereq_is_excluded_from_tested_and_failed(self):
+        records = [
+            {"cve": "CVE-A", "state": "PASS"},
+            {"cve": "CVE-B", "state": "FAIL_PREREQ",
+             "reason": "network kind declared as external"},
+        ]
+        text = report.render(records, {"repo_sha": "x"})
+        self.assertIn("Labs tested: **1**", text)
+        self.assertIn("Failed: **0**", text)

--- a/.github/audit/tests/test_safety.py
+++ b/.github/audit/tests/test_safety.py
@@ -1,0 +1,122 @@
+import types
+import unittest
+import unittest.mock
+
+import safety
+
+
+def snap(images=("img_pre",), tags=("repo:tag",), volumes=("vol_pre",),
+         networks=("net_pre",)):
+    return {
+        "images": set(images),
+        "image_tags": set(tags),
+        "volumes": set(volumes),
+        "networks": set(networks),
+    }
+
+
+class TestArtifactDiff(unittest.TestCase):
+    def setUp(self):
+        self.before = snap()
+
+    def test_new_artifacts_reports_only_additions(self):
+        after = snap(images=("img_pre", "img_new"))
+        self.assertEqual(safety.new_artifacts(self.before, after)["images"],
+                         {"img_new"})
+
+    def test_missing_artifacts_reports_only_removals(self):
+        after = snap(images=())
+        self.assertEqual(safety.missing_artifacts(self.before, after)["images"],
+                         {"img_pre"})
+
+    def test_assert_preserved_passes_when_nothing_removed(self):
+        after = snap(images=("img_pre", "img_new"))
+        self.assertIsNone(safety.assert_preserved(self.before, after))
+
+
+class TestPreservationSemantics(unittest.TestCase):
+    """Regression guard from the pilot run.
+
+    Rebuilding a lab moves its tag to a fresh image ID and leaves the old ID
+    unreferenced. That is normal Docker behaviour and destroys nothing, so it
+    must not be reported as host mutation. Losing a *tag*, volume or network is
+    real destruction and must always raise.
+    """
+
+    def test_rebuild_replacing_image_id_is_not_mutation(self):
+        before = snap(images=("old_id",), tags=("cve-lab:local",))
+        after = snap(images=("new_id",), tags=("cve-lab:local",))
+        self.assertIsNone(safety.assert_preserved(before, after))
+
+    def test_losing_a_tag_is_mutation(self):
+        before = snap(tags=("wordpress:6.5", "cve-lab:local"))
+        after = snap(tags=("cve-lab:local",))
+        with self.assertRaises(safety.HostMutationError) as ctx:
+            safety.assert_preserved(before, after)
+        self.assertIn("wordpress:6.5", str(ctx.exception))
+
+    def test_losing_a_volume_is_mutation(self):
+        with self.assertRaises(safety.HostMutationError) as ctx:
+            safety.assert_preserved(snap(), snap(volumes=()))
+        self.assertIn("vol_pre", str(ctx.exception))
+
+    def test_losing_a_network_is_mutation(self):
+        with self.assertRaises(safety.HostMutationError):
+            safety.assert_preserved(snap(), snap(networks=()))
+
+    def test_image_ids_are_not_protected(self):
+        self.assertNotIn("images", safety.PROTECTED_KINDS)
+        for kind in ("image_tags", "volumes", "networks"):
+            self.assertIn(kind, safety.PROTECTED_KINDS)
+
+
+class TestDiskGuard(unittest.TestCase):
+    def test_disk_ok_true_when_above_floor(self):
+        self.assertTrue(safety.disk_ok("/", floor=1))
+
+    def test_disk_ok_false_when_floor_unreachable(self):
+        self.assertFalse(safety.disk_ok("/", floor=10 ** 18))
+
+    def test_floor_is_one_hundred_gib(self):
+        self.assertEqual(safety.DISK_FLOOR_BYTES, 100 * 1024 ** 3)
+
+
+class TestVolumeTeardownIsScoped(unittest.TestCase):
+    """Regression guard for a real loss during the full run.
+
+    `docker compose down -v` deleted `cve-2025-24490_pg_data`, a volume that
+    existed before the audit started. Teardown must only remove volumes that
+    appeared while the lab was up.
+    """
+
+    def test_preexisting_volume_is_never_a_removal_candidate(self):
+        before = {"cve-2025-24490_pg_data"}
+        # Nothing new appeared, so nothing may be removed.
+        with unittest.mock.patch.object(safety, "_ids", return_value=before):
+            self.assertEqual(safety.remove_new_volumes(before), [])
+
+    def test_only_the_new_volume_is_targeted(self):
+        before = {"preexisting_vol"}
+        now = {"preexisting_vol", "lab_created_vol"}
+        calls = []
+
+        def fake_docker(*args, **kwargs):
+            calls.append(args)
+            return types.SimpleNamespace(returncode=0)
+
+        with unittest.mock.patch.object(safety, "_ids", return_value=now), \
+                unittest.mock.patch.object(safety, "_docker", fake_docker):
+            removed = safety.remove_new_volumes(before)
+        self.assertEqual(removed, ["lab_created_vol"])
+        self.assertEqual(calls, [("volume", "rm", "-f", "lab_created_vol")])
+
+
+class TestRemoveNewImagesIsScoped(unittest.TestCase):
+    def test_refuses_to_remove_preexisting(self):
+        before = snap(images=("keep",))
+        after = snap(images=("keep",))
+        self.assertEqual(safety.remove_new_images(before, after), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/lab-health.yml
+++ b/.github/workflows/lab-health.yml
@@ -29,14 +29,38 @@ permissions:
   contents: read
 
 jobs:
+  plan:
+    # The shard count drives both the matrix and the runner argument. Deriving
+    # them from one value keeps them consistent: a hardcoded matrix silently
+    # under-covers the repo as soon as the input differs from it.
+    name: plan
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+      shards: ${{ steps.set.outputs.shards }}
+    steps:
+      - id: set
+        env:
+          SHARDS: ${{ github.event.inputs.shards || '8' }}
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json, os
+          n = int(os.environ["SHARDS"])
+          if not 1 <= n <= 64:
+              raise SystemExit(f"shards must be between 1 and 64, got {n}")
+          print(f"shards={n}")
+          print("matrix=" + json.dumps(list(range(n))))
+          PY
+
   health:
     name: labs (shard ${{ matrix.shard }})
+    needs: plan
     runs-on: ubuntu-latest
     timeout-minutes: 330
     strategy:
       fail-fast: false
       matrix:
-        shard: [0, 1, 2, 3, 4, 5, 6, 7]
+        shard: ${{ fromJson(needs.plan.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
 
@@ -45,12 +69,12 @@ jobs:
         # own. Removing preinstalled toolchains we do not use frees ~20 GB.
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-                      /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" || true
+                      /usr/local/share/boost "${AGENT_TOOLSDIRECTORY:-}" || true
           df -h / | tail -1
 
       - name: Audit shard
         env:
-          SHARDS: ${{ github.event.inputs.shards || '8' }}
+          SHARDS: ${{ needs.plan.outputs.shards }}
           ONLY: ${{ github.event.inputs.only || '' }}
         run: |
           only_args=""
@@ -66,7 +90,7 @@ jobs:
             --build-timeout 2400 \
             --up-timeout 900 \
             --disk-floor-gb 2 \
-            --disk-headroom-gb 12 \
+            --disk-headroom-gb 8 \
             $only_args
 
       - name: Upload shard results
@@ -79,7 +103,7 @@ jobs:
 
   report:
     name: report
-    needs: health
+    needs: [plan, health]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -91,10 +115,18 @@ jobs:
           path: shards
 
       - name: Build report and fail on regressions
+        # --repo lets the summary compare against every lab that should have
+        # been reported, so a shard that died without writing an artifact fails
+        # the run instead of quietly shrinking the coverage.
         run: |
-          find shards -name results.jsonl -exec cat {} + > all-results.jsonl
-          python3 .github/audit/ci_summary.py all-results.jsonl \
-            >> "$GITHUB_STEP_SUMMARY"
+          find shards -name results.jsonl -exec cat {} + > all-results.jsonl || true
+          set +e
+          python3 .github/audit/ci_summary.py all-results.jsonl --repo . > summary.md
+          rc=$?
+          set -e
+          cat summary.md >> "$GITHUB_STEP_SUMMARY"
+          cat summary.md
+          exit "$rc"
 
       - name: Upload combined report
         if: always()

--- a/.github/workflows/lab-health.yml
+++ b/.github/workflows/lab-health.yml
@@ -1,0 +1,105 @@
+name: Lab health
+
+# Builds every CVE lab from source, starts it, and checks it reports healthy.
+#
+# This replaces the old publish workflow, which pushed images to GHCR on every
+# change. That workflow reported success continuously while 14 labs were in
+# fact broken, because a green image build says nothing about whether the lab
+# runs. This one runs the labs.
+#
+# It publishes nothing. The only output is a health report.
+
+on:
+  schedule:
+    # Weekly, Monday 04:00 UTC. Lab rot comes from upstream drift, so time
+    # passing is the trigger, not repository activity.
+    - cron: "0 4 * * 1"
+  workflow_dispatch:
+    inputs:
+      shards:
+        description: "Number of parallel shards"
+        required: false
+        default: "8"
+      only:
+        description: "Audit a single lab (e.g. CVE-2026-58154), blank for all"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  health:
+    name: labs (shard ${{ matrix.shard }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 330
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3, 4, 5, 6, 7]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Reclaim runner disk
+        # A default runner has ~14 GB free, which several labs exceed on their
+        # own. Removing preinstalled toolchains we do not use frees ~20 GB.
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" || true
+          df -h / | tail -1
+
+      - name: Audit shard
+        env:
+          SHARDS: ${{ github.event.inputs.shards || '8' }}
+          ONLY: ${{ github.event.inputs.only || '' }}
+        run: |
+          only_args=""
+          if [ -n "$ONLY" ]; then only_args="--only $ONLY"; fi
+          python3 .github/audit/audit.py \
+            --repo . \
+            --runs-dir "$RUNNER_TEMP/runs" \
+            --run-id "shard-${{ matrix.shard }}" \
+            --shard "${{ matrix.shard }}" \
+            --shards "$SHARDS" \
+            --skip-privileged \
+            --build-workers 2 \
+            --build-timeout 2400 \
+            --up-timeout 900 \
+            --disk-floor-gb 2 \
+            --disk-headroom-gb 12 \
+            $only_args
+
+      - name: Upload shard results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lab-health-shard-${{ matrix.shard }}
+          path: ${{ runner.temp }}/runs/shard-${{ matrix.shard }}
+          retention-days: 30
+
+  report:
+    name: report
+    needs: health
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: lab-health-shard-*
+          path: shards
+
+      - name: Build report and fail on regressions
+        run: |
+          find shards -name results.jsonl -exec cat {} + > all-results.jsonl
+          python3 .github/audit/ci_summary.py all-results.jsonl \
+            >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload combined report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lab-health-report
+          path: all-results.jsonl
+          retention-days: 90

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ RUN-DOCKER-SINGLE.md
 
 # Internal tooling — not part of the CVE collection itself
 /.skills/
+
+# Lab-health audit output (never committed)
+.github/audit/runs/


### PR DESCRIPTION
Adds a workflow that builds every lab from source, starts it, and checks that it
reports healthy. It publishes nothing.

**Why**

The workflow this replaces reported success continuously while 14 labs were
broken. It verified that images *build*; it never verified that a lab *runs*.
It also rebuilt only the directories changed in a push, so rot from upstream
drift was invisible by construction — which is how 14 broken labs accumulated
unnoticed.

Lab rot is driven by time passing, not by repository activity, so this runs on a
weekly schedule rather than on push, and can be dispatched manually.

**How it judges a lab**

Each lab is graded by the strongest signal it offers, and each record states
which was used: services that declare a healthcheck must reach `healthy`;
otherwise every published port must accept a connection; otherwise containers
must simply stay up and not restart or exit non-zero.

The timeout is taken from each lab's own healthcheck declaration
(`start_period + interval x retries`) rather than a fixed value. That matters:
25 labs ask for longer than a naive default, one for 900s, and a fixed timeout
fails a slow-but-working lab.

**What does not fail the run**

Signal is only useful if a red run means something. These are reported but not
counted as failures:

- `FAIL_PREREQ` — the lab needs something the runner does not provide, such as
  the kind cluster CVE-2026-44182 documents as a requirement
- `CRASH_EXPECTED` — the target aborts under a sanitizer by design, recorded
  only when the lab declares that intent and its output carries a sanitizer
  signature
- `INFRA_ERROR` — a registry or network problem rather than the lab

Privileged labs are skipped on hosted runners and reported as such.

**Operational notes**

Work is split across 8 shards, dealt round-robin so no shard inherits a run of
slow builds. Each runner reclaims ~20 GB by removing preinstalled toolchains,
since several labs exceed the default free space. Builds run 2-wide: several
labs invoke `make -j$(nproc)`, and a higher width starves them into timeouts
that look like failures but are not.

The same tool runs locally:

    python3 .github/audit/audit.py --repo . --runs-dir /tmp/runs --run-id local

**Scope**

It answers "does the lab stand up", not "does the exploit still work". A lab can
come up perfectly with a dead PoC and this will call it healthy. Auditing PoC
correctness needs a per-lab oracle that does not exist yet.