### PR TITLE
Restore CVE-2026-71319 index row and sync package total (137)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ environment that you own or are explicitly authorized to test.
 | [CVE&#8209;2025&#8209;24490](CVE-2025-24490/) | **Mattermost Server (Boards Plugin)**<br>SQL Injection (Blind) | **9.6** |
 | [CVE&#8209;2026&#8209;50540](CVE-2026-50540/) | **Kata Containers**<br>Config Path Annotation Arbitrary File Loading to Host Root Exec | **9.6** |
 | [CVE&#8209;2026&#8209;73843](CVE-2026-73843/) | **OpenChoreo control-plane `cluster-gateway`**<br>OpenChoreo cluster-gateway unauthenticated data-plane management APIs | **9.6** |
+| [CVE&#8209;2026&#8209;71319](CVE-2026-71319/) | **@nuxt/devtools**<br>Nuxt DevTools Unauthenticated WebSocket RPC Remote Code Execution | **9.6** |
 | [CVE&#8209;2026&#8209;53488](CVE-2026-53488/) | **containerd CRI plugin**<br>Image LABEL Host Command Execution | **9.4** |
 | [CVE&#8209;2026&#8209;63221](CVE-2026-63221/) | **CodeIgniter4 Query Builder `deleteBatch()`**<br>CodeIgniter4 deleteBatch() SQL Injection | **9.4** |
 | [CVE&#8209;2026&#8209;50561](CVE-2026-50561/) | **xerrors Yuxi**<br>Yuxi JWT Authentication Bypass<br><br>**Bypass / fix review:** v0.6.2 fix sufficient; no bypass or sibling variant found | **9.4** |
@@ -172,7 +173,7 @@ environment that you own or are explicitly authorized to test.
 | [CVE&#8209;2026&#8209;35414](CVE-2026-35414/) | **OpenSSH**<br>Certificate Principal Matching Authentication Bypass | **N/A** |
 | [CVE&#8209;2025&#8209;59060](CVE-2025-59060/) | **Apache Ranger**<br>Apache Ranger TLS Hostname Verification Bypass | **N/A** |
 
-26 of the 135 indexed packages record a bypass or incomplete-fix finding.
+26 of the 137 indexed packages record a bypass or incomplete-fix finding.
 
 ## Typical package layout
 


### PR DESCRIPTION
## Summary

The merge of #53 accidentally dropped the CVE-2026-71319 row from the CVE
index table (introduced by a mechanical rebase-conflict resolution during a
parallel-publish cleanup). The table landed at 136 rows while the summary
said 135, tripping the publish pipeline's target README contract gate and
blocking CVE-2026-53657.

## Changes

- Restore the CVE-2026-71319 row (Nuxt DevTools WS RPC RCE, 9.6, sorted into
  the 9.6 block alongside CVE-2026-73843).
- Correct the summary line: `26 of the 137 indexed packages`.

## Verification

- `validateTargetReadme`: 137 package rows, 26 bypass findings — contract passes.
- All six rows from the merged publish PRs (#49–#54) present.