### PR TITLE
Fix CVE index package total (131) and bypass count (25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ environment that you own or are explicitly authorized to test.
 | [CVE&#8209;2026&#8209;35414](CVE-2026-35414/) | **OpenSSH**<br>Certificate Principal Matching Authentication Bypass | **N/A** |
 | [CVE&#8209;2025&#8209;59060](CVE-2025-59060/) | **Apache Ranger**<br>Apache Ranger TLS Hostname Verification Bypass | **N/A** |
 
-24 of the 129 indexed packages record a bypass or incomplete-fix finding.
+25 of the 131 indexed packages record a bypass or incomplete-fix finding.
 
 ## Typical package layout
 


### PR DESCRIPTION
## Summary

The CVE index summary line in README.md drifted out of sync with the table:

- PR #45 (CVE-2026-50027) bumped the total 128 → 129 correctly.
- PR #46 (CVE-2026-70456) bumped the bypass count 23 → 24 but **not** the total (should have been 130).
- PR #47 (CVE-2026-50561) added its row but bumped **neither** count.

Result: summary said `24 of the 129`, table has 131 rows / 25 bypass findings. The publish pipeline's target README contract gate validates this line and blocks publishing until they match (same failure class as PR #43).

## Changes

One line: `24 of the 129` → `25 of the 131`.

Verified against the publish validator: 131 package rows, 25 bypass findings, contract passes.