### PR TITLE
Fix CVE-2025-62507 lab: build the shared image once

### DIFF
--- a/CVE-2025-62507/docker-compose.yml
+++ b/CVE-2025-62507/docker-compose.yml
@@ -1,9 +1,12 @@
 x-redis-common: &redis-common
+  # All three services run the same image. The build lives on `vulnerable`
+  # alone: with `build:` in this anchor every service inherited it, and Compose
+  # built the same Dockerfile three times concurrently into one tag, failing
+  # with 'image "cve-2025-62507-lab:latest": already exists'. Newer Compose
+  # de-duplicates identical builds and masks it, so the lab built on some hosts
+  # and not others.
   image: cve-2025-62507-lab:latest
   platform: linux/amd64
-  build:
-    context: .
-    dockerfile: Dockerfile.vulnerable
   privileged: true
   cap_add:
     - SYS_PTRACE


### PR DESCRIPTION
**Symptom:** the lab cannot be built on some machines:

    target redis-aslr: failed to solve:
    image "docker.io/library/cve-2025-62507-lab:latest": already exists

**Root cause:** the `x-redis-common` anchor carries both `image:` and `build:`,
so all three services (`vulnerable`, `redis-aslr`, `redis-no-aslr`) inherit the
same image tag *and* the same build. Compose builds the same Dockerfile three
times concurrently into one tag, and the builds collide. `vulnerable` also
re-declared both keys redundantly.

Newer Compose de-duplicates identical builds and hides the problem, which is why
this lab builds on one host and fails on another. It was found by auditing the
repository on a second machine running Compose 2.40; the machine the labs are
usually built on runs 5.4 and never showed it.

**Fix:** the anchor keeps the shared image reference and runtime settings, and
only `vulnerable` declares the build. The image is built once and the other two
services reference it.

Nothing the lab demonstrates changes: all three services still run the same
image from the same `Dockerfile.vulnerable`, with the same ASLR_MODE split
(`vulnerable` and `redis-no-aslr` disabled, `redis-aslr` enabled) that the
ASLR-comparison PoC relies on.

**Verification**

Built from a cleared image cache and started: build OK, and all three
containers report healthy on their published ports — `vulnerable` 6381,
`redis-aslr` 6379, `redis-no-aslr` 6380.